### PR TITLE
Fix: populate webLinker in meta section

### DIFF
--- a/internal/helpers/schema_meta.go
+++ b/internal/helpers/schema_meta.go
@@ -1,0 +1,102 @@
+package helpers
+
+import (
+	"slices"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// metaWebLinkSchema returns the schema definition for a meta object containing
+// a webLink field. This schema describes the meta section injected by
+// WebLinker at runtime into API responses.
+func metaWebLinkSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"webLink": {
+				Type:        "string",
+				Description: "A direct URL to this resource in the Teamwork.com web application.",
+			},
+		},
+	}
+}
+
+// WithMetaWebLinkSchema patches a JSON schema generated from an API response
+// type to include a meta.webLink property on entity objects. This aligns the
+// output schema with the runtime behavior of WebLinker, which injects web links
+// into serialized responses.
+//
+// If the top-level schema is itself an array of objects, the "meta" property
+// with a "webLink" field is added to each item schema.
+//
+// Otherwise, the function walks the top-level properties of the schema and, for
+// each property that is not a known root field (like "meta" or "included"):
+//   - If the property is an object, it adds a "meta" property with a "webLink"
+//     field to that object's schema.
+//   - If the property is an array of objects, it adds the "meta" property to
+//     the array item schema.
+//
+// If the entity object already has a "meta" property in its schema, the
+// "webLink" field is merged into the existing meta schema without overwriting
+// any existing "webLink" definition.
+//
+// The schema is modified in place and also returned for convenient chaining:
+//
+//	schema, err = jsonschema.For[Response](opts)
+//	schema = helpers.WithMetaWebLinkSchema(schema)
+func WithMetaWebLinkSchema(schema *jsonschema.Schema) *jsonschema.Schema {
+	if schema == nil {
+		return schema
+	}
+
+	for key, prop := range schema.Properties {
+		if slices.Contains(knownRootFields, key) || prop == nil {
+			continue
+		}
+
+		switch {
+		case prop.Type == "object" && prop.Properties != nil:
+			// Single entity: {"task": {"id": 123, ...}}
+			addMetaWebLinkToSchema(prop)
+
+		case isSchemaArray(prop) && prop.Items != nil && prop.Items.Properties != nil:
+			// Array of entities: {"tasks": [{"id": 123, ...}, ...]}
+			addMetaWebLinkToSchema(prop.Items)
+		}
+	}
+
+	return schema
+}
+
+// isSchemaArray reports whether a schema represents an array type, handling
+// both single type ("array") and union types (["null", "array"]).
+func isSchemaArray(s *jsonschema.Schema) bool {
+	return s.Type == "array" || slices.Contains(s.Types, "array")
+}
+
+// addMetaWebLinkToSchema adds or merges a meta.webLink property into an object
+// schema. If the schema already has a "meta" property, the "webLink" field is
+// added to the existing meta properties (unless it already exists). Otherwise,
+// a new "meta" property is created with the webLink definition.
+func addMetaWebLinkToSchema(objectSchema *jsonschema.Schema) {
+	if objectSchema.Properties == nil {
+		objectSchema.Properties = make(map[string]*jsonschema.Schema)
+	}
+
+	webLinkSchema := &jsonschema.Schema{
+		Type:        "string",
+		Description: "A direct URL to this resource in the Teamwork.com web application.",
+	}
+
+	if existing, ok := objectSchema.Properties["meta"]; ok && existing != nil {
+		// Meta property already exists; merge webLink into it.
+		if existing.Properties == nil {
+			existing.Properties = make(map[string]*jsonschema.Schema)
+		}
+		if _, hasWebLink := existing.Properties["webLink"]; !hasWebLink {
+			existing.Properties["webLink"] = webLinkSchema
+		}
+	} else {
+		objectSchema.Properties["meta"] = metaWebLinkSchema()
+	}
+}

--- a/internal/helpers/schema_meta_test.go
+++ b/internal/helpers/schema_meta_test.go
@@ -1,0 +1,358 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/teamwork/mcp/internal/helpers"
+)
+
+func TestWithMetaWebLinkSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *jsonschema.Schema
+		check  func(t *testing.T, schema *jsonschema.Schema)
+	}{
+		{
+			name:   "nil schema returns nil",
+			schema: nil,
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema != nil {
+					t.Error("expected nil schema")
+				}
+			},
+		},
+		{
+			name:   "schema without properties returns unchanged",
+			schema: &jsonschema.Schema{Type: "object"},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties != nil {
+					t.Error("expected nil properties")
+				}
+			},
+		},
+		{
+			name: "top-level array without items is left unchanged",
+			schema: &jsonschema.Schema{
+				Type: "array",
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Items != nil {
+					t.Error("items schema should remain nil")
+				}
+			},
+		},
+		{
+			name: "top-level array with items without properties is left unchanged",
+			schema: &jsonschema.Schema{
+				Type:  "array",
+				Items: &jsonschema.Schema{Type: "string"},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Items.Properties != nil {
+					t.Error("items properties should remain nil")
+				}
+			},
+		},
+		{
+			name: "single entity object gets meta.webLink",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"task": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id":   {Type: "integer"},
+							"name": {Type: "string"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				task := schema.Properties["task"]
+				if task == nil {
+					t.Fatal("expected task property")
+				}
+				meta := task.Properties["meta"]
+				if meta == nil {
+					t.Fatal("expected meta property on task")
+				}
+				if meta.Type != "object" {
+					t.Errorf("expected meta type 'object', got %q", meta.Type)
+				}
+				webLink := meta.Properties["webLink"]
+				if webLink == nil {
+					t.Fatal("expected webLink property in meta")
+				}
+				if webLink.Type != "string" {
+					t.Errorf("expected webLink type 'string', got %q", webLink.Type)
+				}
+				if webLink.Description == "" {
+					t.Error("expected webLink to have a description")
+				}
+			},
+		},
+		{
+			name: "array of entities gets meta.webLink on items",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"tasks": {
+						Type: "array",
+						Items: &jsonschema.Schema{
+							Type: "object",
+							Properties: map[string]*jsonschema.Schema{
+								"id":   {Type: "integer"},
+								"name": {Type: "string"},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				items := schema.Properties["tasks"].Items
+				if items == nil {
+					t.Fatal("expected tasks items")
+				}
+				meta := items.Properties["meta"]
+				if meta == nil {
+					t.Fatal("expected meta property on task items")
+				}
+				webLink := meta.Properties["webLink"]
+				if webLink == nil {
+					t.Fatal("expected webLink property in meta")
+				}
+			},
+		},
+		{
+			name: "nullable array gets meta.webLink on items",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"tasks": {
+						Types: []string{"null", "array"},
+						Items: &jsonschema.Schema{
+							Type: "object",
+							Properties: map[string]*jsonschema.Schema{
+								"id": {Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				items := schema.Properties["tasks"].Items
+				meta := items.Properties["meta"]
+				if meta == nil {
+					t.Fatal("expected meta property on nullable array items")
+				}
+				if meta.Properties["webLink"] == nil {
+					t.Fatal("expected webLink in meta")
+				}
+			},
+		},
+		{
+			name: "known root fields are skipped",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"meta": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"page": {Type: "object"},
+						},
+					},
+					"included": {
+						Type: "array",
+						Items: &jsonschema.Schema{
+							Type: "object",
+							Properties: map[string]*jsonschema.Schema{
+								"id": {Type: "integer"},
+							},
+						},
+					},
+					"task": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				// "meta" root field should not be modified
+				rootMeta := schema.Properties["meta"]
+				if _, hasWebLink := rootMeta.Properties["webLink"]; hasWebLink {
+					t.Error("root meta should not get webLink")
+				}
+				// "included" should not be modified
+				includedItems := schema.Properties["included"].Items
+				if _, hasMeta := includedItems.Properties["meta"]; hasMeta {
+					t.Error("included items should not get meta")
+				}
+				// "task" should get meta
+				task := schema.Properties["task"]
+				if task.Properties["meta"] == nil {
+					t.Error("task should get meta")
+				}
+			},
+		},
+		{
+			name: "existing meta with webLink is not overwritten",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"task": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+							"meta": {
+								Type: "object",
+								Properties: map[string]*jsonschema.Schema{
+									"webLink": {
+										Type:        "string",
+										Description: "custom link",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				meta := schema.Properties["task"].Properties["meta"]
+				webLink := meta.Properties["webLink"]
+				if webLink.Description != "custom link" {
+					t.Errorf("expected existing webLink to be preserved, got %q", webLink.Description)
+				}
+			},
+		},
+		{
+			name: "existing meta without webLink gets webLink merged",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"task": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+							"meta": {
+								Type: "object",
+								Properties: map[string]*jsonschema.Schema{
+									"customField": {Type: "string"},
+								},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				meta := schema.Properties["task"].Properties["meta"]
+				if meta.Properties["customField"] == nil {
+					t.Error("expected existing customField to be preserved")
+				}
+				if meta.Properties["webLink"] == nil {
+					t.Error("expected webLink to be merged into existing meta")
+				}
+			},
+		},
+		{
+			name: "multiple entity properties each get meta",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"project": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+						},
+					},
+					"tasks": {
+						Type: "array",
+						Items: &jsonschema.Schema{
+							Type: "object",
+							Properties: map[string]*jsonschema.Schema{
+								"id": {Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["project"].Properties["meta"] == nil {
+					t.Error("expected project to get meta")
+				}
+				if schema.Properties["tasks"].Items.Properties["meta"] == nil {
+					t.Error("expected task items to get meta")
+				}
+			},
+		},
+		{
+			name: "non-object non-array properties are left unchanged",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"count": {Type: "integer"},
+					"name":  {Type: "string"},
+					"task": {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["count"].Type != "integer" {
+					t.Error("count should remain integer")
+				}
+				if schema.Properties["name"].Type != "string" {
+					t.Error("name should remain string")
+				}
+				if schema.Properties["task"].Properties["meta"] == nil {
+					t.Error("task should get meta")
+				}
+			},
+		},
+		{
+			name: "array without items is left unchanged",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"items": {
+						Type: "array",
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["items"].Items != nil {
+					t.Error("items schema should remain nil")
+				}
+			},
+		},
+		{
+			name: "array with items that have no properties is left unchanged",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"items": {
+						Type:  "array",
+						Items: &jsonschema.Schema{Type: "string"},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["items"].Items.Properties != nil {
+					t.Error("items properties should remain nil")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := helpers.WithMetaWebLinkSchema(tt.schema)
+			tt.check(t, result)
+		})
+	}
+}

--- a/internal/helpers/web_linker.go
+++ b/internal/helpers/web_linker.go
@@ -135,6 +135,39 @@ func WebLinker(
 	return encoded
 }
 
+// StructuredWebLinker is a variant of WebLinker that operates on structured
+// types. It marshals the data to JSON, applies WebLinker to inject web links,
+// and unmarshals back to a generic representation. Because Go structs have
+// fixed fields and cannot receive dynamically injected keys (like
+// "meta.webLink"), the returned value is a map[string]any rather than the
+// original typed struct.
+//
+// Returns the original data unchanged if JSON marshaling fails, the customer
+// URL is missing, or buildPath is nil.
+func StructuredWebLinker(
+	ctx context.Context,
+	data any,
+	buildPath func(map[string]any) string,
+	opts ...WebLinkerOption,
+) any {
+	if data == nil || buildPath == nil {
+		return data
+	}
+
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return data
+	}
+
+	modified := WebLinker(ctx, encoded, buildPath, opts...)
+
+	var result any
+	if err := json.Unmarshal(modified, &result); err != nil {
+		return data
+	}
+	return result
+}
+
 // WebLinkerWithIDPathBuilder creates a path builder function for entities with
 // an "id" field. It returns a function that builds a path in the format
 // "prefix/id" for objects containing a non-zero "id" field. Returns an empty

--- a/internal/helpers/web_linker_test.go
+++ b/internal/helpers/web_linker_test.go
@@ -205,3 +205,201 @@ func TestWebLinkerWithIDPathBuilder(t *testing.T) {
 		})
 	}
 }
+
+func TestStructuredWebLinker(t *testing.T) {
+	type Entity struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+	type EntityWithMeta struct {
+		ID   int64          `json:"id"`
+		Name string         `json:"name"`
+		Meta map[string]any `json:"meta,omitempty"`
+	}
+	type SingleResponse struct {
+		Entity Entity `json:"entity"`
+	}
+	type ListResponse struct {
+		Meta struct {
+			Page struct {
+				HasMore bool `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+		Entities []Entity `json:"entities"`
+	}
+	type WithExistingMeta struct {
+		Entity EntityWithMeta `json:"entity"`
+	}
+
+	tests := []struct {
+		name    string
+		data    any
+		url     string
+		want    map[string]any
+		builder func(map[string]any) string
+		options []helpers.WebLinkerOption
+	}{{
+		name: "single entity struct",
+		data: SingleResponse{
+			Entity: Entity{ID: 123, Name: "Test"},
+		},
+		url:     "https://example.com/",
+		builder: helpers.WebLinkerWithIDPathBuilder("entities"),
+		want: map[string]any{
+			"entity": map[string]any{
+				"id":   float64(123),
+				"name": "Test",
+				"meta": map[string]any{
+					"webLink": "https://example.com/entities/123",
+				},
+			},
+		},
+	}, {
+		name: "list response struct",
+		data: ListResponse{
+			Entities: []Entity{
+				{ID: 1, Name: "One"},
+				{ID: 2, Name: "Two"},
+			},
+		},
+		url:     "https://example.com/",
+		builder: helpers.WebLinkerWithIDPathBuilder("entities"),
+		want: map[string]any{
+			"meta": map[string]any{
+				"page": map[string]any{
+					"hasMore": false,
+				},
+			},
+			"entities": []any{
+				map[string]any{
+					"id":   float64(1),
+					"name": "One",
+					"meta": map[string]any{
+						"webLink": "https://example.com/entities/1",
+					},
+				},
+				map[string]any{
+					"id":   float64(2),
+					"name": "Two",
+					"meta": map[string]any{
+						"webLink": "https://example.com/entities/2",
+					},
+				},
+			},
+		},
+	}, {
+		name: "nil data returns nil",
+		data: nil,
+		url:  "https://example.com/",
+		want: nil,
+	}, {
+		name: "nil builder returns original",
+		data: SingleResponse{
+			Entity: Entity{ID: 1, Name: "One"},
+		},
+		url:     "https://example.com/",
+		builder: nil,
+		want: map[string]any{
+			"entity": map[string]any{
+				"id":   float64(1),
+				"name": "One",
+			},
+		},
+	}, {
+		name: "missing customer URL returns original",
+		data: SingleResponse{
+			Entity: Entity{ID: 1, Name: "One"},
+		},
+		url:     "",
+		builder: helpers.WebLinkerWithIDPathBuilder("entities"),
+		want: map[string]any{
+			"entity": map[string]any{
+				"id":   float64(1),
+				"name": "One",
+			},
+		},
+	}, {
+		name: "entity with existing meta and webLink preserved",
+		data: WithExistingMeta{
+			Entity: EntityWithMeta{
+				ID:   123,
+				Name: "Test",
+				Meta: map[string]any{"webLink": "https://other.com/custom/123", "note": "keep"},
+			},
+		},
+		url:     "https://example.com/",
+		builder: helpers.WebLinkerWithIDPathBuilder("entities"),
+		want: map[string]any{
+			"entity": map[string]any{
+				"id":   float64(123),
+				"name": "Test",
+				"meta": map[string]any{
+					"webLink": "https://other.com/custom/123",
+					"note":    "keep",
+				},
+			},
+		},
+	}, {
+		name: "additional ignore field via options",
+		data: struct {
+			SkipMe Entity   `json:"skipMe"`
+			Items  []Entity `json:"items"`
+		}{
+			SkipMe: Entity{ID: 9, Name: "Ignored"},
+			Items:  []Entity{{ID: 1, Name: "One"}},
+		},
+		url:     "https://example.com/",
+		builder: helpers.WebLinkerWithIDPathBuilder("entities"),
+		options: []helpers.WebLinkerOption{helpers.WebLinkerWithIgnoreFields("skipMe")},
+		want: map[string]any{
+			"skipMe": map[string]any{
+				"id":   float64(9),
+				"name": "Ignored",
+			},
+			"items": []any{
+				map[string]any{
+					"id":   float64(1),
+					"name": "One",
+					"meta": map[string]any{
+						"webLink": "https://example.com/entities/1",
+					},
+				},
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.url != "" {
+				ctx = config.WithCustomerURL(ctx, tt.url)
+			}
+			got := helpers.StructuredWebLinker(ctx, tt.data, tt.builder, tt.options...)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			// Marshal both to JSON for comparison to handle type differences
+			gotJSON, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("failed to marshal got: %v", err)
+			}
+			wantJSON, err := json.Marshal(tt.want)
+			if err != nil {
+				t.Fatalf("failed to marshal want: %v", err)
+			}
+			var gotMap, wantMap map[string]any
+			if err := json.Unmarshal(gotJSON, &gotMap); err != nil {
+				t.Fatalf("failed to unmarshal got: %v", err)
+			}
+			if err := json.Unmarshal(wantJSON, &wantMap); err != nil {
+				t.Fatalf("failed to unmarshal want: %v", err)
+			}
+			if !reflect.DeepEqual(gotMap, wantMap) {
+				t.Errorf("unexpected result:\n  got:  %s\n  want: %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -83,7 +83,9 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: ticket,
+				StructuredContent: helpers.StructuredWebLinker(ctx, ticket,
+					helpers.WebLinkerWithIDPathBuilder("/desk/tickets"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -45,6 +45,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for ActivityListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(activityListOutputSchema)
 }
 
 // ActivityList lists activities in Teamwork.com.

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -64,10 +64,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CommentGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(commentGetOutputSchema)
 	commentListOutputSchema, err = jsonschema.For[projects.CommentListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CommentListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(commentListOutputSchema)
 }
 
 // CommentCreate creates a comment in Teamwork.com.
@@ -327,7 +329,7 @@ func CommentGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: comment,
+				StructuredContent: helpers.StructuredWebLinker(ctx, comment, commentPathBuilder),
 			}, nil
 		},
 	}
@@ -406,7 +408,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: commentList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
 			}, nil
 		},
 	}
@@ -492,7 +494,7 @@ func CommentListByFileVersion(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: commentList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
 			}, nil
 		},
 	}
@@ -577,7 +579,7 @@ func CommentListByMilestone(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: commentList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
 			}, nil
 		},
 	}
@@ -662,7 +664,7 @@ func CommentListByNotebook(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: commentList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
 			}, nil
 		},
 	}
@@ -747,7 +749,7 @@ func CommentListByTask(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
 					},
 				},
-				StructuredContent: commentList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
 			}, nil
 		},
 	}

--- a/internal/twprojects/companies.go
+++ b/internal/twprojects/companies.go
@@ -53,10 +53,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CompanyGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(companyGetOutputSchema)
 	companyListOutputSchema, err = jsonschema.For[projects.CompanyListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CompanyListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(companyListOutputSchema)
 }
 
 // CompanyCreate creates a company in Teamwork.com.
@@ -412,7 +414,9 @@ func CompanyGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: company,
+				StructuredContent: helpers.StructuredWebLinker(ctx, company,
+					helpers.WebLinkerWithIDPathBuilder("/app/clients"),
+				),
 			}, nil
 		},
 	}
@@ -496,7 +500,9 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: companyList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, companyList,
+					helpers.WebLinkerWithIDPathBuilder("/app/clients"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/industries.go
+++ b/internal/twprojects/industries.go
@@ -42,6 +42,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for IndustryListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(industryListOutputSchema)
 }
 
 // IndustryList lists projects in Teamwork.com.

--- a/internal/twprojects/jobroles.go
+++ b/internal/twprojects/jobroles.go
@@ -51,10 +51,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for JobRoleGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(jobRoleGetOutputSchema)
 	jobRoleListOutputSchema, err = jsonschema.For[projects.JobRoleListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for JobRoleListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(jobRoleListOutputSchema)
 }
 
 // JobRoleCreate creates a job role in Teamwork.com.

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -54,10 +54,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for MilestoneGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(milestoneGetOutputSchema)
 	milestoneListOutputSchema, err = jsonschema.For[projects.MilestoneListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for MilestoneListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(milestoneListOutputSchema)
 }
 
 // MilestoneCreate creates a milestone in Teamwork.com.
@@ -420,7 +422,9 @@ func MilestoneGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: milestone,
+				StructuredContent: helpers.StructuredWebLinker(ctx, milestone,
+					helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
+				),
 			}, nil
 		},
 	}
@@ -506,7 +510,9 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: milestoneList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, milestoneList,
+					helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
+				),
 			}, nil
 		},
 	}
@@ -598,7 +604,9 @@ func MilestoneListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: milestoneList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, milestoneList,
+					helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/notebooks.go
+++ b/internal/twprojects/notebooks.go
@@ -52,10 +52,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for NotebookGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(notebookGetOutputSchema)
 	notebookListOutputSchema, err = jsonschema.For[projects.NotebookListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for NotebookListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(notebookListOutputSchema)
 }
 
 // NotebookCreate creates a notebook in Teamwork.com.
@@ -308,7 +310,9 @@ func NotebookGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: notebook,
+				StructuredContent: helpers.StructuredWebLinker(ctx, notebook,
+					helpers.WebLinkerWithIDPathBuilder("/app/notebooks"),
+				),
 			}, nil
 		},
 	}
@@ -408,7 +412,9 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: notebookList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, notebookList,
+					helpers.WebLinkerWithIDPathBuilder("/app/notebooks"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/project_categories.go
+++ b/internal/twprojects/project_categories.go
@@ -52,10 +52,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for ProjectCategoryGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(projectCategoryGetOutputSchema)
 	projectCategoryListOutputSchema, err = jsonschema.For[projects.ProjectCategoryListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for ProjectCategoryListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(projectCategoryListOutputSchema)
 }
 
 // ProjectCategoryCreate creates a project category in Teamwork.com.
@@ -263,7 +265,7 @@ func ProjectCategoryGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, projectCategoryPathBuilder)),
 					},
 				},
-				StructuredContent: projectCategory,
+				StructuredContent: helpers.StructuredWebLinker(ctx, projectCategory, projectCategoryPathBuilder),
 			}, nil
 		},
 	}
@@ -329,7 +331,7 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 						Text: string(helpers.WebLinker(ctx, encoded, projectCategoryPathBuilder)),
 					},
 				},
-				StructuredContent: projectCategoryList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, projectCategoryList, projectCategoryPathBuilder),
 			}, nil
 		},
 	}

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -53,10 +53,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for ProjectGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(projectGetOutputSchema)
 	projectListOutputSchema, err = jsonschema.For[projects.ProjectListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for ProjectListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(projectListOutputSchema)
 }
 
 // ProjectCreate creates a project in Teamwork.com.
@@ -322,7 +324,9 @@ func ProjectGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: project,
+				StructuredContent: helpers.StructuredWebLinker(ctx, project,
+					helpers.WebLinkerWithIDPathBuilder("/app/projects"),
+				),
 			}, nil
 		},
 	}
@@ -412,7 +416,9 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: projectList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, projectList,
+					helpers.WebLinkerWithIDPathBuilder("/app/projects"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/skills.go
+++ b/internal/twprojects/skills.go
@@ -52,10 +52,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for SkillGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(skillGetOutputSchema)
 	skillListOutputSchema, err = jsonschema.For[projects.SkillListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for SkillListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(skillListOutputSchema)
 }
 
 // SkillCreate creates a skill in Teamwork.com.

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -51,10 +51,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TagGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(tagGetOutputSchema)
 	tagListOutputSchema, err = jsonschema.For[projects.TagListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TagListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(tagListOutputSchema)
 }
 
 // TagCreate creates a tag in Teamwork.com.

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -54,10 +54,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TasklistGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(tasklistGetOutputSchema)
 	tasklistListOutputSchema, err = jsonschema.For[projects.TasklistListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TasklistListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(tasklistListOutputSchema)
 }
 
 // TasklistCreate creates a tasklist in Teamwork.com.
@@ -272,7 +274,9 @@ func TasklistGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: tasklist,
+				StructuredContent: helpers.StructuredWebLinker(ctx, tasklist,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
+				),
 			}, nil
 		},
 	}
@@ -340,7 +344,9 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: tasklistList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, tasklistList,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
+				),
 			}, nil
 		},
 	}
@@ -414,7 +420,9 @@ func TasklistListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: tasklistList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, tasklistList,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -56,10 +56,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(taskGetOutputSchema)
 	taskListOutputSchema, err = jsonschema.For[projects.TaskListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(taskListOutputSchema)
 }
 
 // TaskCreate creates a task in Teamwork.com.
@@ -557,7 +559,9 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: task,
+				StructuredContent: helpers.StructuredWebLinker(ctx, task,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
+				),
 			}, nil
 		},
 	}
@@ -643,7 +647,9 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: taskList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
+				),
 			}, nil
 		},
 	}
@@ -735,7 +741,9 @@ func TaskListByTasklist(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: taskList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
+				),
 			}, nil
 		},
 	}
@@ -827,7 +835,9 @@ func TaskListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: taskList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
+					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -55,10 +55,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TeamGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(teamGetOutputSchema)
 	teamListOutputSchema, err = jsonschema.For[projects.TeamListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TeamListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(teamListOutputSchema)
 }
 
 // TeamCreate creates a team in Teamwork.com.
@@ -315,7 +317,9 @@ func TeamGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: team,
+				StructuredContent: helpers.StructuredWebLinker(ctx, team,
+					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
+				),
 			}, nil
 		},
 	}
@@ -388,7 +392,9 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: teamList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
+					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
+				),
 			}, nil
 		},
 	}
@@ -462,7 +468,9 @@ func TeamListByCompany(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: teamList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
+					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
+				),
 			}, nil
 		},
 	}
@@ -536,7 +544,9 @@ func TeamListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: teamList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
+					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -56,10 +56,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TimelogGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(timelogGetOutputSchema)
 	timelogListOutputSchema, err = jsonschema.For[projects.TimelogListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TimelogListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(timelogListOutputSchema)
 }
 
 // TimelogCreate creates a timelog in Teamwork.com.

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -58,10 +58,12 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TimerGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(timerGetOutputSchema)
 	timerListOutputSchema, err = jsonschema.For[projects.TimerListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TimerListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(timerListOutputSchema)
 }
 
 // TimerCreate creates a timer in Teamwork.com.
@@ -430,7 +432,9 @@ func TimerGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: timer,
+				StructuredContent: helpers.StructuredWebLinker(ctx, timer,
+					helpers.WebLinkerWithIDPathBuilder("/app/timers"),
+				),
 			}, nil
 		},
 	}
@@ -517,7 +521,9 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: timerList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, timerList,
+					helpers.WebLinkerWithIDPathBuilder("/app/timers"),
+				),
 			}, nil
 		},
 	}

--- a/internal/twprojects/users.go
+++ b/internal/twprojects/users.go
@@ -57,14 +57,17 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for UserGetResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(userGetOutputSchema)
 	userGetMeOutputSchema, err = jsonschema.For[projects.UserGetMeResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for UserGetMeResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(userGetMeOutputSchema)
 	userListOutputSchema, err = jsonschema.For[projects.UserListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for UserListResponse: %v", err))
 	}
+	helpers.WithMetaWebLinkSchema(userListOutputSchema)
 }
 
 // UserCreate creates a user in Teamwork.com.
@@ -318,7 +321,9 @@ func UserGet(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: user,
+				StructuredContent: helpers.StructuredWebLinker(ctx, user,
+					helpers.WebLinkerWithIDPathBuilder("/app/people"),
+				),
 			}, nil
 		},
 	}
@@ -359,7 +364,9 @@ func UserGetMe(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: user,
+				StructuredContent: helpers.StructuredWebLinker(ctx, user,
+					helpers.WebLinkerWithIDPathBuilder("/app/people"),
+				),
 			}, nil
 		},
 	}
@@ -436,7 +443,9 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: userList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, userList,
+					helpers.WebLinkerWithIDPathBuilder("/app/people"),
+				),
 			}, nil
 		},
 	}
@@ -519,7 +528,9 @@ func UserListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
 						)),
 					},
 				},
-				StructuredContent: userList,
+				StructuredContent: helpers.StructuredWebLinker(ctx, userList,
+					helpers.WebLinkerWithIDPathBuilder("/app/people"),
+				),
 			}, nil
 		},
 	}


### PR DESCRIPTION
## Description

The metadata section was missing from both the output schema and the structured representation, preventing web application linking.

This adds the webLinker field to provide references for items returned by the MCP server.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors