### PR TITLE
Fix: twspaces - Allow null for all optional parameters

### DIFF
--- a/internal/twdesk/companies.go
+++ b/internal/twdesk/companies.go
@@ -69,20 +69,25 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 func CompanyList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "string",
 			Description: "The name of the company to filter by.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "string"},
+				{Type: "null"},
+			},
 		},
 		"domains": {
-			Type:        "array",
 			Description: "The domains of the company to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"kind": {
-			Type:        "string",
 			Description: "The kind of the company to filter by.",
-			Enum:        []any{"company", "group"},
+			AnyOf: []*jsonschema.Schema{
+				{Type: "string", Enum: []any{"company", "group"}},
+				{Type: "null"},
+			},
 		},
 	}
 	properties = paginationOptions(properties)
@@ -100,6 +105,7 @@ func CompanyList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -159,40 +165,59 @@ func CompanyCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the company.",
 					},
 					"description": {
-						Type:        "string",
 						Description: "The description of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"details": {
-						Type:        "string",
 						Description: "The details of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"industry": {
-						Type:        "string",
 						Description: "The industry of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"website": {
-						Type:        "string",
 						Description: "The website of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"permission": {
-						Type:        "string",
 						Description: "The permission level of the company.",
-						Enum:        []any{"own", "all"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{"own", "all"}},
+							{Type: "null"},
+						},
 					},
 					"kind": {
-						Type:        "string",
 						Description: "The kind of the company.",
-						Enum:        []any{"company", "group"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{"company", "group"}},
+							{Type: "null"},
+						},
 					},
 					"note": {
-						Type:        "string",
 						Description: "The note for the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"domains": {
-						Type:        "array",
 						Description: "The domains for the company.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 				},
@@ -256,44 +281,66 @@ func CompanyUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the company to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"description": {
-						Type:        "string",
 						Description: "The new description of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"details": {
-						Type:        "string",
 						Description: "The new details of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"industry": {
-						Type:        "string",
 						Description: "The new industry of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"website": {
-						Type:        "string",
 						Description: "The new website of the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"permission": {
-						Type:        "string",
 						Description: "The new permission level of the company.",
-						Enum:        []any{"own", "all"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{"own", "all"}},
+							{Type: "null"},
+						},
 					},
 					"kind": {
-						Type:        "string",
 						Description: "The new kind of the company.",
-						Enum:        []any{"company", "group"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{"company", "group"}},
+							{Type: "null"},
+						},
 					},
 					"note": {
-						Type:        "string",
 						Description: "The new note for the company.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"domains": {
-						Type:        "array",
 						Description: "The new domains for the company.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 				},

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -70,24 +70,24 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 func CustomerList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"companyIDs": {
-			Type:        "array",
 			Description: "The IDs of the companies to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"companyNames": {
-			Type:        "array",
 			Description: "The names of the companies to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"emails": {
-			Type:        "array",
 			Description: "The emails of the customers to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -106,6 +106,7 @@ func CustomerList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -162,58 +163,98 @@ func CustomerCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"firstName": {
-						Type:        "string",
 						Description: "The first name of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"lastName": {
-						Type:        "string",
 						Description: "The last name of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"email": {
-						Type:        "string",
 						Description: "The email of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"organization": {
-						Type:        "string",
 						Description: "The organization of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"extraData": {
-						Type:        "string",
 						Description: "The extra data of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"notes": {
-						Type:        "string",
 						Description: "The notes of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"linkedinURL": {
-						Type:        "string",
 						Description: "The LinkedIn URL of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"facebookURL": {
-						Type:        "string",
 						Description: "The Facebook URL of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"twitterHandle": {
-						Type:        "string",
 						Description: "The Twitter handle of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"jobTitle": {
-						Type:        "string",
 						Description: "The job title of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"phone": {
-						Type:        "string",
 						Description: "The phone number of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"mobile": {
-						Type:        "string",
 						Description: "The mobile number of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"address": {
-						Type:        "string",
 						Description: "The address of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
+				Required: []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -279,56 +320,95 @@ func CustomerUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the customer to update.",
 					},
 					"firstName": {
-						Type:        "string",
 						Description: "The new first name of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"lastName": {
-						Type:        "string",
 						Description: "The new last name of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"email": {
-						Type:        "string",
 						Description: "The new email of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"organization": {
-						Type:        "string",
 						Description: "The new organization of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"extraData": {
-						Type:        "string",
 						Description: "The new extra data of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"notes": {
-						Type:        "string",
 						Description: "The new notes of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"linkedinURL": {
-						Type:        "string",
 						Description: "The new LinkedIn URL of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"facebookURL": {
-						Type:        "string",
 						Description: "The new Facebook URL of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"twitterHandle": {
-						Type:        "string",
 						Description: "The new Twitter handle of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"jobTitle": {
-						Type:        "string",
 						Description: "The new job title of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"phone": {
-						Type:        "string",
 						Description: "The new phone number of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"mobile": {
-						Type:        "string",
 						Description: "The new mobile number of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"address": {
-						Type:        "string",
 						Description: "The new address of the customer.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/files.go
+++ b/internal/twdesk/files.go
@@ -43,11 +43,16 @@ func FileCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The MIME type of the file.",
 					},
 					"disposition": {
-						Type:        "string",
 						Description: "The disposition of the file.",
-						Enum: []any{
-							string(deskmodels.DispositionAttachment),
-							string(deskmodels.DispositionAttachmentInline),
+						AnyOf: []*jsonschema.Schema{
+							{
+								Type: "string",
+								Enum: []any{
+									string(deskmodels.DispositionAttachment),
+									string(deskmodels.DispositionAttachmentInline),
+								},
+							},
+							{Type: "null"},
 						},
 					},
 					"data": {

--- a/internal/twdesk/inboxes.go
+++ b/internal/twdesk/inboxes.go
@@ -65,17 +65,17 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 func InboxList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "array",
 			Description: "The name of the inbox to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"email": {
-			Type:        "array",
 			Description: "The email of the inbox to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -92,6 +92,7 @@ func InboxList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/twdesk/messages.go
+++ b/internal/twdesk/messages.go
@@ -39,27 +39,28 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the ticket that the message will be sent to.",
 					},
 					"threadType": {
-						Type:        "string",
 						Description: "The thread type of the message. Valid values are 'message' or 'note'.",
-						Enum:        []any{"message", "note"},
-						Deprecated:  false,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{"message", "note"}},
+							{Type: "null"},
+						},
 					},
 					"body": {
 						Type:        "string",
 						Description: "The body of the message.",
 					},
 					"bcc": {
-						Type:        "array",
 						Description: "An array of email addresses to BCC on message reply.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 					"cc": {
-						Type:        "array",
 						Description: "An array of email addresses to CC on message reply.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 				},

--- a/internal/twdesk/meta.go
+++ b/internal/twdesk/meta.go
@@ -13,20 +13,32 @@ func paginationOptions(properties map[string]*jsonschema.Schema) map[string]*jso
 		properties = make(map[string]*jsonschema.Schema)
 	}
 	properties["page"] = &jsonschema.Schema{
-		Type:        "integer",
 		Description: "The page number to retrieve.",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "integer"},
+			{Type: "null"},
+		},
 	}
 	properties["pageSize"] = &jsonschema.Schema{
-		Type:        "integer",
 		Description: "The number of results to retrieve per page.",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "integer"},
+			{Type: "null"},
+		},
 	}
 	properties["orderBy"] = &jsonschema.Schema{
-		Type:        "string",
 		Description: "The field to order the results by.",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "null"},
+		},
 	}
 	properties["orderDirection"] = &jsonschema.Schema{
-		Type:        "string",
 		Description: "The direction to order the results by (asc, desc).",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "null"},
+		},
 	}
 	return properties
 }

--- a/internal/twdesk/priorities.go
+++ b/internal/twdesk/priorities.go
@@ -68,17 +68,17 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 func PriorityList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "array",
 			Description: "The name of the priority to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"color": {
-			Type:        "array",
 			Description: "The color of the priority to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -97,6 +97,7 @@ func PriorityList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -149,8 +150,11 @@ func PriorityCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the priority.",
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the priority.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"name"},
@@ -196,12 +200,18 @@ func PriorityUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the priority to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name of the priority.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the priority.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/statuses.go
+++ b/internal/twdesk/statuses.go
@@ -69,24 +69,24 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 func StatusList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "array",
 			Description: "The name of the status to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"color": {
-			Type:        "array",
 			Description: "The color of the status to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"code": {
-			Type:        "array",
 			Description: "The code of the status to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -105,6 +105,7 @@ func StatusList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -162,12 +163,18 @@ func StatusCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the status.",
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the status.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"displayOrder": {
-						Type:        "integer",
 						Description: "The display order of the status.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"name"},
@@ -214,16 +221,25 @@ func StatusUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the status to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name of the status.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the status.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"displayOrder": {
-						Type:        "integer",
 						Description: "The display order of the status.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/tags.go
+++ b/internal/twdesk/tags.go
@@ -68,18 +68,24 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "string",
 			Description: "The name of the tag to filter by.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "string"},
+				{Type: "null"},
+			},
 		},
 		"color": {
-			Type:        "string",
 			Description: "The color of the tag to filter by.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "string"},
+				{Type: "null"},
+			},
 		},
 		"inboxIDs": {
-			Type:        "array",
 			Description: "The IDs of the inboxes to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -98,6 +104,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -154,8 +161,11 @@ func TagCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the tag.",
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the tag.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"name"},
@@ -201,12 +211,18 @@ func TagUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the tag to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name of the tag.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"color": {
-						Type:        "string",
 						Description: "The color of the tag.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -87,116 +87,122 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 func TicketList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"inboxIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the inboxes to filter by.
 				Inbox IDs can be found by using the 'twdesk-list_inboxes' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"customerIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the customers to filter by. 
+			The IDs of the customers to filter by.
 			Customer IDs can be found by using the 'twdesk-list_customers' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"companyIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the companies to filter by. 
+			The IDs of the companies to filter by.
 			Company IDs can be found by using the 'twdesk-list_companies' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"tagIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the tags to filter by. 
+			The IDs of the tags to filter by.
 			Tag IDs can be found by using the 'twdesk-list_tags' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"taskIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the tasks to filter by.
 				Task IDs can be found by using the 'twprojects-list_tasks' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"projectsIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the projects to filter by.
 				Project IDs can be found by using the 'twprojects-list_projects' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"statusIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the statuses to filter by.
 				Status IDs can be found by using the 'twdesk-list_statuses' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"priorityIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the priorities to filter by.
 				Priority IDs can be found by using the 'twdesk-list_priorities' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"slaIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the SLAs to filter by.
 				SLA IDs can be found by using the 'twdesk-list_slas' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"userIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the users to filter by.
 				User IDs can be found by using the 'twdesk-list_users' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"shared": {
-			Type: "boolean",
 			Description: `
 			Find tickets shared with me outside of inboxes I have access to
 		`,
+			AnyOf: []*jsonschema.Schema{
+				{Type: "boolean"},
+				{Type: "null"},
+			},
 		},
 		"slaBreached": {
-			Type: "boolean",
 			Description: `
 			Find tickets where the SLA has been breached
 		`,
+			AnyOf: []*jsonschema.Schema{
+				{Type: "boolean"},
+				{Type: "null"},
+			},
 		},
 	}
 	properties = paginationOptions(properties)
@@ -214,6 +220,7 @@ func TicketList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -311,86 +318,92 @@ func TicketSearch(httpClient *http.Client) toolsets.ToolWrapper {
 			`,
 		},
 		"inboxIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the inboxes to filter by.
 				Inbox IDs can be found by using the 'twdesk-list_inboxes' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"customerIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the customers to filter by. 
+			The IDs of the customers to filter by.
 			Customer IDs can be found by using the 'twdesk-list_customers' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"companyIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the companies to filter by. 
+			The IDs of the companies to filter by.
 			Company IDs can be found by using the 'twdesk-list_companies' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"tagIDs": {
-			Type: "array",
 			Description: `
-			The IDs of the tags to filter by. 
+			The IDs of the tags to filter by.
 			Tag IDs can be found by using the 'twdesk-list_tags' tool.
 		`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"statusIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the statuses to filter by.
 				Status IDs can be found by using the 'twdesk-list_statuses' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"priorityIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the priorities to filter by.
 				Priority IDs can be found by using the 'twdesk-list_priorities' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"userIDs": {
-			Type: "array",
 			Description: `
 				The IDs of the users to filter by.
 				User IDs can be found by using the 'twdesk-list_users' tool.
 			`,
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"shared": {
-			Type: "boolean",
 			Description: `
 			Find tickets shared with me outside of inboxes I have access to
 		`,
+			AnyOf: []*jsonschema.Schema{
+				{Type: "boolean"},
+				{Type: "null"},
+			},
 		},
 		"slaBreached": {
-			Type: "boolean",
 			Description: `
 			Find tickets where the SLA has been breached
 		`,
+			AnyOf: []*jsonschema.Schema{
+				{Type: "boolean"},
+				{Type: "null"},
+			},
 		},
 	}
 	properties = paginationOptions(properties)
@@ -473,94 +486,115 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "The body of the ticket.",
 					},
-					"notifyCustomer": {
-						Type:        "boolean",
-						Description: "Set to true if the the customer should be sent a copy of the ticket.",
-					},
-					"bcc": {
-						Type:        "array",
-						Description: "An array of email addresses to BCC on ticket creation.",
-						Items: &jsonschema.Schema{
-							Type: "string",
-						},
-					},
-					"cc": {
-						Type:        "array",
-						Description: "An array of email addresses to CC on ticket creation.",
-						Items: &jsonschema.Schema{
-							Type: "string",
-						},
-					},
-					"files": {
-						Type: "array",
-						Description: `
-					An array of file IDs to attach to the ticket.  
-					Use the 'twdesk-create_file' tool to upload files.
-				`,
-						Items: &jsonschema.Schema{
-							Type: "integer",
-						},
-					},
-					"tags": {
-						Type: "array",
-						Description: `
-					An array of tag IDs to associate with the ticket. 
-					Tag IDs can be found by using the 'twdesk-list_tags' tool.
-				`,
-						Items: &jsonschema.Schema{
-							Type: "integer",
-						},
-					},
-					"priorityId": {
-						Type: "integer",
-						Description: `
-					The priority of the ticket. 
-					Use the 'twdesk-list_priorities' tool to find valid IDs.
-				`,
-					},
-					"statusId": {
-						Type: "integer",
-						Description: `
-					The status of the ticket. 
-					Use the 'twdesk-list_statuses' tool to find valid IDs.
-				`,
-					},
 					"inboxId": {
 						Type: "integer",
 						Description: `
-					The inbox ID of the ticket. 
+					The inbox ID of the ticket.
 					Use the 'twdesk-list_inboxes' tool to find valid IDs.
 				`,
 					},
-					"customerId": {
-						Type: "integer",
+					"notifyCustomer": {
+						Description: "Set to true if the the customer should be sent a copy of the ticket.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
+					},
+					"bcc": {
+						Description: "An array of email addresses to BCC on ticket creation.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
+						},
+					},
+					"cc": {
+						Description: "An array of email addresses to CC on ticket creation.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
+						},
+					},
+					"files": {
 						Description: `
-					The customer ID of the ticket. 
+					An array of file IDs to attach to the ticket.
+					Use the 'twdesk-create_file' tool to upload files.
+				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
+						},
+					},
+					"tags": {
+						Description: `
+					An array of tag IDs to associate with the ticket.
+					Tag IDs can be found by using the 'twdesk-list_tags' tool.
+				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
+						},
+					},
+					"priorityId": {
+						Description: `
+					The priority of the ticket.
+					Use the 'twdesk-list_priorities' tool to find valid IDs.
+				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"statusId": {
+						Description: `
+					The status of the ticket.
+					Use the 'twdesk-list_statuses' tool to find valid IDs.
+				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"customerId": {
+						Description: `
+					The customer ID of the ticket.
 					Use the 'twdesk-list_customers' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"customerEmail": {
-						Type: "string",
 						Description: `
-				The email address of the customer. 
+				The email address of the customer.
 				This is used to identify the customer in the system.
-				Either the customerId or customerEmail is required to create a ticket.  
+				Either the customerId or customerEmail is required to create a ticket.
 				If email is provided we will either find or create the customer.
 			`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"typeId": {
-						Type: "integer",
 						Description: `
-					The type ID of the ticket. 
+					The type ID of the ticket.
 					Use the 'twdesk-list_types' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"agentId": {
-						Type: "integer",
 						Description: `
-					The agent ID that the ticket should be assigned to. 
+					The agent ID that the ticket should be assigned to.
 					Use the 'twdesk-list_agents' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"subject", "body", "inboxId"},
@@ -700,61 +734,82 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the ticket to update.",
 					},
 					"subject": {
-						Type:        "string",
 						Description: "The subject of the ticket.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"body": {
-						Type:        "string",
 						Description: "The body of the ticket.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"bcc": {
-						Type:        "array",
 						Description: "An array of email addresses to BCC on ticket update.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 					"cc": {
-						Type:        "array",
 						Description: "An array of email addresses to CC on ticket update.",
-						Items: &jsonschema.Schema{
-							Type: "string",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+							{Type: "null"},
 						},
 					},
 					"inboxId": {
-						Type: "integer",
 						Description: `
-							The inbox ID of the ticket. 
+							The inbox ID of the ticket.
 							Use the 'twdesk-list_inboxes' tool to find valid IDs.
 						`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"priorityId": {
-						Type: "integer",
 						Description: `
-					The priority of the ticket. 
+					The priority of the ticket.
 					Use the 'twdesk-list_priorities' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"statusId": {
-						Type: "integer",
 						Description: `
-					The status of the ticket. 
+					The status of the ticket.
 					Use the 'twdesk-list_statuses' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"typeId": {
-						Type: "integer",
 						Description: `
-					The type ID of the ticket. 
+					The type ID of the ticket.
 					Use the 'twdesk-list_types' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"agentId": {
-						Type: "integer",
 						Description: `
-					The agent ID that the ticket should be assigned to. 
+					The agent ID that the ticket should be assigned to.
 					Use the 'twdesk-list_agents' tool to find valid IDs.
 				`,
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -68,17 +68,17 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"name": {
-			Type:        "array",
 			Description: "The name of the type to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"inboxIDs": {
-			Type:        "array",
 			Description: "The inbox IDs of the type to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 	}
@@ -97,6 +97,7 @@ func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -150,12 +151,18 @@ func TypeCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the type.",
 					},
 					"displayOrder": {
-						Type:        "integer",
 						Description: "The display order of the type.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"enabledForFutureInboxes": {
-						Type:        "boolean",
 						Description: "Whether the type is enabled for future inboxes.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"name"},
@@ -202,16 +209,25 @@ func TypeUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the type to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name of the type.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"displayOrder": {
-						Type:        "integer",
 						Description: "The display order of the type.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"enabledForFutureInboxes": {
-						Type:        "boolean",
 						Description: "Whether the type is enabled for future inboxes.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -65,36 +65,39 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 func UserList(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"firstName": {
-			Type:        "array",
 			Description: "The first names of the users to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"lastName": {
-			Type:        "array",
 			Description: "The last names of the users to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"email": {
-			Type:        "array",
 			Description: "The email addresses of the users to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "string",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
 			},
 		},
 		"inboxIDs": {
-			Type:        "array",
 			Description: "The IDs of the inboxes to filter by.",
-			Items: &jsonschema.Schema{
-				Type: "integer",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+				{Type: "null"},
 			},
 		},
 		"isPartTime": {
-			Type:        "boolean",
 			Description: "Whether to include part-time users in the results.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "boolean"},
+				{Type: "null"},
+			},
 		},
 	}
 	properties = paginationOptions(properties)
@@ -112,6 +115,7 @@ func UserList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/twspaces/categories.go
+++ b/internal/twspaces/categories.go
@@ -73,6 +73,7 @@ func CategoryList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -111,8 +112,11 @@ func CategoryCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The name of the category.",
 					},
 					"color": {
-						Type:        "string",
 						Description: "A hex color code for the category (e.g. \"#FF5733\").",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"name"},
@@ -158,12 +162,18 @@ func CategoryUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the category to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name for the category.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"color": {
-						Type:        "string",
 						Description: "A new hex color code for the category.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twspaces/comments.go
+++ b/internal/twspaces/comments.go
@@ -145,12 +145,18 @@ func CommentCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The content of the comment.",
 					},
 					"parentId": {
-						Type:        "integer",
 						Description: "The ID of the parent comment (for creating a reply).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"isPrivate": {
-						Type:        "boolean",
 						Description: "Set to true to create a private comment visible only to space members.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"spaceId", "pageId", "content"},
@@ -210,16 +216,25 @@ func CommentUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the comment to update.",
 					},
 					"content": {
-						Type:        "string",
 						Description: "The new content of the comment.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"state": {
-						Type:        "string",
 						Description: "The new state of the comment (e.g. \"active\", \"resolved\").",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"isPrivate": {
-						Type:        "boolean",
 						Description: "Change the privacy setting of the comment.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"spaceId", "pageId", "commentId"},

--- a/internal/twspaces/pages.go
+++ b/internal/twspaces/pages.go
@@ -170,36 +170,60 @@ func PageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The title of the page.",
 					},
 					"content": {
-						Type:        "string",
 						Description: "The HTML content of the page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"parentId": {
-						Type:        "integer",
 						Description: "The ID of the parent page (for creating a sub-page).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"slug": {
-						Type:        "string",
 						Description: "A URL-friendly slug for the page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"isPublish": {
-						Type:        "boolean",
 						Description: "Set to true to publish the page immediately (default: draft).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"isRequiredReading": {
-						Type:        "boolean",
 						Description: "Mark this page as required reading for space members.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"isFullWidth": {
-						Type:        "boolean",
 						Description: "Display the page in full-width layout.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"changeMessage": {
-						Type:        "string",
 						Description: "A message describing the changes made in this version.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"readerInlineCommentsEnabled": {
-						Type:        "boolean",
 						Description: "Allow readers to add inline comments on this page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"spaceId", "title"},
@@ -262,12 +286,18 @@ func PageDuplicate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The title for the duplicated page.",
 					},
 					"parentId": {
-						Type:        "integer",
 						Description: "The ID of the parent page for the duplicate (defaults to same parent).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"slug": {
-						Type:        "string",
 						Description: "A URL-friendly slug for the duplicated page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"spaceId", "pageId", "title"},
@@ -323,44 +353,74 @@ func PageUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the page to update.",
 					},
 					"title": {
-						Type:        "string",
 						Description: "The new title of the page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"content": {
-						Type:        "string",
 						Description: "The new HTML content of the page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"parentId": {
-						Type:        "integer",
 						Description: "The ID of the new parent page (to move the page).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"slug": {
-						Type:        "string",
 						Description: "A new URL-friendly slug for the page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"isPublish": {
-						Type:        "boolean",
 						Description: "Set to true to publish the page, false to revert to draft.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"isRequiredReading": {
-						Type:        "boolean",
 						Description: "Mark or unmark this page as required reading.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"isFullWidth": {
-						Type:        "boolean",
 						Description: "Toggle full-width layout for this page.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"isMinorChange": {
-						Type:        "boolean",
 						Description: "Mark this update as a minor change (won't notify watchers).",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 					"changeMessage": {
-						Type:        "string",
 						Description: "A message describing the changes made in this version.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"readerInlineCommentsEnabled": {
-						Type:        "boolean",
 						Description: "Allow or disallow readers from adding inline comments.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"spaceId", "pageId"},

--- a/internal/twspaces/pagination.go
+++ b/internal/twspaces/pagination.go
@@ -13,12 +13,18 @@ func paginationOptions(properties map[string]*jsonschema.Schema) map[string]*jso
 		properties = make(map[string]*jsonschema.Schema)
 	}
 	properties["pageSize"] = &jsonschema.Schema{
-		Type:        "integer",
 		Description: "The number of results to retrieve per page.",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "integer"},
+			{Type: "null"},
+		},
 	}
 	properties["pageOffset"] = &jsonschema.Schema{
-		Type:        "integer",
 		Description: "The index position to start retrieving results from (not a page number).",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "integer"},
+			{Type: "null"},
+		},
 	}
 	return properties
 }

--- a/internal/twspaces/search.go
+++ b/internal/twspaces/search.go
@@ -35,15 +35,18 @@ func Search(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The search query string.",
 					},
 					"spaceIds": {
-						Type:        "array",
 						Description: "Limit search to specific space IDs. Use 'twspaces-list_spaces' to find valid IDs.",
-						Items: &jsonschema.Schema{
-							Type: "integer",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
 						},
 					},
 					"includeDeleted": {
-						Type:        "boolean",
 						Description: "Include deleted pages in search results.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
 					},
 				}),
 				Required: []string{"query"},

--- a/internal/twspaces/spaces.go
+++ b/internal/twspaces/spaces.go
@@ -78,6 +78,7 @@ func SpaceList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -120,25 +121,40 @@ func SpaceCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "A short unique code/identifier for the space (e.g. \"ENG\", \"DOCS\").",
 					},
 					"purpose": {
-						Type:        "string",
 						Description: "A brief description of the space's purpose.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"spaceColor": {
-						Type:        "string",
 						Description: "A hex color code for the space (e.g. \"#FF5733\").",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"icon": {
-						Type:        "string",
 						Description: "An icon identifier for the space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"projectId": {
-						Type:        "integer",
 						Description: "The ID of a Teamwork project to link to this space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"categoryId": {
-						Type: "integer",
 						Description: "The ID of the category to assign to this space. " +
 							"Use the 'twspaces-list_categories' tool to find valid IDs.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"title", "code"},
@@ -199,37 +215,61 @@ func SpaceUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the space to update.",
 					},
 					"title": {
-						Type:        "string",
 						Description: "The new title of the space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"code": {
-						Type:        "string",
 						Description: "A new short unique code/identifier for the space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"purpose": {
-						Type:        "string",
 						Description: "A new brief description of the space's purpose.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"spaceColor": {
-						Type:        "string",
 						Description: "A new hex color code for the space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"icon": {
-						Type:        "string",
 						Description: "A new icon identifier for the space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"state": {
-						Type:        "string",
 						Description: "The state of the space (e.g. \"active\", \"archived\").",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"projectId": {
-						Type:        "integer",
 						Description: "The ID of a Teamwork project to link to this space.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 					"categoryId": {
-						Type: "integer",
 						Description: "The ID of the category to assign to this space. " +
 							"Use the 'twspaces-list_categories' tool to find valid IDs.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},

--- a/internal/twspaces/tags.go
+++ b/internal/twspaces/tags.go
@@ -73,6 +73,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
+				Required:   []string{},
 			},
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -187,12 +188,18 @@ func TagUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the tag to update.",
 					},
 					"name": {
-						Type:        "string",
 						Description: "The new name for the tag.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 					"color": {
-						Type:        "string",
 						Description: "A new hex color code for the tag.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
 					},
 				},
 				Required: []string{"id"},


### PR DESCRIPTION
## Description

In OpenAI strict mode, all parameters MUST be provided, even if they are not required. Giving the `null` option for those parameters will help the OpenAI model to correctly call the tool.

https://developers.openai.com/api/docs/guides/structured-outputs#all-fields-must-be-required

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors