### PR TITLE
Fix: Wrong image label for registry validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$BUILD_VCS_REF \
       org.label-schema.vendor="Teamwork.com" \
       org.label-schema.version=$BUILD_VERSION \
-      io.modelcontextprotocol.server.name="io.github.teamwork/mcp"
+      io.modelcontextprotocol.server.name="com.teamwork/mcp"
 
 ENTRYPOINT [ "/bin/tw-mcp-http" ]
 


### PR DESCRIPTION
## Description

> registry validation failed for package 0 (teamwork/mcp): OCI image ownership validation failed. Expected annotation 'io.modelcontextprotocol.server.name' = 'com.teamwork/mcp', got 'io.github.teamwork/mcp'

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors