### PR TITLE
Fix: Registry - Use custom domain instead of GitHub's domain

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.Teamwork/mcp",
+  "name": "com.teamwork/mcp",
   "description": "The Teamwork.com official MCP server helps teams efficiently manage client projects with AI.",
   "status": "active",
   "repository": {


### PR DESCRIPTION
## Description

To correctly register the MCP server, we MUST use a custom domain since the server is not deployed under `github.io`.

> Error: publish failed: server returned status 400: {"title":"Bad Request","status":400,"detail":"Failed to publish server","errors":[{"message":"remote URL https://mcp.ai.teamwork.com does not match namespace io.github.Teamwork/mcp: remote URL host mcp.ai.teamwork.com does not match publisher domain Teamwork.github.io"}]}

https://github.com/modelcontextprotocol/registry/blob/773f09441ad8d9ce43c34957a7fb21d02e4bed5d/docs/guides/publishing/publish-server.md#step-3-configure-your-server-details

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors