### PR TITLE
make clone project description less semantically similar to create project

### DIFF
--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -322,8 +322,7 @@ func ProjectClone(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name: string(MethodProjectClone),
-			Description: "Create a new project by cloning/copying an existing one or generating it from a project " +
-				"template. " + projectDescription,
+			Description: "Clone/copy an existing project or generate one from a project template. " + projectDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Clone Project",
 			},

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -321,7 +321,7 @@ func ProjectDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 func ProjectClone(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodProjectClone),
+			Name:        string(MethodProjectClone),
 			Description: "Clone/copy an existing project or generate one from a project template. " + projectDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Clone Project",


### PR DESCRIPTION
## Description
twprojects-create_project: "Create a new project in [Teamwork.com](http://teamwork.com/)."
twprojects-clone_project: "Create a new project by cloning/copying an existing one or generating it from a project template."
Both start with "Create a new project". [Claude.ai](http://claude.ai/)'s tool search is semantic/keyword-based across 174+ deferred tools. When searching for "create project", clone_project likely wins or crowds out create_project because its description has more semantic content around that phrase — it's more specific and detailed while also matching the same keywords.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors