### PR TITLE
Chore: Improve error message when providing a required date input

### DIFF
--- a/internal/helpers/tool_parser.go
+++ b/internal/helpers/tool_parser.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	twapi "github.com/teamwork/twapi-go-sdk"
@@ -298,6 +299,12 @@ func timeParam(
 	if !ok {
 		return fmt.Errorf("invalid type for %s: expected string, got %T", key, value)
 	}
+	if strings.TrimSpace(v) == "" {
+		if optional {
+			return nil
+		}
+		return fmt.Errorf("parameter %s is required and cannot be empty", key)
+	}
 	for _, middleware := range middlewares {
 		var err error
 		if ok, err = middleware(&v); err != nil || !ok {
@@ -385,6 +392,12 @@ func timeOnlyParam(
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("invalid type for %s: expected string, got %T", key, value)
+	}
+	if strings.TrimSpace(v) == "" {
+		if optional {
+			return nil
+		}
+		return fmt.Errorf("parameter %s is required and cannot be empty", key)
 	}
 	for _, middleware := range middlewares {
 		var err error
@@ -476,6 +489,12 @@ func dateParam(
 	if !ok {
 		return fmt.Errorf("invalid type for %s: expected string, got %T", key, value)
 	}
+	if strings.TrimSpace(v) == "" {
+		if optional {
+			return nil
+		}
+		return fmt.Errorf("parameter %s is required and cannot be empty", key)
+	}
 	for _, middleware := range middlewares {
 		var err error
 		if ok, err = middleware(&v); err != nil || !ok {
@@ -566,6 +585,12 @@ func legacyDateParam(
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("invalid type for %s: expected string, got %T", key, value)
+	}
+	if strings.TrimSpace(v) == "" {
+		if optional {
+			return nil
+		}
+		return fmt.Errorf("parameter %s is required and cannot be empty", key)
 	}
 	for _, middleware := range middlewares {
 		var err error


### PR DESCRIPTION
## Description

Instead of showing:
> invalid parameters: error binding parameter: invalid date format for date:
> parsing time "" as "2006-01-02": cannot parse "" as "2006"

We will show a more elegant error message:
> invalid parameters: error binding parameter: parameter date is required and
> cannot be empty

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors