### PR TITLE
Enhancement: Task - Allow setting the description content type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d
 	github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d
-	github.com/teamwork/twapi-go-sdk v1.13.4
+	github.com/teamwork/twapi-go-sdk v1.13.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d h1:6+6U0YuIcEtP
 github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d h1:C81tRl2LyM5EW2PyqXj8Ral43vZz9cmZM4vjUt4/LSo=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.13.4 h1:oiCFQp8jFbT7OywLXWnhY1dqb/oi2TcqtJivDYzgO6Y=
-github.com/teamwork/twapi-go-sdk v1.13.4/go.mod h1:l1OHzRbfTA+9u0ZTBjFfsWShz2VKeXNVxW7l3YSBFXY=
+github.com/teamwork/twapi-go-sdk v1.13.5 h1:Y2zebPfk5R9E/j6VG+iyh31xSNHhbOXBdfQ1fUVLk/s=
+github.com/teamwork/twapi-go-sdk v1.13.5/go.mod h1:l1OHzRbfTA+9u0ZTBjFfsWShz2VKeXNVxW7l3YSBFXY=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -87,6 +87,17 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"description_content_type": {
+						Description: "The format of the description. Possible values are: text or html. If not provided, " +
+							"it will default to text.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{
+								projects.TaskDescriptionContentTypeText,
+								projects.TaskDescriptionContentTypeHTML,
+							}},
+							{Type: "null"},
+						},
+					},
 					"priority": {
 						Description: "The priority of the task. Possible values are: low, medium, high.",
 						AnyOf: []*jsonschema.Schema{
@@ -324,6 +335,12 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.RequiredParam(&taskCreateRequest.Name, "name"),
 				helpers.RequiredNumericParam(&taskCreateRequest.Path.TasklistID, "tasklist_id"),
 				helpers.OptionalPointerParam(&taskCreateRequest.Description, "description"),
+				helpers.OptionalPointerParam(&taskCreateRequest.DescriptionContentType, "description_content_type",
+					helpers.RestrictValues(
+						projects.TaskDescriptionContentTypeText,
+						projects.TaskDescriptionContentTypeHTML,
+					),
+				),
 				helpers.OptionalPointerParam(&taskCreateRequest.Priority, "priority",
 					helpers.RestrictValues("low", "medium", "high"),
 				),
@@ -449,6 +466,17 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "The description of the task.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
+							{Type: "null"},
+						},
+					},
+					"description_content_type": {
+						Description: "The format of the description. Possible values are: text or html. If not provided, " +
+							"it will default to text.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{
+								projects.TaskDescriptionContentTypeText,
+								projects.TaskDescriptionContentTypeHTML,
+							}},
 							{Type: "null"},
 						},
 					},
@@ -690,6 +718,12 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericPointerParam(&taskUpdateRequest.TasklistID, "tasklist_id"),
 				helpers.OptionalPointerParam(&taskUpdateRequest.Name, "name"),
 				helpers.OptionalPointerParam(&taskUpdateRequest.Description, "description"),
+				helpers.OptionalPointerParam(&taskUpdateRequest.DescriptionContentType, "description_content_type",
+					helpers.RestrictValues(
+						projects.TaskDescriptionContentTypeText,
+						projects.TaskDescriptionContentTypeHTML,
+					),
+				),
 				helpers.OptionalPointerParam(&taskUpdateRequest.Priority, "priority",
 					helpers.RestrictValues("low", "medium", "high"),
 				),

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -11,15 +11,16 @@ import (
 func TestTaskCreate(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusCreated, []byte(`{"task":{"id":123}}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskCreate.String(), map[string]any{
-		"name":              "Example",
-		"tasklist_id":       float64(123),
-		"description":       "This is an example task.",
-		"priority":          "high",
-		"progress":          float64(50),
-		"start_date":        "2023-10-01",
-		"due_date":          "2023-10-15",
-		"estimated_minutes": float64(120),
-		"parent_task_id":    float64(456),
+		"name":                     "Example",
+		"tasklist_id":              float64(123),
+		"description":              "This is an example task.",
+		"description_content_type": "TEXT",
+		"priority":                 "high",
+		"progress":                 float64(50),
+		"start_date":               "2023-10-01",
+		"due_date":                 "2023-10-15",
+		"estimated_minutes":        float64(120),
+		"parent_task_id":           float64(456),
 		"assignees": map[string]any{
 			"user_ids":    []float64{1, 2, 3},
 			"team_ids":    []float64{4, 5},
@@ -42,16 +43,17 @@ func TestTaskCreate(t *testing.T) {
 func TestTaskUpdate(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskUpdate.String(), map[string]any{
-		"id":                float64(123),
-		"name":              "Example",
-		"tasklist_id":       float64(123),
-		"description":       "This is an example task.",
-		"priority":          "high",
-		"progress":          float64(50),
-		"start_date":        "2023-10-01",
-		"due_date":          "2023-10-15",
-		"estimated_minutes": float64(120),
-		"parent_task_id":    float64(456),
+		"id":                       float64(123),
+		"name":                     "Example",
+		"tasklist_id":              float64(123),
+		"description":              "This is an example task.",
+		"description_content_type": "HTML",
+		"priority":                 "high",
+		"progress":                 float64(50),
+		"start_date":               "2023-10-01",
+		"due_date":                 "2023-10-15",
+		"estimated_minutes":        float64(120),
+		"parent_task_id":           float64(456),
 		"assignees": map[string]any{
 			"user_ids":    []float64{1, 2, 3},
 			"team_ids":    []float64{4, 5},


### PR DESCRIPTION
## Description

Allow setting the description content type (`TEXT` or `HTML`) when creating or updating a task.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors