### PR TITLE
Fix: Return correct schema type for slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,17 @@ require (
 	github.com/DataDog/dd-trace-go/v2 v2.4.0
 	github.com/getsentry/sentry-go v0.40.0
 	github.com/getsentry/sentry-go/slog v0.39.0
-	// using a specific commit until a new version is released with the null types
-	// fix.
+	// using a specific commit until a new version is released with null types
+	// fixes.
 	//
+	// Issues:
 	// https://github.com/google/jsonschema-go/issues/41
+	// https://github.com/google/jsonschema-go/issues/48
+	//
+	// Patches:
 	// https://github.com/google/jsonschema-go/pull/42
-	github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d
+	// https://github.com/google/jsonschema-go/pull/49
+	github.com/google/jsonschema-go v0.3.1-0.20251202234540-11a93dca6d93
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/teamwork/desksdkgo v0.0.0-20251003022928-49eb7d63fe81
 	github.com/teamwork/twapi-go-sdk v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d h1:Gm0k2SMaMbybQdEeFYZqk1nmIXdxyfAGmC9BlbwkyBE=
-github.com/google/jsonschema-go v0.3.1-0.20251107220952-2196fedd778d/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.3.1-0.20251202234540-11a93dca6d93 h1:MTdyb4Qr/mVNzSuvJ5gHzHbb5rNZ+rflf+AQ4yc1WD8=
+github.com/google/jsonschema-go v0.3.1-0.20251202234540-11a93dca6d93/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Description

The MCP server was returning the wrong JSON schema for slices, since they can all be nullable.

| Before | After |
| ------- | ----- |
| <img width="316" height="241" alt="image" src="https://github.com/user-attachments/assets/4fc0964e-0cfb-48fb-b459-691b45b61a76" /> | <img width="341" height="322" alt="image" src="https://github.com/user-attachments/assets/8f9b6150-43ec-4645-b78d-ea6787042ee3" /> |

https://github.com/google/jsonschema-go/issues/48

Resolves #80

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors