### PR TITLE
Feature: New tool to list industries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getsentry/sentry-go v0.35.1
 	github.com/getsentry/sentry-go/slog v0.35.1
 	github.com/mark3labs/mcp-go v0.39.1
-	github.com/teamwork/twapi-go-sdk v1.3.1
+	github.com/teamwork/twapi-go-sdk v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/teamwork/twapi-go-sdk v1.3.1 h1:3XmdVMuXxvnJ7dUlC0Jyk+Tqgxf8jEdEgaQccvnUBkQ=
-github.com/teamwork/twapi-go-sdk v1.3.1/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
+github.com/teamwork/twapi-go-sdk v1.4.0 h1:lajL5uJ7IacmuSP+2pYwxjzYpR1IMBM0Afd3iccAmzc=
+github.com/teamwork/twapi-go-sdk v1.4.0/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
 github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
 github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=

--- a/internal/twprojects/industries.go
+++ b/internal/twprojects/industries.go
@@ -1,0 +1,59 @@
+package twprojects
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/teamwork/mcp/internal/helpers"
+	"github.com/teamwork/mcp/internal/toolsets"
+	"github.com/teamwork/twapi-go-sdk"
+	"github.com/teamwork/twapi-go-sdk/projects"
+)
+
+// List of methods available in the Teamwork.com MCP service.
+//
+// The naming convention for methods follows a pattern described here:
+// https://github.com/github/github-mcp-server/issues/333
+const (
+	MethodIndustryList toolsets.Method = "twprojects-list_industries"
+)
+
+const industryDescription = "Industry refers to the business sector or market category that a company belongs to, " +
+	"such as technology, healthcare, finance, or education. It helps provide context about the nature of a company's " +
+	"work and can be used to better organize and filter data across the platform. By associating companies and " +
+	"projects with specific industries, Teamwork.com allows teams to gain clearer insights, tailor communication, " +
+	"and segment information in ways that make it easier to manage relationships and understand the broader business " +
+	"landscape in which their clients and partners operate."
+
+func init() {
+	// register the toolset methods
+	toolsets.RegisterMethod(MethodIndustryList)
+}
+
+// IndustryList lists projects in Teamwork.com.
+func IndustryList(engine *twapi.Engine) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(string(MethodIndustryList),
+			mcp.WithDescription("List industries in Teamwork.com. "+industryDescription),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				ReadOnlyHint: twapi.Ptr(true),
+			}),
+		),
+		Handler: func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var industryListRequest projects.IndustryListRequest
+
+			industryList, err := projects.IndustryList(ctx, engine, industryListRequest)
+			if err != nil {
+				return helpers.HandleAPIError(err, "failed to list industries")
+			}
+
+			encoded, err := json.Marshal(industryList)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	}
+}

--- a/internal/twprojects/industries_test.go
+++ b/internal/twprojects/industries_test.go
@@ -1,0 +1,34 @@
+package twprojects_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/teamwork/mcp/internal/twprojects"
+)
+
+func TestIndustryList(t *testing.T) {
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = twprojects.MethodIndustryList.String()
+	request.Params.Arguments = map[string]any{}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	checkMessage(t, mcpServer.HandleMessage(context.Background(), encodedRequest))
+}

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -100,6 +100,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			ActivityListByProject(engine),
 			NotebookGet(engine),
 			NotebookList(engine),
+			IndustryList(engine),
 		))
 	return group
 }


### PR DESCRIPTION
## Description

When creating companies, you can optionally set an industry. To correctly identify the industry, a new tool is now available.

<img width="501" height="805" alt="image" src="https://github.com/user-attachments/assets/fb3d2c35-6935-4632-9ef4-a507a62a2477" />

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors