### PR TITLE
Fix: STDIO keep-alive and log file write mode

### DIFF
--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -62,7 +63,7 @@ func main() {
 	f := os.Stderr
 	if logToFile != "" {
 		var err error
-		f, err = os.Open(logToFile)
+		f, err = os.OpenFile(logToFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to open log file: %s\n", err)
 			exit(exitCodeSetupFailure)
@@ -107,7 +108,30 @@ func main() {
 		}
 	})
 
-	if err := mcpServer.Run(ctx, &mcp.StdioTransport{}); err != nil {
+	ss, err := mcpServer.Connect(ctx, &mcp.StdioTransport{}, nil)
+	if err != nil {
+		mcpError(resources.Logger(), fmt.Errorf("failed to connect: %s", err), jsonRPCErrorCodeInternalError)
+		exit(exitCodeSetupFailure)
+	}
+
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				if err := ss.Ping(pingCtx, nil); err != nil {
+					mcpError(resources.Logger(), fmt.Errorf("failed to ping: %s", err), jsonRPCErrorCodeInternalError)
+				}
+				cancel()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	if err := ss.Wait(); err != nil {
 		mcpError(resources.Logger(), fmt.Errorf("failed to serve: %s", err), jsonRPCErrorCodeInternalError)
 		exit(exitCodeSetupFailure)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,6 +188,8 @@ func NewMCPServer(resources Resources, groups ...*toolsets.ToolsetGroup) *mcp.Se
 				"io.modelcontextprotocol/ui": map[string]any{},
 			},
 		},
+		// https://github.com/modelcontextprotocol/go-sdk/blob/v1.5.0/design/design.md#ping--keepalive
+		KeepAlive: 30 * time.Second,
 	}
 	if hasTools {
 		serverOptions.Capabilities.Tools = &mcp.ToolCapabilities{}


### PR DESCRIPTION
## Description

- Fix log file always being empty: `os.Open` opens read-only, so all slog writes silently failed. Changed to `os.OpenFile` with O_CREATE|O_WRONLY|O_APPEND.

- Add keep-alive to prevent silent STDIO pipe stalls on Windows: set `KeepAlive: 30s` on the server options (go-sdk built-in) and add an explicit 30s ping loop in the STDIO entry point using `Connect`+`Wait` instead of `Run`, so the server proactively sends MCP pings to Claude Desktop during idle periods.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors