### PR TITLE
Fixes an issue with variadic parameters in Desk SDK functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getsentry/sentry-go v0.35.3
 	github.com/getsentry/sentry-go/slog v0.35.3
 	github.com/mark3labs/mcp-go v0.40.0
-	github.com/teamwork/desksdkgo v0.0.0-20250924185936-ff711b483ff5
+	github.com/teamwork/desksdkgo v0.0.0-20250926190515-ffa848575e87
 	github.com/teamwork/twapi-go-sdk v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/teamwork/desksdkgo v0.0.0-20250924185936-ff711b483ff5 h1:4M50RqWs/LVmoiEg6SbI7tCSXN6nkBXBydreOlPwBmk=
-github.com/teamwork/desksdkgo v0.0.0-20250924185936-ff711b483ff5/go.mod h1:UHHlSr5OgHCJ4XeYFo0aYKhuIi/C4hXxupJ5Fe4A/tA=
+github.com/teamwork/desksdkgo v0.0.0-20250926190515-ffa848575e87 h1:QEi1AlEqW47oKAMs5PGZMeI4q1sfbXwdPPXMBQIpoTU=
+github.com/teamwork/desksdkgo v0.0.0-20250926190515-ffa848575e87/go.mod h1:UHHlSr5OgHCJ4XeYFo0aYKhuIi/C4hXxupJ5Fe4A/tA=
 github.com/teamwork/twapi-go-sdk v1.5.0 h1:ExlQz2WJPKKlBiGtm5l+Gtp5zp5U3InKVDtBx7AbYAc=
 github.com/teamwork/twapi-go-sdk v1.5.0/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
 github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=

--- a/internal/helpers/sliceutil.go
+++ b/internal/helpers/sliceutil.go
@@ -1,0 +1,10 @@
+package helpers
+
+// SliceToAny converts a slice of any type to []any for use with filter.In()
+func SliceToAny[T any](slice []T) []any {
+	result := make([]any, len(slice))
+	for i, v := range slice {
+		result[i] = v
+	}
+	return result
+}

--- a/internal/twdesk/companies.go
+++ b/internal/twdesk/companies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -88,7 +89,7 @@ func CompanyList(client *deskclient.Client) server.ServerTool {
 			}
 
 			if len(domains) > 0 {
-				filter = filter.In("domains", domains)
+				filter = filter.In("domains", helpers.SliceToAny(domains))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -80,15 +81,15 @@ func CustomerList(client *deskclient.Client) server.ServerTool {
 
 			filter := deskclient.NewFilter()
 			if len(companyIDs) > 0 {
-				filter = filter.In("companies.id", companyIDs)
+				filter = filter.In("companies.id", helpers.SliceToAny(companyIDs))
 			}
 
 			if len(companyNames) > 0 {
-				filter = filter.In("companies.name", companyNames)
+				filter = filter.In("companies.name", helpers.SliceToAny(companyNames))
 			}
 
 			if len(emails) > 0 {
-				filter = filter.In("contacts.value", emails)
+				filter = filter.In("contacts.value", helpers.SliceToAny(emails))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/priorities.go
+++ b/internal/twdesk/priorities.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -78,10 +79,10 @@ func PriorityList(client *deskclient.Client) server.ServerTool {
 
 			filter := deskclient.NewFilter()
 			if len(name) > 0 {
-				filter = filter.In("name", name)
+				filter = filter.In("name", helpers.SliceToAny(name))
 			}
 			if len(color) > 0 {
-				filter = filter.In("color", color)
+				filter = filter.In("color", helpers.SliceToAny(color))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/statuses.go
+++ b/internal/twdesk/statuses.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -80,13 +81,13 @@ func StatusList(client *deskclient.Client) server.ServerTool {
 
 			filter := deskclient.NewFilter()
 			if len(name) > 0 {
-				filter = filter.In("name", name)
+				filter = filter.In("name", helpers.SliceToAny(name))
 			}
 			if len(color) > 0 {
-				filter = filter.In("color", color)
+				filter = filter.In("color", helpers.SliceToAny(color))
 			}
 			if len(code) > 0 {
-				filter = filter.In("code", code)
+				filter = filter.In("code", helpers.SliceToAny(code))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/tags.go
+++ b/internal/twdesk/tags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -86,7 +87,7 @@ func TagList(client *deskclient.Client) server.ServerTool {
 				filter = filter.Eq("color", color)
 			}
 			if len(inboxIDs) > 0 {
-				filter = filter.In("inboxes.id", inboxIDs)
+				filter = filter.In("inboxes.id", helpers.SliceToAny(inboxIDs))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -108,43 +108,43 @@ func TicketList(client *deskclient.Client) server.ServerTool {
 			filter := deskclient.NewFilter()
 
 			if len(inboxIDs) > 0 {
-				filter = filter.In("inboxes.id", inboxIDs)
+				filter = filter.In("inboxes.id", helpers.SliceToAny(inboxIDs))
 			}
 
 			if len(customerIDs) > 0 {
-				filter = filter.In("customers.id", customerIDs)
+				filter = filter.In("customers.id", helpers.SliceToAny(customerIDs))
 			}
 
 			if len(companyIDs) > 0 {
-				filter = filter.In("companies.id", companyIDs)
+				filter = filter.In("companies.id", helpers.SliceToAny(companyIDs))
 			}
 
 			if len(tagIDs) > 0 {
-				filter = filter.In("tags.id", tagIDs)
+				filter = filter.In("tags.id", helpers.SliceToAny(tagIDs))
 			}
 
 			if len(taskIDs) > 0 {
-				filter = filter.In("tasks.id", taskIDs)
+				filter = filter.In("tasks.id", helpers.SliceToAny(taskIDs))
 			}
 
 			if len(projectsIDs) > 0 {
-				filter = filter.In("projects.id", projectsIDs)
+				filter = filter.In("projects.id", helpers.SliceToAny(projectsIDs))
 			}
 
 			if len(statusIDs) > 0 {
-				filter = filter.In("statuses.id", statusIDs)
+				filter = filter.In("statuses.id", helpers.SliceToAny(statusIDs))
 			}
 
 			if len(priorityIDs) > 0 {
-				filter = filter.In("priorities.id", priorityIDs)
+				filter = filter.In("priorities.id", helpers.SliceToAny(priorityIDs))
 			}
 
 			if len(slaIDs) > 0 {
-				filter = filter.In("slas.id", slaIDs)
+				filter = filter.In("slas.id", helpers.SliceToAny(slaIDs))
 			}
 
 			if len(userIDs) > 0 {
-				filter = filter.In("users.id", userIDs)
+				filter = filter.In("users.id", helpers.SliceToAny(userIDs))
 			}
 
 			if shared {

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
 	deskmodels "github.com/teamwork/desksdkgo/models"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -77,10 +78,10 @@ func TypeList(client *deskclient.Client) server.ServerTool {
 
 			filter := deskclient.NewFilter()
 			if len(name) > 0 {
-				filter = filter.In("name", name)
+				filter = filter.In("name", helpers.SliceToAny(name))
 			}
 			if len(inboxIDs) > 0 {
-				filter = filter.In("inboxes.id", inboxIDs)
+				filter = filter.In("inboxes.id", helpers.SliceToAny(inboxIDs))
 			}
 
 			params := url.Values{}

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	deskclient "github.com/teamwork/desksdkgo/client"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 )
 
@@ -78,16 +79,16 @@ func UserList(client *deskclient.Client) server.ServerTool {
 
 			filter := deskclient.NewFilter()
 			if len(firstNames) > 0 {
-				filter = filter.In("firstName", firstNames)
+				filter = filter.In("firstName", helpers.SliceToAny(firstNames))
 			}
 			if len(lastNames) > 0 {
-				filter = filter.In("lastName", lastNames)
+				filter = filter.In("lastName", helpers.SliceToAny(lastNames))
 			}
 			if len(emails) > 0 {
-				filter = filter.In("email", emails)
+				filter = filter.In("email", helpers.SliceToAny(emails))
 			}
 			if len(inboxIDs) > 0 {
-				filter = filter.In("inboxes.id", inboxIDs)
+				filter = filter.In("inboxes.id", helpers.SliceToAny(inboxIDs))
 			}
 
 			isPartTime := request.GetBool("isPartTime", false)


### PR DESCRIPTION
filter.In() took a variadic number of any arguments, but the generated Desk SDK functions were passing a slice of interface{} instead of expanding the slice into individual arguments. This caused nested slices and incorrect filtering behavior.

## Description
<!-- Briefly describe what this PR does and why it's needed -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors