### PR TITLE
Enhancement: Official MCP registry

### DIFF
--- a/.github/workflows/publish-mcp.yaml
+++ b/.github/workflows/publish-mcp.yaml
@@ -1,0 +1,60 @@
+# GitHub Actions workflow to publish to MCP Registry:
+# https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/guides/publishing/github-actions.md
+
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  GO_VERSION: "1.24.x"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check version
+        id: check_version
+        run: |
+          tag_version="${GITHUB_REF#refs/tags/v}"
+          server_version=$(jq -r .version server.json)
+          if [[ "$tag_version" != "$server_version" ]]; then
+            echo "❌ Tag $tag_version does not match server.json version $server_version" >> $GITHUB_STEP_SUMMARY
+            echo "proceed=false" >> $GITHUB_OUTPUT
+          else
+            echo "✅ Tag $tag_version matches server.json version $server_version" >> $GITHUB_STEP_SUMMARY
+            echo "proceed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Go
+        if: steps.check_version.outputs.proceed == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install MCP Publisher
+        if: steps.check_version.outputs.proceed == 'true'
+        run: |
+          git clone https://github.com/modelcontextprotocol/registry publisher-repo
+          cd publisher-repo
+          make publisher
+          cp cmd/publisher/bin/mcp-publisher ../mcp-publisher
+          cd ..
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry
+        if: steps.check_version.outputs.proceed == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: steps.check_version.outputs.proceed == 'true'
+        run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/teamwork/mcp" \
       org.label-schema.vcs-ref=$BUILD_VCS_REF \
       org.label-schema.vendor="Teamwork.com" \
-      org.label-schema.version=$BUILD_VERSION
+      org.label-schema.version=$BUILD_VERSION \
+      io.modelcontextprotocol.server.name="io.github.teamwork/mcp"
 
 ENTRYPOINT [ "/bin/tw-mcp-http" ]
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.teamwork/mcp",
+  "description": "The Teamwork.com official MCP server helps teams efficiently manage client projects with AI.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/teamwork/mcp",
+    "source": "github"
+  },
+  "version": "1.2.0",
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://mcp.ai.teamwork.com",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "API key generated from the Teamwork.com OAuth2 process: https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
+          "is_required": true,
+          "is_secret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.ai.teamwork.com",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "API key generated from the Teamwork.com OAuth2 process: https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
+          "is_required": true,
+          "is_secret": true
+        }
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "registry_type": "oci",
+      "registry_base_url": "https://docker.io",
+      "identifier": "teamwork/mcp",
+      "version": "v1.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "description": "API key generated from the Teamwork.com OAuth2 process: https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
+          "is_required": true,
+          "format": "string",
+          "is_secret": true,
+          "name": "TW_MCP_BEARER_TOKEN"
+        },
+        {
+          "description": "Choose log output format between 'text' or 'json'. Default is 'text'.",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "TW_MCP_LOG_FORMAT"
+        },
+        {
+          "description": "Choose log level between 'debug', 'info', 'warn' or 'error'. Default is 'info'.",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "TW_MCP_LOG_LEVEL"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

The official MCP registry was announced:
https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/

Following the steps to publish the MCP server:
* https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/guides/publishing/publish-server.md
* https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/reference/server-json/server.schema.json
* https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/reference/server-json/generic-server-json.md#server-with-remote-and-package-options

And automating the release:
* https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/guides/publishing/github-actions.md

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors