### PR TITLE
Enhancement: OAuth DCR - Allow registering apps for spaces scope

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -157,7 +157,7 @@ func newRouter(resources config.Resources) *http.ServeMux {
   "authorization_servers": ["` + resources.Info.APIURL + `"],
   "bearer_methods_supported": ["header"],
   "resource_documentation": "https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
-  "scopes_supported": [ "projects", "desk" ]
+  "scopes_supported": [ "projects", "desk", "spaces" ]
 }`))
 	})
 	return mux


### PR DESCRIPTION
## Description

The MCP now supports Spaces' tools, but the OAuth DCR flow doesn't add the Spaces scope to allow playing with them. Adding to the supported scopes should fix this issue.

<img width="876" height="557" alt="image" src="https://github.com/user-attachments/assets/3f6a4b44-655a-4878-8c1d-5ec5907500fc" />

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors