### PR TITLE
Fix: MCP CLI - Token should be optional

### DIFF
--- a/cmd/mcp-http-cli/README.md
+++ b/cmd/mcp-http-cli/README.md
@@ -41,10 +41,7 @@ This CLI tool is designed for:
 
 ```bash
 # List all available tools
-go run cmd/mcp-http-cli/main.go \
-  -mcp-url=https://my-mcp.example.com \
-  -mcp-token=your-bearer-token \
-  list-tools
+go run cmd/mcp-http-cli/main.go list-tools
 
 # Call a tool without parameters
 go run cmd/mcp-http-cli/main.go \

--- a/cmd/mcp-http-cli/main.go
+++ b/cmd/mcp-http-cli/main.go
@@ -36,14 +36,15 @@ func main() {
 		resources.Logger().Error("MCP URL is required")
 		exit(exitCodeSetupFailure)
 	}
-	if *mcpToken == "" {
-		resources.Logger().Error("MCP token is required")
-		exit(exitCodeSetupFailure)
+
+	var options []transport.StreamableHTTPCOption
+	if *mcpToken != "" {
+		options = append(options, transport.WithHTTPHeaders(map[string]string{
+			"Authorization": "Bearer " + *mcpToken,
+		}))
 	}
 
-	mcpTransport, err := transport.NewStreamableHTTP(*mcpURL, transport.WithHTTPHeaders(map[string]string{
-		"Authorization": "Bearer " + *mcpToken,
-	}))
+	mcpTransport, err := transport.NewStreamableHTTP(*mcpURL, options...)
 	if err != nil {
 		resources.Logger().Error("failed to create MCP transport",
 			slog.String("error", err.Error()),


### PR DESCRIPTION
## Description

It's not required to provide a token only to list the MCP tools.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors