### PR TITLE
Feature: New tool to mark tasks as complete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c
-	github.com/teamwork/twapi-go-sdk v1.12.1
+	github.com/teamwork/twapi-go-sdk v1.13.0
 )
 
 require (
@@ -83,7 +83,7 @@ require (
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c h1:eILMvTElVNkm68HOcPjEDear3/EYFgvEI59TbfHXRH0=
 github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
-github.com/teamwork/twapi-go-sdk v1.12.1 h1:W82ojqy7524jZ6H5AoceOR/5iV+bKoZn82bbofExEvM=
-github.com/teamwork/twapi-go-sdk v1.12.1/go.mod h1:bTr8DQ5dSRdzrCcfKfQJhPXZnituxbf6/VbuHVgdbAc=
+github.com/teamwork/twapi-go-sdk v1.13.0 h1:1DvPK15CafLOA2k8/auM71YI7kPHW4im/bQLKPjVgwU=
+github.com/teamwork/twapi-go-sdk v1.13.0/go.mod h1:l1OHzRbfTA+9u0ZTBjFfsWShz2VKeXNVxW7l3YSBFXY=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
@@ -291,8 +291,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -21,6 +21,7 @@ const (
 	MethodTaskCreate         toolsets.Method = "twprojects-create_task"
 	MethodTaskUpdate         toolsets.Method = "twprojects-update_task"
 	MethodTaskDelete         toolsets.Method = "twprojects-delete_task"
+	MethodTaskComplete       toolsets.Method = "twprojects-complete_task"
 	MethodTaskGet            toolsets.Method = "twprojects-get_task"
 	MethodTaskList           toolsets.Method = "twprojects-list_tasks"
 	MethodTaskListByTasklist toolsets.Method = "twprojects-list_tasks_by_tasklist"
@@ -725,6 +726,49 @@ func TaskDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.HandleAPIError(err, "failed to delete task")
 			}
 			return helpers.NewToolResultText("Task deleted successfully"), nil
+		},
+	}
+}
+
+// TaskComplete marks a task as complete in Teamwork.com.
+func TaskComplete(engine *twapi.Engine) toolsets.ToolWrapper {
+	return toolsets.ToolWrapper{
+		Tool: &mcp.Tool{
+			Name:        string(MethodTaskComplete),
+			Description: "Mark an existing task as complete in Teamwork.com. " + taskDescription,
+			Annotations: &mcp.ToolAnnotations{
+				Title: "Complete Task",
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"id": {
+						Type:        "integer",
+						Description: "The ID of the task to mark as complete.",
+					},
+				},
+				Required: []string{"id"},
+			},
+		},
+		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var taskCompleteRequest projects.TaskCompleteRequest
+
+			var arguments map[string]any
+			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
+				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
+			}
+			err := helpers.ParamGroup(arguments,
+				helpers.RequiredNumericParam(&taskCompleteRequest.Path.ID, "id"),
+			)
+			if err != nil {
+				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
+			}
+
+			_, err = projects.TaskComplete(ctx, engine, taskCompleteRequest)
+			if err != nil {
+				return helpers.HandleAPIError(err, "failed to complete task")
+			}
+			return helpers.NewToolResultText("Task completed successfully"), nil
 		},
 	}
 }

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -78,6 +78,13 @@ func TestTaskDelete(t *testing.T) {
 	})
 }
 
+func TestTaskComplete(t *testing.T) {
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskComplete.String(), map[string]any{
+		"id": float64(123),
+	})
+}
+
 func TestTaskGet(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskGet.String(), map[string]any{

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -67,6 +67,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 
 	// --- tasks sub-toolset ---
 	tasksWriteTools := []toolsets.ToolWrapper{
+		TaskComplete(engine),
 		TaskCreate(engine),
 		TasklistCreate(engine),
 		TasklistUpdate(engine),


### PR DESCRIPTION
## Summary
- Adds new MCP write tool `twprojects-complete_task` that marks a task as complete via `PUT /tasks/{id}/complete.json`
- Wraps the new `TaskComplete` operation added in twapi-go-sdk v1.13.0
- Registered in `tasksWriteTools` (not gated behind `allowDelete` — completion is non-destructive)

## Motivation
Closing a task currently requires setting `status` via `update_task`, which is less reliable and doesn't trigger the same server-side workflow (notifications, automations) as the dedicated complete endpoint.

## Description
Introduces `twprojects-complete_task`, a one-parameter MCP tool that marks a task as fully complete through the Teamwork v1 API. The tool accepts only a task `id` and issues a `PUT /tasks/{id}/complete.json` with no body via the newly-released `projects.TaskComplete` SDK function (twapi-go-sdk v1.13.0).

Implementation mirrors the existing `TaskDelete` tool pattern — single required field, minimal handler, delegating all transport concerns to the SDK. Registered as a write tool (not a delete tool) so it's available under any write-capable toolset without requiring `-allow-delete`.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Validated at three layers:

1. **Unit test** — `TestTaskComplete` in `internal/twprojects/tasks_test.go` uses the existing `mcpServerMock` harness, asserting the tool accepts an `id` parameter and returns success on an HTTP 200.
2. **Full suite** — `go test -v ./...` passes with no regressions against twapi-go-sdk v1.13.0.
3. **End-to-end** — invoked the live tool through `cmd/mcp-http` against a real Teamwork installation.  Server returned `"Task completed successfully"` and the task shows as completed in the Teamwork UI.

- [X] Tests pass locally (`go test -v ./...`)
- [X] Added/updated tests for new functionality

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed the code
- [X] Added necessary documentation
- [X] No new warnings or errors