### PR TITLE
Chore: Add hint for VSCode setup

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -106,6 +106,14 @@ Alternatively, you can use a Docker image:
 
 Use either `command` (STDIO) or `httpUrl` (hosted) style.
 
+> [!TIP]
+>
+> When using HTTP, in case you get a "Teamwork account not found" error during
+> the OAuth2 authentication process, ensure VSCode didn't cache old credentials.
+> You can clear cached credentials by going to Cmd+Shift+P (or Ctrl+Shift+P on
+> Windows/Linux) and selecting "Authentication: Remove Dynamic Authentication
+> Providers".
+
 ### 🌐 Gemini CLI (HTTP)
 
 <img width="732" height="558" alt="image" src="https://github.com/user-attachments/assets/b26d2fe0-2d88-4bcc-beb5-3dab5cb575b0" />


### PR DESCRIPTION
## Description

VSCode may cache old credentials, causing issues for the OAuth 2.0 DCR login flow. This usually results in a "Teamwork account not found" message because the client ID doesn't match any existing accounts.

This improvement adds a hint to clear authentication providers, ensuring old cached credentials are removed.

Resolves #122

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors