### PR TITLE
Fix: Tasks - Alert about invalid assignees when creating/updating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c
-	github.com/teamwork/twapi-go-sdk v1.13.1
+	github.com/teamwork/twapi-go-sdk v1.13.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c h1:eILMvTElVNkm68HOcPjEDear3/EYFgvEI59TbfHXRH0=
 github.com/teamwork/desksdkgo v0.0.0-20260409174248-9cf41197609c/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
-github.com/teamwork/twapi-go-sdk v1.13.1 h1:CjgVlwgMvsdFhISt/XU58HiduHWSbE3Vd0NwYqhBqsA=
-github.com/teamwork/twapi-go-sdk v1.13.1/go.mod h1:l1OHzRbfTA+9u0ZTBjFfsWShz2VKeXNVxW7l3YSBFXY=
+github.com/teamwork/twapi-go-sdk v1.13.2 h1:CvMXov9ovFZhIRzr6k/NZhWprVdZWgR6g9VDrQ6A/0Q=
+github.com/teamwork/twapi-go-sdk v1.13.2/go.mod h1:l1OHzRbfTA+9u0ZTBjFfsWShz2VKeXNVxW7l3YSBFXY=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -271,6 +271,7 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var taskCreateRequest projects.TaskCreateRequest
 			taskCreateRequest.Options.Notify = true
+			taskCreateRequest.Options.CheckInvalidUsers = true
 
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
@@ -586,6 +587,7 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var taskUpdateRequest projects.TaskUpdateRequest
 			taskUpdateRequest.Options.Notify = true
+			taskUpdateRequest.Options.CheckInvalidUsers = true
 
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {


### PR DESCRIPTION
## Description

The MCP server was silently dropping invalid assignees when creating/updating a task. Now it will raise an error, helping the agent/LLM to fix the issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors