### PR TITLE
Fix: MCP registry schema changed

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-11/server.schema.json",
   "name": "com.teamwork/mcp",
   "description": "The Teamwork.com official MCP server helps teams efficiently manage client projects with AI.",
   "repository": {
@@ -36,9 +36,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://docker.io",
-      "identifier": "teamwork/mcp",
-      "version": "v1.0.0",
+      "identifier": "docker.io/teamwork/mcp:v1.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Description

<img width="1300" height="72" alt="image" src="https://github.com/user-attachments/assets/6fb812c0-0b1d-4ddf-8cbb-3640e1a74028" />

> version field is now optional - Previously required for all packages, now
> only used by npm, pypi, and nuget. OCI packages include version in the
> identifier (e.g., ghcr.io/owner/repo:v1.0.0), and MCPB packages use direct
> download URLs.

https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md#2025-10-11

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors