### PR TITLE
Fix: Comments failing to list due to performance issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/teamwork/desksdkgo v0.0.0-20251003022928-49eb7d63fe81
-	github.com/teamwork/twapi-go-sdk v1.5.0
+	github.com/teamwork/twapi-go-sdk v1.5.1
 )
 
 require (
@@ -86,7 +86,7 @@ require (
 	golang.org/x/mod v0.28.0 // indirect
 	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teamwork/desksdkgo v0.0.0-20251003022928-49eb7d63fe81 h1:Qn2ImqRPM/wuDibaVUMwiEVPAOfK7SrMsMznkgjBFYg=
 github.com/teamwork/desksdkgo v0.0.0-20251003022928-49eb7d63fe81/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
-github.com/teamwork/twapi-go-sdk v1.5.0 h1:ExlQz2WJPKKlBiGtm5l+Gtp5zp5U3InKVDtBx7AbYAc=
-github.com/teamwork/twapi-go-sdk v1.5.0/go.mod h1:PTxcuGSCYS5UXWbSZEbXalWnVttScOr+ia5rM3uulRM=
+github.com/teamwork/twapi-go-sdk v1.5.1 h1:37BQQ3VmMqNIBENLDQvPzKo7s9Ft6PCoMQc9bdyfIOc=
+github.com/teamwork/twapi-go-sdk v1.5.1/go.mod h1:4VZyEJ9+67cwqIg8mGd8zdDvPEeJOmtia1JBH41h5Xg=
 github.com/theckman/httpforwarded v0.4.0 h1:N55vGJT+6ojTnLY3LQCNliJC4TW0P0Pkeys1G1WpX2w=
 github.com/theckman/httpforwarded v0.4.0/go.mod h1:GVkFynv6FJreNbgH/bpOU9ITDZ7a5WuzdNCtIMI1pVI=
 github.com/tinylib/msgp v1.4.0 h1:SYOeDRiydzOw9kSiwdYp9UcBgPFtLU2WDHaJXyHruf8=
@@ -286,8 +286,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -349,6 +350,13 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "A search term to filter comments by name.",
 					},
+					"updated_after": {
+						Type:   "string",
+						Format: "date-time",
+						Description: "Filter comments updated after this date and time. " +
+							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
+							"updated on the last 3 months.",
+					},
 					"page": {
 						Type:        "integer",
 						Description: "Page number for pagination of results.",
@@ -370,11 +378,17 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 			}
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
+				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError(fmt.Sprintf("invalid parameters: %s", err.Error())), nil
+			}
+
+			if commentListRequest.Filters.UpdatedAfter.IsZero() {
+				// default to last 3 months to improve performance
+				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
 			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
@@ -420,6 +434,13 @@ func CommentListByFileVersion(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "A search term to filter comments by name.",
 					},
+					"updated_after": {
+						Type:   "string",
+						Format: "date-time",
+						Description: "Filter comments updated after this date and time. " +
+							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
+							"updated on the last 3 months.",
+					},
 					"page": {
 						Type:        "integer",
 						Description: "Page number for pagination of results.",
@@ -443,11 +464,17 @@ func CommentListByFileVersion(engine *twapi.Engine) toolsets.ToolWrapper {
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&commentListRequest.Path.FileVersionID, "file_version_id"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
+				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError(fmt.Sprintf("invalid parameters: %s", err.Error())), nil
+			}
+
+			if commentListRequest.Filters.UpdatedAfter.IsZero() {
+				// default to last 3 months to improve performance
+				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
 			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
@@ -492,6 +519,13 @@ func CommentListByMilestone(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "A search term to filter comments by name.",
 					},
+					"updated_after": {
+						Type:   "string",
+						Format: "date-time",
+						Description: "Filter comments updated after this date and time. " +
+							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
+							"updated on the last 3 months.",
+					},
 					"page": {
 						Type:        "integer",
 						Description: "Page number for pagination of results.",
@@ -515,11 +549,17 @@ func CommentListByMilestone(engine *twapi.Engine) toolsets.ToolWrapper {
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&commentListRequest.Path.MilestoneID, "milestone_id"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
+				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError(fmt.Sprintf("invalid parameters: %s", err.Error())), nil
+			}
+
+			if commentListRequest.Filters.UpdatedAfter.IsZero() {
+				// default to last 3 months to improve performance
+				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
 			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
@@ -564,6 +604,13 @@ func CommentListByNotebook(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "A search term to filter comments by name.",
 					},
+					"updated_after": {
+						Type:   "string",
+						Format: "date-time",
+						Description: "Filter comments updated after this date and time. " +
+							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
+							"updated on the last 3 months.",
+					},
 					"page": {
 						Type:        "integer",
 						Description: "Page number for pagination of results.",
@@ -587,11 +634,17 @@ func CommentListByNotebook(engine *twapi.Engine) toolsets.ToolWrapper {
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&commentListRequest.Path.NotebookID, "notebook_id"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
+				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError(fmt.Sprintf("invalid parameters: %s", err.Error())), nil
+			}
+
+			if commentListRequest.Filters.UpdatedAfter.IsZero() {
+				// default to last 3 months to improve performance
+				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
 			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
@@ -636,6 +689,13 @@ func CommentListByTask(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "A search term to filter comments by name.",
 					},
+					"updated_after": {
+						Type:   "string",
+						Format: "date-time",
+						Description: "Filter comments updated after this date and time. " +
+							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
+							"updated on the last 3 months.",
+					},
 					"page": {
 						Type:        "integer",
 						Description: "Page number for pagination of results.",
@@ -659,11 +719,17 @@ func CommentListByTask(engine *twapi.Engine) toolsets.ToolWrapper {
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&commentListRequest.Path.TaskID, "task_id"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
+				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError(fmt.Sprintf("invalid parameters: %s", err.Error())), nil
+			}
+
+			if commentListRequest.Filters.UpdatedAfter.IsZero() {
+				// default to last 3 months to improve performance
+				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
 			commentList, err := projects.CommentList(ctx, engine, commentListRequest)

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -46,9 +46,10 @@ func TestCommentGet(t *testing.T) {
 func TestCommentList(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
-		"search_term": "test",
-		"page":        float64(1),
-		"page_size":   float64(10),
+		"search_term":   "test",
+		"updated_after": "2025-01-01T00:00:00Z",
+		"page":          float64(1),
+		"page_size":     float64(10),
 	})
 }
 
@@ -57,6 +58,7 @@ func TestCommentListByFileVersion(t *testing.T) {
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByFileVersion.String(), map[string]any{
 		"search_term":     "test",
 		"file_version_id": float64(123),
+		"updated_after":   "2025-01-01T00:00:00Z",
 		"page":            float64(1),
 		"page_size":       float64(10),
 	})
@@ -65,29 +67,32 @@ func TestCommentListByFileVersion(t *testing.T) {
 func TestCommentListByMilestone(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByMilestone.String(), map[string]any{
-		"search_term":  "test",
-		"milestone_id": float64(123),
-		"page":         float64(1),
-		"page_size":    float64(10),
+		"search_term":   "test",
+		"milestone_id":  float64(123),
+		"updated_after": "2025-01-01T00:00:00Z",
+		"page":          float64(1),
+		"page_size":     float64(10),
 	})
 }
 
 func TestCommentListByNotebook(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByNotebook.String(), map[string]any{
-		"search_term": "test",
-		"notebook_id": float64(123),
-		"page":        float64(1),
-		"page_size":   float64(10),
+		"search_term":   "test",
+		"notebook_id":   float64(123),
+		"updated_after": "2025-01-01T00:00:00Z",
+		"page":          float64(1),
+		"page_size":     float64(10),
 	})
 }
 
 func TestCommentListByTask(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByTask.String(), map[string]any{
-		"search_term": "test",
-		"task_id":     float64(123),
-		"page":        float64(1),
-		"page_size":   float64(10),
+		"search_term":   "test",
+		"task_id":       float64(123),
+		"updated_after": "2025-01-01T00:00:00Z",
+		"page":          float64(1),
+		"page_size":     float64(10),
 	})
 }


### PR DESCRIPTION
## Description

Loading all comments from a heavy installation can be slow due to the number of records. By default, the MCP server will now load only comments modified in the last 3 months.

Resolves #81

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors