### PR TITLE
Fix: Timelog App - Correctly render in Claude Desktop

### DIFF
--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -115,6 +115,19 @@ func (e *ToolsetDoesNotExistError) Is(target error) bool {
 	return ok
 }
 
+// ServerResource represents a plain resource that can be registered with the
+// MCP server and will appear in resources/list.
+type ServerResource struct {
+	resource *mcp.Resource
+	handler  mcp.ResourceHandler
+}
+
+// NewServerResource creates a new ServerResource with the given resource and
+// handler function.
+func NewServerResource(resource *mcp.Resource, handler mcp.ResourceHandler) ServerResource {
+	return ServerResource{resource: resource, handler: handler}
+}
+
 // ServerResourceTemplate represents a resource template that can be registered
 // with the MCP server.
 type ServerResourceTemplate struct {
@@ -173,6 +186,7 @@ type Toolset struct {
 	// resources are not tools, but the community seems to be moving towards
 	// namespaces as a broader concept and in order to have multiple servers
 	// running concurrently, we want to avoid overlapping resources too.
+	resources         []ServerResource
 	resourceTemplates []ServerResourceTemplate
 	// prompts are also not tools but are namespaced similarly
 	prompts []ServerPrompt
@@ -222,6 +236,33 @@ func (t *Toolset) RegisterTools(s *mcp.Server) {
 		for _, tool := range t.writeTools {
 			s.AddTool(tool.Tool, tool.Handler)
 		}
+	}
+}
+
+// AddResources adds plain resources to the Toolset. These will appear in
+// resources/list responses.
+func (t *Toolset) AddResources(resources ...ServerResource) *Toolset {
+	t.resources = append(t.resources, resources...)
+	return t
+}
+
+// GetActiveResources returns the plain resources that are currently active in
+// the Toolset.
+func (t *Toolset) GetActiveResources() []ServerResource {
+	if !t.Enabled {
+		return nil
+	}
+	return t.resources
+}
+
+// RegisterResources registers the plain resources in the Toolset with the MCP
+// server.
+func (t *Toolset) RegisterResources(s *mcp.Server) {
+	if !t.Enabled {
+		return
+	}
+	for _, r := range t.resources {
+		s.AddResource(r.resource, r.handler)
 	}
 }
 
@@ -403,6 +444,7 @@ func (tg *ToolsetGroup) EnableToolset(method Method) error {
 func (tg *ToolsetGroup) RegisterAll(s *mcp.Server) {
 	for _, toolset := range tg.Toolsets {
 		toolset.RegisterTools(s)
+		toolset.RegisterResources(s)
 		toolset.RegisterResourcesTemplates(s)
 		toolset.RegisterPrompts(s)
 	}

--- a/internal/twprojects/apps/timelog_create.html
+++ b/internal/twprojects/apps/timelog_create.html
@@ -346,7 +346,7 @@
         return value;
       }
 
-      function request(method, params) {
+      function request(method, params, timeoutMs) {
         return new Promise(function (resolve, reject) {
           var id = nextID++;
           pending.set(id, { resolve: resolve, reject: reject });
@@ -362,7 +362,7 @@
             }
             pending.delete(id);
             reject(new Error("Timed out calling " + method));
-          }, 30000);
+          }, timeoutMs || 30000);
         });
       }
 
@@ -816,6 +816,21 @@
         }
       });
 
+      async function initialize() {
+        var initResult = await request("ui/initialize", {
+          protocolVersion: "2026-01-26",
+          capabilities: {}
+        }, 5000);
+
+        // Acknowledge — fire-and-forget, no response expected.
+        window.parent.postMessage(
+          { jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} },
+          hostOrigin
+        );
+
+        return initResult;
+      }
+
       var defaults = nowDefaults();
       dateField.value = defaults.date;
       timeField.value = defaults.time;
@@ -865,7 +880,11 @@
         }
       });
 
-      loadProjects();
+      initialize().then(loadProjects).catch(function (err) {
+        // Fallback: if the host doesn't support ui/initialize (e.g. MCP
+        // Inspector), the request will time out. Load projects anyway.
+        loadProjects();
+      });
     })();
   </script>
 </body>

--- a/internal/twprojects/timelog_app.go
+++ b/internal/twprojects/timelog_app.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	mcpAppMimeType                   = "text/html;profile=mcp-app"
-	timelogCreateAppResourceURI      = "ui://teamwork/timelog-create"
-	timelogCreateAppResourceTitle    = "Create Timelog App"
-	timelogCreateAppResourceTemplate = "ui://teamwork/timelog-create"
-	timelogCreateAppDescription      = "Interactive form for creating Teamwork timelogs."
+	mcpAppMimeType                = "text/html;profile=mcp-app"
+	timelogCreateAppURI           = "ui://teamwork/timelog-create"
+	timelogCreateAppResourceTitle = "Create Timelog App"
+	timelogCreateAppDescription   = "Interactive form for creating Teamwork timelogs."
 )
 
 var timelogCreateWidgetCSP = map[string]any{
@@ -35,28 +34,31 @@ var timelogCreateResourceMeta = mcp.Meta{
 //go:embed apps/timelog_create.html
 var timelogCreateAppHTML string
 
-// TimelogCreateAppResourceTemplate registers the MCP Apps resource used by the
-// twprojects-create_timelog tool.
-func TimelogCreateAppResourceTemplate() toolsets.ServerResourceTemplate {
-	return toolsets.NewServerResourceTemplate(
-		&mcp.ResourceTemplate{
+func timelogCreateReadHandler(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:      timelogCreateAppURI,
+				MIMEType: mcpAppMimeType,
+				Text:     timelogCreateAppHTML,
+				Meta:     timelogCreateResourceMeta,
+			},
+		},
+	}, nil
+}
+
+// TimelogCreateAppResource returns the MCP Apps plain resource so it appears
+// in resources/list.
+func TimelogCreateAppResource() toolsets.ServerResource {
+	return toolsets.NewServerResource(
+		&mcp.Resource{
 			Name:        "twprojects-create_timelog-ui",
 			Title:       timelogCreateAppResourceTitle,
 			Description: timelogCreateAppDescription,
 			MIMEType:    mcpAppMimeType,
-			URITemplate: timelogCreateAppResourceTemplate,
+			URI:         timelogCreateAppURI,
+			Meta:        timelogCreateResourceMeta,
 		},
-		func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-			return &mcp.ReadResourceResult{
-				Contents: []*mcp.ResourceContents{
-					{
-						URI:      req.Params.URI,
-						MIMEType: mcpAppMimeType,
-						Text:     timelogCreateAppHTML,
-						Meta:     timelogCreateResourceMeta,
-					},
-				},
-			}, nil
-		},
+		timelogCreateReadHandler,
 	)
 }

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -61,9 +61,9 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 		Tool: &mcp.Tool{
 			Meta: mcp.Meta{
 				"ui": map[string]any{
-					"resourceUri": timelogCreateAppResourceURI,
+					"resourceUri": timelogCreateAppURI,
 				},
-				"openai/outputTemplate": timelogCreateAppResourceURI,
+				"openai/outputTemplate": timelogCreateAppURI,
 			},
 			Name:        string(MethodTimelogCreate),
 			Description: "Create a new timelog in Teamwork.com. " + timelogDescription,

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -178,7 +178,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			TimerList(engine),
 		)
 	if !readOnly {
-		timeToolset.AddResourceTemplates(TimelogCreateAppResourceTemplate())
+		timeToolset.AddResources(TimelogCreateAppResource())
 	}
 	group.AddToolset(timeToolset)
 


### PR DESCRIPTION
## Description

The timelog create app was skipping the `ui/initialize` → `ui/notifications/initialized` handshake required by Claude Desktop, causing it to fail there while appearing to work in MCP Inspector (which renders iframes unconditionally).

Changes:
- `timelog_create.html`: perform the `ui/initialize` handshake (ext-apps spec 2026-01-26) on load with a 5s timeout, falling back to loadProjects() for hosts that don't support the extension (e.g. older MCP Inspector builds)
- `timelog_app.go`: register the app as a plain `mcp.Resource` instead of a `ResourceTemplate` with no URI variables, so it surfaces in `resources/list` and clients can read it without needing to expand a template

Related to:
https://github.com/anthropics/claude-ai-mcp/issues/61

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors