### PR TITLE
Fix: Use the correct logger in the HTTP middleware

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -152,7 +152,7 @@ func addRouterMiddlewares(resources config.Resources, mux *http.ServeMux) http.H
 				resources,
 				authMiddleware(
 					resources,
-					logMiddleware(mux),
+					logMiddleware(mux, resources.Logger()),
 				),
 			),
 		),
@@ -213,7 +213,7 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return rw.ResponseWriter.Write(b)
 }
 
-func logMiddleware(next http.Handler) http.Handler {
+func logMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
@@ -225,7 +225,7 @@ func logMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(rw, r)
 		duration := time.Since(start)
 
-		slog.Info("request completed",
+		logger.Info("request completed",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.String("query", r.URL.RawQuery),


### PR DESCRIPTION
## Description

The default slog logger may be using a different format from others, causing inconsistency.

For example, we would expect the below to folow the JSON format:
```
2026/01/30 15:05:33 INFO request completed method=GET path=/api/health query="" status=200 response_body=OK duration=5.54µs
2026/01/30 15:05:35 INFO request completed method=GET path=/api/health query="" status=200 response_body=OK duration=5.64µs
2026/01/30 15:05:36 INFO request completed method=GET path=/api/health query="" status=200 response_body=OK duration=5.83µs
2026/01/30 15:05:36 INFO request completed method=GET path=/api/health query="" status=200 response_body=OK duration=5.41µs
2026/01/30 15:05:36 INFO request completed method=GET path=/api/health query="" status=200 response_body=OK duration=5.63µs
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors