### PR TITLE
inject bearer token into the desk context

### DIFF
--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -60,6 +60,8 @@ func main() {
 			authenticated = true
 			// inject customer URL in the context
 			ctx = config.WithCustomerURL(ctx, info.URL)
+			// inject bearer token in the context (used by Desk SDK clients)
+			ctx = config.WithBearerToken(ctx, resources.Info.BearerToken)
 			// inject bearer token in the context
 			ctx = session.WithBearerTokenContext(ctx, session.NewBearerToken(resources.Info.BearerToken, info.URL))
 		}


### PR DESCRIPTION
## Description
Fixes and issue with Claude where the token was not being set and therefore auth was not happening properly when making Desk tool calls.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors