### PR TITLE
Fix: Add missing `git` tool in the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY --chown=root:root . /usr/src/mcp
 
 ARG BUILD_VERSION=dev
 
+RUN apk add --no-cache git
 RUN go mod download
 RUN go build -ldflags="-X 'github.com/teamwork/mcp/internal/config.Version=$BUILD_VERSION'" -o /app/tw-mcp-http ./cmd/mcp-http
 RUN go build -ldflags="-X 'github.com/teamwork/mcp/internal/config.Version=$BUILD_VERSION'" -o /app/tw-mcp-stdio ./cmd/mcp-stdio


### PR DESCRIPTION
## Description

`golang:1.26-alpine` doesn't contain the `git` tool anymore.

```
go: github.com/teamwork/twapi-go-sdk@v1.13.4: unable to resolve git version: failed to execute git version: exec: "git": executable file not found in $PATH
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors