### PR TITLE
Feature: mcp-http-cli - Add export-tools subcommand

### DIFF
--- a/cmd/mcp-http-cli/README.md
+++ b/cmd/mcp-http-cli/README.md
@@ -18,6 +18,7 @@ This CLI tool is designed for:
 - **Testing MCP tools**: Execute individual tools and see their responses
 - **Development and debugging**: Validate MCP server functionality during development
 - **Exploration**: Discover available tools and their parameters
+- **Exporting tool catalogues**: Dump every tool's full schema as JSON for downstream systems
 
 ## ✨ Features
 
@@ -85,6 +86,19 @@ Lists all available tools from the MCP server.
 
 ```bash
 go run cmd/mcp-http-cli/main.go list-tools
+```
+
+#### `export-tools`
+
+Dumps every tool's full schema (name, title, description, `inputSchema`,
+`outputSchema`, `annotations`, `_meta`) as a JSON object keyed by tool name.
+Logs are written to stderr, the JSON document to stdout, so you can redirect
+output directly to a file.
+
+```bash
+go run cmd/mcp-http-cli/main.go \
+  -mcp-url=https://my-mcp.example.com \
+  export-tools > mcp-tools.json
 ```
 
 #### `call-tool <tool-name> [parameters]`

--- a/cmd/mcp-http-cli/main.go
+++ b/cmd/mcp-http-cli/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ var (
 func main() {
 	defer handleExit()
 
-	resources, teardown := config.Load(os.Stdout)
+	resources, teardown := config.Load(os.Stderr)
 	defer teardown()
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
@@ -92,6 +93,43 @@ func main() {
 				slog.String("description", tool.Description),
 			)
 		}
+	case "export-tools":
+		toolsResult, err := mcpClientSession.ListTools(ctx, &mcp.ListToolsParams{})
+		if err != nil {
+			resources.Logger().Error("failed to list tools",
+				slog.String("error", err.Error()),
+			)
+			exit(exitCodeRunFailure)
+		}
+
+		out := make(map[string]any, len(toolsResult.Tools))
+		for _, tool := range toolsResult.Tools {
+			entry := map[string]any{
+				"description": tool.Description,
+				"title":       tool.Title,
+				"inputSchema": map[string]any{"jsonSchema": tool.InputSchema},
+				"type":        "dynamic",
+			}
+			if tool.OutputSchema != nil {
+				entry["outputSchema"] = map[string]any{"jsonSchema": tool.OutputSchema}
+			}
+			if tool.Annotations != nil {
+				entry["annotations"] = tool.Annotations
+			}
+			if tool.Meta != nil {
+				entry["_meta"] = tool.Meta
+			}
+			out[tool.Name] = entry
+		}
+
+		encoded, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			resources.Logger().Error("failed to marshal tools",
+				slog.String("error", err.Error()),
+			)
+			exit(exitCodeRunFailure)
+		}
+		fmt.Println(string(encoded))
 	case "call-tool":
 		if len(args) < 2 {
 			resources.Logger().Error("no tool name provided")
@@ -137,7 +175,7 @@ func main() {
 	default:
 		resources.Logger().Error("unknown command",
 			slog.String("command", args[0]),
-			slog.String("available_commands", "list-tools, call-tool"),
+			slog.String("available_commands", "list-tools, export-tools, call-tool"),
 		)
 		exit(exitCodeSetupFailure)
 	}


### PR DESCRIPTION
## Summary
- New \`export-tools\` subcommand on \`mcp-http-cli\` that dumps every tool's full schema (name, title, description, \`inputSchema\`, \`outputSchema\`, \`annotations\`, \`_meta\`) as a JSON object keyed by tool name.
- Logger output moved to stderr so stdout is pure JSON and can be redirected straight to a file.
- README updated with the new command and use case.

## Test plan
- [ ] \`go run ./cmd/mcp-http-cli -mcp-url=https://mcp.ai.teamwork.com export-tools > /tmp/mcp-tools.json\` produces valid JSON keyed by tool name with full schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)