### PR TITLE
add support for cc and bcc as string slices

### DIFF
--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -713,6 +713,20 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "The body of the ticket.",
 					},
+					"bcc": {
+						Type:        "array",
+						Description: "An array of email addresses to BCC on ticket update.",
+						Items: &jsonschema.Schema{
+							Type: "string",
+						},
+					},
+					"cc": {
+						Type:        "array",
+						Description: "An array of email addresses to CC on ticket update.",
+						Items: &jsonschema.Schema{
+							Type: "string",
+						},
+					},
 					"priorityId": {
 						Type: "integer",
 						Description: `
@@ -760,6 +774,14 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 
 			if body := arguments.GetString("body", ""); body != "" {
 				data.Body = body
+			}
+
+			if len(arguments.GetStringSlice("bcc", []string{})) > 0 {
+				data.BCC = arguments.GetStringSlice("bcc", []string{})
+			}
+
+			if len(arguments.GetStringSlice("cc", []string{})) > 0 {
+				data.CC = arguments.GetStringSlice("cc", []string{})
 			}
 
 			if statusId := arguments.GetInt("statusId", 0); statusId > 0 {

--- a/internal/twdesk/tickets_test.go
+++ b/internal/twdesk/tickets_test.go
@@ -16,6 +16,8 @@ func TestTicketCreate(t *testing.T) {
 	testutil.ExecuteToolRequest(t, mcpServer, twdesk.MethodTicketCreate.String(), map[string]any{
 		"subject":    "Test Ticket",
 		"body":       "This is a test ticket",
+		"cc":         []string{"cc@example.com"},
+		"bcc":        []string{"bcc@example.com"},
 		"priorityId": "1",
 		"statusId":   "1",
 		"typeId":     "1",
@@ -32,6 +34,8 @@ func TestTicketUpdate(t *testing.T) {
 	testutil.ExecuteToolRequest(t, mcpServer, twdesk.MethodTicketUpdate.String(), map[string]any{
 		"id":         "123",
 		"subject":    "Updated Ticket",
+		"cc":         []string{"cc-update@example.com"},
+		"bcc":        []string{"bcc-update@example.com"},
 		"priorityId": "2",
 		"statusId":   "2",
 		"typeId":     "2",


### PR DESCRIPTION
Implements CC and BCC from https://github.com/Teamwork/mcp/issues/163

I will implement the ability to reply to messages in a separate PR as that is currently not implemented at all