### PR TITLE
Fix: MCP registry - Typo in the name causing registration issues

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.teamwork/mcp",
+  "name": "io.github.Teamwork/mcp",
   "description": "The Teamwork.com official MCP server helps teams efficiently manage client projects with AI.",
   "status": "active",
   "repository": {


### PR DESCRIPTION
## Description

> You do not have permission to publish on this server. You have permission to
> publish: io.github.Teamwork/*. Attempting to publish: io.github.teamwork/mcp

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors