### PR TITLE
add validators for all of desk schemas to ensure all properties are added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/dd-trace-go/v2 v2.2.3
 	github.com/getsentry/sentry-go v0.35.3
 	github.com/getsentry/sentry-go/slog v0.35.3
+	github.com/google/jsonschema-go v0.3.0
 	github.com/mark3labs/mcp-go v0.41.0
 	github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb
 	github.com/teamwork/twapi-go-sdk v1.5.0
@@ -32,7 +33,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/brianvoe/gofakeit/v7 v7.2.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
@@ -48,7 +48,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/brianvoe/gofakeit/v7 v7.2.1 h1:AGojgaaCdgq4Adzrd2uWdbGNDyX6MWNhHdQBraNfOHI=
-github.com/brianvoe/gofakeit/v7 v7.2.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -97,6 +95,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -105,8 +105,6 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -177,8 +175,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/teamwork/desksdkgo v0.0.0-20250926190515-ffa848575e87 h1:QEi1AlEqW47oKAMs5PGZMeI4q1sfbXwdPPXMBQIpoTU=
-github.com/teamwork/desksdkgo v0.0.0-20250926190515-ffa848575e87/go.mod h1:UHHlSr5OgHCJ4XeYFo0aYKhuIi/C4hXxupJ5Fe4A/tA=
 github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb h1:SfMo8teNL3mBsvpSyxoP3u60htTC7rTI1TZjIzwPM60=
 github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
 github.com/teamwork/twapi-go-sdk v1.5.0 h1:ExlQz2WJPKKlBiGtm5l+Gtp5zp5U3InKVDtBx7AbYAc=

--- a/internal/testutil/schema_validation_helpers.go
+++ b/internal/testutil/schema_validation_helpers.go
@@ -1,0 +1,479 @@
+// Package testutil provides schema validation helpers for testing MCP tools
+//
+//nolint:lll
+package testutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/mark3labs/mcp-go/server"
+	deskclient "github.com/teamwork/desksdkgo/client"
+	"github.com/teamwork/mcp/internal/twdesk"
+)
+
+// SchemaValidationTestSuite provides a comprehensive test suite for validating MCP tool JSON schemas
+type SchemaValidationTestSuite struct {
+	tools       map[string]server.ServerTool
+	validData   map[string]map[string]map[string]any // [toolName][testCase] -> data
+	invalidData map[string]map[string]map[string]any // [toolName][testCase] -> data
+}
+
+// NewSchemaValidationTestSuite creates a new test suite with all twdesk tools
+func NewSchemaValidationTestSuite() *SchemaValidationTestSuite {
+	client := &deskclient.Client{}
+
+	tools := map[string]server.ServerTool{
+		// Company tools
+		"CompanyCreate": twdesk.CompanyCreate(client),
+		"CompanyUpdate": twdesk.CompanyUpdate(client),
+		"CompanyGet":    twdesk.CompanyGet(client),
+		"CompanyList":   twdesk.CompanyList(client),
+
+		// Customer tools
+		"CustomerCreate": twdesk.CustomerCreate(client),
+		"CustomerUpdate": twdesk.CustomerUpdate(client),
+		"CustomerGet":    twdesk.CustomerGet(client),
+		"CustomerList":   twdesk.CustomerList(client),
+
+		// Ticket tools
+		"TicketCreate": twdesk.TicketCreate(client),
+		"TicketUpdate": twdesk.TicketUpdate(client),
+		"TicketGet":    twdesk.TicketGet(client),
+		"TicketList":   twdesk.TicketList(client),
+
+		// Priority tools
+		"PriorityCreate": twdesk.PriorityCreate(client),
+		"PriorityUpdate": twdesk.PriorityUpdate(client),
+		"PriorityGet":    twdesk.PriorityGet(client),
+		"PriorityList":   twdesk.PriorityList(client),
+
+		// Status tools
+		"StatusCreate": twdesk.StatusCreate(client),
+		"StatusUpdate": twdesk.StatusUpdate(client),
+		"StatusGet":    twdesk.StatusGet(client),
+		"StatusList":   twdesk.StatusList(client),
+
+		// Tag tools
+		"TagCreate": twdesk.TagCreate(client),
+		"TagUpdate": twdesk.TagUpdate(client),
+		"TagGet":    twdesk.TagGet(client),
+		"TagList":   twdesk.TagList(client),
+
+		// Type tools
+		"TypeCreate": twdesk.TypeCreate(client),
+		"TypeUpdate": twdesk.TypeUpdate(client),
+		"TypeGet":    twdesk.TypeGet(client),
+		"TypeList":   twdesk.TypeList(client),
+
+		// User tools
+		"UserGet":  twdesk.UserGet(client),
+		"UserList": twdesk.UserList(client),
+
+		// Message tools
+		"MessageCreate": twdesk.MessageCreate(client),
+
+		// File tools
+		"FileCreate": twdesk.FileCreate(client),
+	}
+
+	return &SchemaValidationTestSuite{
+		tools:       tools,
+		validData:   GetValidTestData(),
+		invalidData: GetInvalidTestData(),
+	}
+}
+
+// RunAllSchemaValidationTests runs comprehensive schema validation tests for all tools
+func (s *SchemaValidationTestSuite) RunAllSchemaValidationTests(t *testing.T) {
+	for toolName, tool := range s.tools {
+		t.Run(toolName, func(t *testing.T) {
+			s.runToolSchemaValidation(t, toolName, tool)
+		})
+	}
+}
+
+// GetTool returns a tool by name if it exists
+func (s *SchemaValidationTestSuite) GetTool(toolName string) (server.ServerTool, bool) {
+	tool, exists := s.tools[toolName]
+	return tool, exists
+}
+
+// RunToolSchemaValidation runs schema validation tests for a single tool (exported version)
+func (s *SchemaValidationTestSuite) RunToolSchemaValidation(t *testing.T, toolName string, tool server.ServerTool) {
+	s.runToolSchemaValidation(t, toolName, tool)
+}
+
+// runToolSchemaValidation runs schema validation tests for a single tool
+func (s *SchemaValidationTestSuite) runToolSchemaValidation(t *testing.T, toolName string, tool server.ServerTool) {
+	inputSchema := tool.Tool.InputSchema
+
+	schemaBytes, err := json.Marshal(inputSchema)
+	if err != nil {
+		t.Fatalf("Failed to marshal input schema to JSON: %v", err)
+	}
+
+	var schema jsonschema.Schema
+	err = json.Unmarshal(schemaBytes, &schema)
+	if err != nil {
+		t.Fatalf("Invalid JSON schema for %s tool: %v\nSchema: %s", toolName, err, string(schemaBytes))
+	}
+
+	resolvedSchema, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("Failed to resolve schema for %s tool: %v", toolName, err)
+	}
+
+	t.Run("ValidateValidData", func(t *testing.T) {
+		s.testValidDataAgainstSchema(t, toolName, resolvedSchema)
+	})
+
+	t.Run("ValidateInvalidData", func(t *testing.T) {
+		s.testInvalidDataAgainstSchema(t, toolName, resolvedSchema)
+	})
+
+	t.Run("ValidateArrayItemTypes", func(t *testing.T) {
+		s.validateArrayItemTypes(t, toolName, inputSchema)
+	})
+}
+
+// testValidDataAgainstSchema tests the schema with valid input data
+func (s *SchemaValidationTestSuite) testValidDataAgainstSchema(t *testing.T, toolName string, resolvedSchema *jsonschema.Resolved) {
+	validTestData, exists := s.validData[toolName]
+	if !exists {
+		t.Logf("No valid test data defined for %s tool, skipping", toolName)
+		return
+	}
+
+	for testName, testData := range validTestData {
+		t.Run(testName, func(t *testing.T) {
+			err := resolvedSchema.Validate(testData)
+			if err != nil {
+				t.Errorf("Valid data should pass schema validation for %s tool.\nError: %v\nData: %+v",
+					toolName, err, testData)
+			}
+		})
+	}
+}
+
+// testInvalidDataAgainstSchema tests the schema with invalid input data
+func (s *SchemaValidationTestSuite) testInvalidDataAgainstSchema(t *testing.T, toolName string, resolvedSchema *jsonschema.Resolved) {
+	invalidTestData, exists := s.invalidData[toolName]
+	if !exists {
+		t.Logf("No invalid test data defined for %s tool, skipping", toolName)
+		return
+	}
+
+	for testName, testData := range invalidTestData {
+		t.Run(testName, func(t *testing.T) {
+			err := resolvedSchema.Validate(testData)
+			if err == nil {
+				t.Errorf("Invalid data should fail schema validation for %s tool.\nData: %+v",
+					toolName, testData)
+			}
+		})
+	}
+}
+
+// validateArrayItemTypes specifically checks that array properties have proper string type constraints
+func (s *SchemaValidationTestSuite) validateArrayItemTypes(t *testing.T, toolName string, inputSchema any) {
+	schemaBytes, err := json.Marshal(inputSchema)
+	if err != nil {
+		t.Fatalf("Failed to marshal schema for %s tool: %v", toolName, err)
+	}
+
+	var schemaMap map[string]any
+	if err := json.Unmarshal(schemaBytes, &schemaMap); err != nil {
+		t.Fatalf("Failed to unmarshal schema for %s tool: %v", toolName, err)
+	}
+
+	properties, ok := schemaMap["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for propName, property := range properties {
+		propertyMap, ok := property.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if propertyType, exists := propertyMap["type"]; exists && propertyType == "array" {
+			if items, exists := propertyMap["items"]; exists {
+				itemsMap, ok := items.(map[string]any)
+				if !ok {
+					t.Errorf("%s property items should be a map for %s tool", propName, toolName)
+					continue
+				}
+
+				if itemType, exists := itemsMap["type"]; exists {
+					if itemType == "" {
+						t.Errorf("%s array items should have a non-empty type for %s tool", propName, toolName)
+					}
+				} else {
+					t.Errorf("%s array items should have a 'type' property for %s tool", propName, toolName)
+				}
+			} else {
+				t.Errorf("%s array should have an 'items' property for %s tool", propName, toolName)
+			}
+		}
+	}
+}
+
+// GetValidTestData returns valid test data for all tools
+func GetValidTestData() map[string]map[string]map[string]any {
+	return map[string]map[string]map[string]any{
+		"CompanyCreate": {
+			"minimal": {
+				"name": "Test Company",
+			},
+			"complete": {
+				"name":        "Test Company",
+				"description": "A test company",
+				"details":     "Company details",
+				"industry":    "Technology",
+				"website":     "https://example.com",
+				"permission":  "own",
+				"kind":        "company",
+				"note":        "Test note",
+				"domains":     []string{"example.com", "test.com"},
+			},
+		},
+		"CompanyUpdate": {
+			"minimal": {
+				"id": "123",
+			},
+			"complete": {
+				"id":          "123",
+				"name":        "Updated Company",
+				"description": "Updated description",
+				"domains":     []string{"updated.com"},
+			},
+		},
+		"CompanyGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"CompanyList": {
+			"empty": {},
+			"with_filters": {
+				"name":      "Test Company",
+				"domains":   []string{"example.com"},
+				"kind":      "company",
+				"page":      1,
+				"page_size": 10,
+			},
+		},
+		"CustomerCreate": {
+			"minimal": {
+				"firstName": "John",
+				"lastName":  "Doe",
+				"email":     "john.doe@example.com",
+			},
+		},
+		"CustomerGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"CustomerList": {
+			"empty": {},
+		},
+		"TicketCreate": {
+			"minimal": {
+				"subject": "Test Ticket",
+				"message": "Test message",
+			},
+		},
+		"TicketGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"TicketList": {
+			"empty": {},
+		},
+		"PriorityCreate": {
+			"minimal": {
+				"name": "High Priority",
+			},
+		},
+		"PriorityGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"PriorityList": {
+			"empty": {},
+		},
+		"StatusCreate": {
+			"minimal": {
+				"name": "Open",
+			},
+		},
+		"StatusGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"StatusList": {
+			"empty": {},
+		},
+		"TagCreate": {
+			"minimal": {
+				"name": "Important",
+			},
+		},
+		"TagGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"TagList": {
+			"empty": {},
+		},
+		"TypeCreate": {
+			"minimal": {
+				"name": "Bug Report",
+			},
+		},
+		"TypeGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"TypeList": {
+			"empty": {},
+		},
+		"UserGet": {
+			"valid": {
+				"id": "123",
+			},
+		},
+		"UserList": {
+			"empty": {},
+		},
+		"MessageCreate": {
+			"minimal": {
+				"ticketID": 123,
+				"body":     "Test message",
+			},
+		},
+		"FileCreate": {
+			"minimal": {
+				"name":     "test.txt",
+				"mimeType": "text/plain",
+				"data":     "VGVzdCBjb250ZW50", // base64 encoded "Test content"
+			},
+		},
+	}
+}
+
+// GetInvalidTestData returns invalid test data for all tools
+func GetInvalidTestData() map[string]map[string]map[string]any {
+	return map[string]map[string]map[string]any{
+		"CompanyCreate": {
+			"missing_required_name": {
+				"description": "A test company",
+			},
+			"invalid_permission": {
+				"name":       "Test Company",
+				"permission": "invalid_permission",
+			},
+			"invalid_kind": {
+				"name": "Test Company",
+				"kind": "invalid_kind",
+			},
+			"invalid_domains_type": {
+				"name":    "Test Company",
+				"domains": "should_be_array",
+			},
+			"invalid_domain_item_type": {
+				"name":    "Test Company",
+				"domains": []any{123, 456}, // should be strings
+			},
+		},
+		"CompanyUpdate": {
+			"missing_required_id": {
+				"name": "Updated Company",
+			},
+			"invalid_domains_type": {
+				"id":      "123",
+				"domains": "should_be_array",
+			},
+		},
+		"CompanyGet": {
+			"missing_required_id": {},
+		},
+		"CompanyList": {
+			"invalid_kind": {
+				"kind": "invalid_kind",
+			},
+			"invalid_domains_type": {
+				"domains": "should_be_array",
+			},
+		},
+		"CustomerCreate": {
+			"invalid_property_type": {
+				"firstName": 123, // should be string, not number
+				"lastName":  "Doe",
+				"email":     "john@example.com",
+			},
+		},
+		"CustomerGet": {
+			"missing_required_id": {},
+		},
+		"TicketCreate": {
+			"missing_required_subject": {
+				"message": "Test message",
+			},
+		},
+		"TicketGet": {
+			"missing_required_id": {},
+		},
+		"PriorityCreate": {
+			"missing_required_name": {},
+		},
+		"PriorityGet": {
+			"missing_required_id": {},
+		},
+		"StatusCreate": {
+			"missing_required_name": {},
+		},
+		"StatusGet": {
+			"missing_required_id": {},
+		},
+		"TagCreate": {
+			"missing_required_name": {},
+		},
+		"TagGet": {
+			"missing_required_id": {},
+		},
+		"TypeCreate": {
+			"missing_required_name": {},
+		},
+		"TypeGet": {
+			"missing_required_id": {},
+		},
+		"UserGet": {
+			"missing_required_id": {},
+		},
+		"MessageCreate": {
+			"missing_required_ticketID": {
+				"body": "Test message",
+			},
+		},
+		"FileCreate": {
+			"missing_required_name": {
+				"mimeType": "text/plain",
+				"data":     "VGVzdCBjb250ZW50",
+			},
+			"missing_required_data": {
+				"name":     "test.txt",
+				"mimeType": "text/plain",
+			},
+		},
+	}
+}

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -133,10 +133,6 @@ func CustomerCreate(client *deskclient.Client) server.ServerTool {
 				"Create a new customer in Teamwork Desk by specifying their name, contact details, and other attributes. "+
 					"Useful for onboarding new clients, customizing Desk for business relationships, or "+
 					"adapting support processes."),
-			mcp.WithString("id",
-				mcp.Required(),
-				mcp.Description("The ID of the customer to update."),
-			),
 			mcp.WithString("firstName",
 				mcp.Description("The first name of the customer."),
 			),

--- a/internal/twdesk/schema_validation_test.go
+++ b/internal/twdesk/schema_validation_test.go
@@ -1,0 +1,13 @@
+package twdesk_test
+
+import (
+	"testing"
+
+	"github.com/teamwork/mcp/internal/testutil"
+)
+
+// TestAllToolsJSONSchemaValidation tests that all twdesk tools generate valid JSON schemas
+func TestAllToolsJSONSchemaValidation(t *testing.T) {
+	suite := testutil.NewSchemaValidationTestSuite()
+	suite.RunAllSchemaValidationTests(t)
+}

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -64,11 +64,37 @@ func UserList(client *deskclient.Client) server.ServerTool {
 				"Enables users to audit, analyze, or synchronize user configurations for support management, " +
 				"reporting, or integration scenarios."),
 		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithArray("firstName", mcp.Description("The first names of the users to filter by.")),
-		mcp.WithArray("lastName", mcp.Description("The last names of the users to filter by.")),
-		mcp.WithArray("email", mcp.Description("The email addresses of the users to filter by.")),
-		mcp.WithArray("inboxIDs", mcp.Description("The IDs of the inboxes to filter by.")),
-		mcp.WithBoolean("isPartTime", mcp.Description("Whether to include part-time users in the results.")),
+		mcp.WithArray(
+			"firstName",
+			mcp.Description("The first names of the users to filter by."),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+		mcp.WithArray(
+			"lastName",
+			mcp.Description("The last names of the users to filter by."),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+		mcp.WithArray(
+			"email",
+			mcp.Description("The email addresses of the users to filter by."),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+		mcp.WithArray(
+			"inboxIDs",
+			mcp.Description("The IDs of the inboxes to filter by."),
+			mcp.Items(map[string]any{
+				"type": "integer",
+			}),
+		),
+		mcp.WithBoolean(
+			"isPartTime",
+			mcp.Description("Whether to include part-time users in the results.")),
 	}
 
 	opts = append(opts, paginationOptions()...)


### PR DESCRIPTION
We were getting errors when types were defined as `WithArray` but the data type was not included.  I've added tests to ensure that the generated json spec is valid as well as that when the type is array that there is a sub-field `items` specifying the data type (integer, string, etc)