### PR TITLE
Fix: Return correct schema type when the field is nullable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,12 @@ require (
 	github.com/DataDog/dd-trace-go/v2 v2.3.1
 	github.com/getsentry/sentry-go v0.36.2
 	github.com/getsentry/sentry-go/slog v0.36.2
-	github.com/google/jsonschema-go v0.3.0
+	// using a specific commit until a new version is released with the null types
+	// fix.
+	//
+	// https://github.com/google/jsonschema-go/issues/41
+	// https://github.com/google/jsonschema-go/pull/42
+	github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/teamwork/desksdkgo v0.0.0-20251003022928-49eb7d63fe81
 	github.com/teamwork/twapi-go-sdk v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
-github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d h1:Gm0k2SMaMbybQdEeFYZqk1nmIXdxyfAGmC9BlbwkyBE=
+github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Description

The MCP server was returning wrong JSON schema types for nullable fields. For example, the `deletedAt` field can return a string containing the date-time when the task was deleted, or a null value otherwise. But the JSON schema was still reporting that it would only return a `string` type. This caused issues for client parsers.

The root cause was in Google's jsonschema-go dependency library, which didn't cover all pointer scenarios.

https://github.com/google/jsonschema-go/issues/41

Resolves #60 #68

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors