### PR TITLE
Create tickets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/getsentry/sentry-go/slog v0.35.3
 	github.com/google/jsonschema-go v0.3.0
 	github.com/mark3labs/mcp-go v0.41.0
-	github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb
+	github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3
 	github.com/teamwork/twapi-go-sdk v1.5.0
 )
 
@@ -33,6 +33,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/brianvoe/gofakeit/v7 v7.2.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/getsentry/sentry-go/slog v0.35.3
 	github.com/google/jsonschema-go v0.3.0
 	github.com/mark3labs/mcp-go v0.41.0
-	github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3
+	github.com/teamwork/desksdkgo v0.0.0-20251001134327-c1de59729eb7
 	github.com/teamwork/twapi-go-sdk v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb h1:SfMo8teNL3mB
 github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
 github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3 h1:8DFttxHW5l0ezooaXPB93OgeOtjc8gs3IJUNVvnYeXA=
 github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
+github.com/teamwork/desksdkgo v0.0.0-20251001134327-c1de59729eb7 h1:ia1IAaaQccOPqrnnDCgvDU7dtMcSfZL0IqoI07jN+gw=
+github.com/teamwork/desksdkgo v0.0.0-20251001134327-c1de59729eb7/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
 github.com/teamwork/twapi-go-sdk v1.5.0 h1:ExlQz2WJPKKlBiGtm5l+Gtp5zp5U3InKVDtBx7AbYAc=
 github.com/teamwork/twapi-go-sdk v1.5.0/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
 github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/brianvoe/gofakeit/v7 v7.2.1 h1:AGojgaaCdgq4Adzrd2uWdbGNDyX6MWNhHdQBraNfOHI=
+github.com/brianvoe/gofakeit/v7 v7.2.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -105,6 +107,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -177,6 +181,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb h1:SfMo8teNL3mBsvpSyxoP3u60htTC7rTI1TZjIzwPM60=
 github.com/teamwork/desksdkgo v0.0.0-20250929211500-ca36cbdf08eb/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
+github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3 h1:8DFttxHW5l0ezooaXPB93OgeOtjc8gs3IJUNVvnYeXA=
+github.com/teamwork/desksdkgo v0.0.0-20250930210058-3418119359c3/go.mod h1:6P8Kni1Kbngl2ZF/P+zZWcrnq30iJgTqW6nbjocN5fI=
 github.com/teamwork/twapi-go-sdk v1.5.0 h1:ExlQz2WJPKKlBiGtm5l+Gtp5zp5U3InKVDtBx7AbYAc=
 github.com/teamwork/twapi-go-sdk v1.5.0/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
 github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -263,14 +263,34 @@ func TicketCreate(client *deskclient.Client) server.ServerTool {
 				"Create a new ticket in Teamwork Desk by specifying subject, description, priority, and status. "+
 					"Useful for automating ticket creation, integrating external systems, or customizing support workflows."),
 			mcp.WithString("subject", mcp.Required(), mcp.Description("The subject of the ticket.")),
-			mcp.WithString("description", mcp.Description("The description of the ticket.")),
-			mcp.WithString("priority", mcp.Description("The priority of the ticket.")),
-			mcp.WithString("status", mcp.Description("The status of the ticket.")),
+			mcp.WithString("body", mcp.Required(), mcp.Description("The body of the ticket.")),
+			mcp.WithNumber("priorityId", mcp.Required(), mcp.Description("The priority of the ticket.")),
+			mcp.WithNumber("statusId", mcp.Required(), mcp.Description("The status of the ticket.")),
+			mcp.WithNumber("inboxId", mcp.Required(), mcp.Description("The inbox ID of the ticket.")),
+			mcp.WithNumber("customerId", mcp.Required(), mcp.Description("The customer ID of the ticket.")),
+			mcp.WithNumber("typeId", mcp.Required(), mcp.Description("The type ID of the ticket.")),
+			mcp.WithNumber("agentId", mcp.Required(), mcp.Description("The agent ID that the ticket should be assigned to.")),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ticket, err := client.Tickets.Create(ctx, &deskmodels.TicketResponse{
 				Ticket: deskmodels.Ticket{
 					Subject: request.GetString("subject", ""),
+					Body:    request.GetString("body", ""),
+					Status: deskmodels.EntityRef{
+						ID: request.GetInt("statusId", 0),
+					},
+					Inbox: deskmodels.EntityRef{
+						ID: request.GetInt("inboxId", 0),
+					},
+					Customer: deskmodels.EntityRef{
+						ID: request.GetInt("customerId", 0),
+					},
+					Type: deskmodels.EntityRef{
+						ID: request.GetInt("typeId", 0),
+					},
+					Agent: deskmodels.EntityRef{
+						ID: request.GetInt("agentId", 0),
+					},
 				},
 			})
 			if err != nil {

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -305,27 +305,45 @@ func TicketCreate(client *deskclient.Client) server.ServerTool {
 			),
 			mcp.WithNumber("priorityId",
 				mcp.Required(),
-				mcp.Description("The priority of the ticket."),
+				mcp.Description(`
+					The priority of the ticket. 
+					Use the 'twdesk-list_priorities' tool to find valid IDs.
+				`),
 			),
 			mcp.WithNumber("statusId",
 				mcp.Required(),
-				mcp.Description("The status of the ticket."),
+				mcp.Description(`
+					The status of the ticket. 
+					Use the 'twdesk-list_statuses' tool to find valid IDs.
+				`),
 			),
 			mcp.WithNumber("inboxId",
 				mcp.Required(),
-				mcp.Description("The inbox ID of the ticket."),
+				mcp.Description(`
+					The inbox ID of the ticket. 
+					Use the 'twdesk-list_inboxes' tool to find valid IDs.
+				`),
 			),
 			mcp.WithNumber("customerId",
 				mcp.Required(),
-				mcp.Description("The customer ID of the ticket."),
+				mcp.Description(`
+					The customer ID of the ticket. 
+					Use the 'twdesk-list_customers' tool to find valid IDs.
+				`),
 			),
 			mcp.WithNumber("typeId",
 				mcp.Required(),
-				mcp.Description("The type ID of the ticket."),
+				mcp.Description(`
+					The type ID of the ticket. 
+					Use the 'twdesk-list_types' tool to find valid IDs.
+				`),
 			),
 			mcp.WithNumber("agentId",
 				mcp.Required(),
-				mcp.Description("The agent ID that the ticket should be assigned to."),
+				mcp.Description(`
+					The agent ID that the ticket should be assigned to. 
+					Use the 'twdesk-list_agents' tool to find valid IDs.
+				`),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -297,7 +297,7 @@ func TicketCreate(client *deskclient.Client) server.ServerTool {
 				return nil, fmt.Errorf("failed to create ticket: %w", err)
 			}
 
-			return mcp.NewToolResultText(fmt.Sprintf("Ticket created successfully with ID %d", ticket.Ticket.ID)), nil
+			return mcp.NewToolResultJSON(ticket)
 		},
 	}
 }

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -270,6 +270,9 @@ func TicketCreate(client *deskclient.Client) server.ServerTool {
 				mcp.Required(),
 				mcp.Description("The body of the ticket."),
 			),
+			mcp.WithBoolean("notifyCustomer",
+				mcp.Description("Set to true if the the customer should be sent a copy of the ticket."),
+			),
 			mcp.WithArray("bcc",
 				mcp.Description("An array of email addresses to BCC on ticket creation."),
 				mcp.Items(map[string]any{
@@ -344,6 +347,10 @@ func TicketCreate(client *deskclient.Client) server.ServerTool {
 				Agent: deskmodels.EntityRef{
 					ID: request.GetInt("agentId", 0),
 				},
+			}
+
+			if request.GetBool("notifyCustomer", false) {
+				data.NotifyCustomer = true
 			}
 
 			if len(request.GetIntSlice("files", []int{})) > 0 {


### PR DESCRIPTION
Adds ticket creation via the create ticket tool.  Accepts all options that the API supports including file uploads, cc, bcc, notifying customers.  Provides hints as to where priorities, inboxes, types, sources, customers, and users can be looked up.