### PR TITLE
Fix: Hide sensitive HTTP headers from logs

### DIFF
--- a/internal/network/roundtripper.go
+++ b/internal/network/roundtripper.go
@@ -36,11 +36,16 @@ func (lrt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	}
 
+	headers := req.Header.Clone()
+	if headers.Get("Authorization") != "" {
+		headers.Set("Authorization", "REDACTED")
+	}
+
 	// Log the request
 	lrt.Log.Info("HTTP request",
 		"url", req.URL.String(),
 		"method", req.Method,
-		"headers", req.Header,
+		"headers", headers,
 		"body", string(reqBody),
 	)
 


### PR DESCRIPTION
## Description

The logging interceptor would show sensitive HTTP headers, such as `Authorization`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added necessary documentation
- [x] No new warnings or errors