### PR TITLE
Fix: MCP HTTP client - Use the correct transport

### DIFF
--- a/cmd/mcp-http-cli/main.go
+++ b/cmd/mcp-http-cli/main.go
@@ -42,7 +42,7 @@ func main() {
 		httpClient.Transport = newAuthRoundTripper(*mcpToken, httpClient.Transport)
 	}
 
-	mcpTransport := &mcp.SSEClientTransport{
+	mcpTransport := &mcp.StreamableClientTransport{
 		Endpoint:   *mcpURL,
 		HTTPClient: httpClient,
 	}


### PR DESCRIPTION
## Description

Fix transport issue when using the client against the MCP server:
```
$ TW_MCP_BEARER_TOKEN=dev go run main.go -mcp-url="https://mcp.rafael.dev.stg.teamworkops.com/" list-tools
time=2026-01-07T09:08:36.616-03:00 level=INFO msg="HTTP request" url=https://mcp.rafael.dev.stg.teamworkops.com/ method=GET headers="map[Accept:[text/event-stream] Authorization:[REDACTED]]" body=""
time=2026-01-07T09:08:39.209-03:00 level=INFO msg="HTTP response" url=https://mcp.rafael.dev.stg.teamworkops.com/ method=GET status="405 Method Not Allowed" headers="map[Content-Length:[31] Content-Type:[text/plain; charset=utf-8] Date:[Wed, 07 Jan 2026 12:08:39 GMT] Strict-Transport-Security:[max-age=31536000; includeSubDomains] X-Content-Type-Options:[nosniff]]" body="GET requires an active session\n" duration=2.593131666s
time=2026-01-07T09:08:39.210-03:00 level=ERROR msg="failed to create MCP client" error="failed to initialize MCP client: missing endpoint: malformed line in SSE stream: \"GET requires an active session\""
exit status 1
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors