### PR TITLE
Fix: Set supported scopes in MCP metadata

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -132,11 +132,13 @@ func newRouter(resources config.Resources) *http.ServeMux {
 			return
 		}
 
+		// https://datatracker.ietf.org/doc/html/rfc9728/#section-2
 		_, _ = w.Write([]byte(`{
   "resource": "` + resources.Info.MCPURL + `",
   "authorization_servers": ["` + resources.Info.APIURL + `"],
   "bearer_methods_supported": ["header"],
-  "resource_documentation": "https://apidocs.teamwork.com/guides/teamwork/app-login-flow"
+  "resource_documentation": "https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
+  "scopes_supported": [ "projects", "desk" ]
 }`))
 	})
 	return mux


### PR DESCRIPTION
## Description

AWS Quick Suite is failing to connect to the Teamwork.com MCP server due to wrong scopes.

The AWS endpoint [1] returns something like:
```json
{
    "ApiSpecificationMetadata": {
        "actionConnectorDescription": null,
        "actionConnectorName": null,
        "actions": [],
        "supportedAuthSchemes": [
            {
                "AuthSchema": {
                    "AuthorizationCodeGrantSchema": {
                        "AuthURL": "https://www.teamwork.com/launchpad/login",
                        "RegistrationURL": "https://www.teamwork.com/developer/api/v1/apps/register.json",
                        "Scopes": [],
                        "TokenURL": "https://www.teamwork.com/launchpad/v1/token.json"
                    }
                },
                "AuthType": "OAUTH2_AUTHORIZATION_CODE"
            }
        ]
    },
    "RequestId": "...",
    "Status": 200
}
```

The empty `Scopes` array is causing issues, since AWS will default to sending the scopes:

* `mcp:stream`
* `openid`

Teamwork.com's authorisation server will then deny the authentication due to invalid scopes.

To fix this, we will set the `scopes_supported` in the MCP metadata endpoint (`/.well-known/oauth-protected-resource`), following RFC 9728 (section 2) [2].

> scopes_supported
>
> RECOMMENDED. JSON array containing a list of scope values, as defined in
> OAuth 2.0 [RFC6749], that are used in authorisation requests to request
> access to this protected resource. Protected resources MAY choose not to
> advertise some scope values supported even when this parameter is used.

See https://github.com/Teamwork/mcp/issues/135

[1] `/sn/qbsproxy/quicksight/actions/internal/<id>/action-connectors/specification-metadata`
[2] https://datatracker.ietf.org/doc/html/rfc9728/#section-2

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors