### PR TITLE
Fix: Wrong image entrypoint for stdio mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ push-stdio:
 	  -t $(LATEST_TAG) \
 	  --push \
 	  --progress=plain \
-	  --target runner \
 	  .
 
 install:


### PR DESCRIPTION
## Description

A typo in the Makefile caused the image to run in HTTP mode instead of STDIO mode.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors