### PR TITLE
Fix: Set default notification behaviour for comments and task

### DIFF
--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -112,7 +112,7 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the new comment. Accepts either 'all', true (followers) or an " +
-							"object specifying user, team, or company IDs.",
+							"object specifying user, team, or company IDs. By default, followers are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -159,6 +159,7 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`true`),
 					},
 				},
 				Required: []string{"object", "body"},
@@ -208,6 +209,8 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either boolean true, " +
 						"string ('all'), or an object"), nil
 				}
+			} else {
+				commentCreateRequest.Notify = projects.NewCommentNotifyFollowers()
 			}
 
 			var objectType string
@@ -286,7 +289,7 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the comment change. Accepts either 'all', true (followers) or " +
-							"an object specifying user, team, or company IDs.",
+							"an object specifying user, team, or company IDs. By default, followers are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -333,6 +336,7 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`true`),
 					},
 				},
 				Required: []string{"id", "body"},
@@ -383,6 +387,8 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either boolean true, " +
 						"string ('all'), or an object"), nil
 				}
+			} else {
+				commentUpdateRequest.Notify = projects.NewCommentNotifyFollowers()
 			}
 
 			_, err = projects.CommentUpdate(ctx, engine, commentUpdateRequest)

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -79,7 +79,7 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the new message reply. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs.",
+							"object specifying user, team, or company IDs. By default, all project members are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -121,6 +121,7 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`"all"`),
 					},
 				},
 				Required: []string{"message_id", "body"},
@@ -165,6 +166,8 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
 						"or an object"), nil
 				}
+			} else {
+				messageReplyCreateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
 			messageReply, err := projects.MessageReplyCreate(ctx, engine, messageReplyCreateRequest)
@@ -202,7 +205,7 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the new messageReply. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs.",
+							"object specifying user, team, or company IDs. By default, all project members are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -244,6 +247,7 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`"all"`),
 					},
 				},
 				Required: []string{"id"},
@@ -288,6 +292,8 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
 						"or an object"), nil
 				}
+			} else {
+				messageReplyUpdateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
 			_, err = projects.MessageReplyUpdate(ctx, engine, messageReplyUpdateRequest)

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -83,7 +83,7 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the new message. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs.",
+							"object specifying user, team, or company IDs. By default, all project members are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -125,6 +125,7 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`"all"`),
 					},
 				},
 				Required: []string{"title", "project_id", "body"},
@@ -170,6 +171,8 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
 						"or an object"), nil
 				}
+			} else {
+				messageCreateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
 			message, err := projects.MessageCreate(ctx, engine, messageCreateRequest)
@@ -215,7 +218,7 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"notify": {
 						Description: "Who should be notified about the new message. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs.",
+							"object specifying user, team, or company IDs. By default, all project members are notified.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type:        "string",
@@ -257,6 +260,7 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 								},
 							},
 						},
+						Default: json.RawMessage(`"all"`),
 					},
 				},
 				Required: []string{"id"},
@@ -302,6 +306,8 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
 						"or an object"), nil
 				}
+			} else {
+				messageUpdateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
 			_, err = projects.MessageUpdate(ctx, engine, messageUpdateRequest)


### PR DESCRIPTION
## Description

By default, notify all followers when creating/updating a comment. When creating/updating a message or message reply, notify all project members.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors