### PR TITLE
Enhancement: Collapse list_X_by_Y tools into unified list_X tools

### DIFF
--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -18,8 +18,7 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodActivityList          toolsets.Method = "twprojects-list_activities"
-	MethodActivityListByProject toolsets.Method = "twprojects-list_activities_by_project"
+	MethodActivityList toolsets.Method = "twprojects-list_activities"
 )
 
 const activityDescription = "Activity is a record of actions and updates that occur across your projects, tasks, and " +
@@ -49,7 +48,7 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodActivityList),
-			Description: "List activities in Teamwork.com. " + activityDescription,
+			Description: "List activities in Teamwork.com. Provide project_id to scope to a specific project. " + activityDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Activities",
 				ReadOnlyHint: true,
@@ -57,6 +56,13 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Description: "The ID of the project to retrieve activities from. Omit to list activities across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"start_date": {
 						Description: "Start date to filter activities. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
 						AnyOf: []*jsonschema.Schema{
@@ -134,120 +140,7 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalTimeParam(&activityListRequest.Filters.StartDate, "start_date"),
-				helpers.OptionalTimeParam(&activityListRequest.Filters.EndDate, "end_date"),
-				helpers.OptionalListParam(&activityListRequest.Filters.LogItemTypes, "log_item_types"),
-				helpers.OptionalNumericParam(&activityListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&activityListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			activityList, err := projects.ActivityList(ctx, engine, activityListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list activities")
-			}
-			return helpers.NewToolResultJSON(activityList)
-		},
-	}
-}
-
-// ActivityListByProject lists activities by project in Teamwork.com.
-func ActivityListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodActivityListByProject),
-			Description: "List activities in Teamwork.com by project. " + activityDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Activities by Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project to retrieve activities from.",
-					},
-					"start_date": {
-						Description: "Start date to filter activities. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"end_date": {
-						Description: "End date to filter activities. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"log_item_types": {
-						Description: "Filter activities by item types.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "array",
-								Items: &jsonschema.Schema{
-									Type: "string",
-									Enum: []any{
-										"message",
-										"comment",
-										"task",
-										"tasklist",
-										"taskgroup",
-										"milestone",
-										"file",
-										"form",
-										"notebook",
-										"timelog",
-										"task_comment",
-										"notebook_comment",
-										"file_comment",
-										"link_comment",
-										"milestone_comment",
-										"project",
-										"link",
-										"billingInvoice",
-										"risk",
-										"projectUpdate",
-										"reacted",
-										"budget",
-									},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: activityListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var activityListRequest projects.ActivityListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&activityListRequest.Path.ProjectID, "project_id"),
+				helpers.OptionalNumericParam(&activityListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalTimeParam(&activityListRequest.Filters.StartDate, "start_date"),
 				helpers.OptionalTimeParam(&activityListRequest.Filters.EndDate, "end_date"),
 				helpers.OptionalListParam(&activityListRequest.Filters.LogItemTypes, "log_item_types"),

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -47,8 +47,11 @@ func init() {
 func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodActivityList),
-			Description: "List activities in Teamwork.com. Provide project_id to scope to a specific project. " + activityDescription,
+			Name: string(MethodActivityList),
+			Description: `
+				List activities in Teamwork.com. 
+				Provide project_id to scope to a specific project. 
+			` + activityDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Activities",
 				ReadOnlyHint: true,

--- a/internal/twprojects/activities_test.go
+++ b/internal/twprojects/activities_test.go
@@ -44,8 +44,8 @@ func TestActivityList(t *testing.T) {
 
 func TestActivityListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodActivityListByProject.String(), map[string]any{
-		"project_id": 123,
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodActivityList.String(), map[string]any{
+		"project_id": float64(123),
 		"start_date": "2023-10-01T00:00:00Z",
 		"end_date":   "2023-10-31T23:59:59Z",
 		"log_item_types": []any{

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -22,16 +22,11 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodCommentCreate            toolsets.Method = "twprojects-create_comment"
-	MethodCommentUpdate            toolsets.Method = "twprojects-update_comment"
-	MethodCommentDelete            toolsets.Method = "twprojects-delete_comment"
-	MethodCommentGet               toolsets.Method = "twprojects-get_comment"
-	MethodCommentList              toolsets.Method = "twprojects-list_comments"
-	MethodCommentListByFileVersion toolsets.Method = "twprojects-list_comments_by_file_version"
-	MethodCommentListByMilestone   toolsets.Method = "twprojects-list_comments_by_milestone"
-	MethodCommentListByNotebook    toolsets.Method = "twprojects-list_comments_by_notebook"
-	MethodCommentListByTask        toolsets.Method = "twprojects-list_comments_by_task"
-	MethodCommentListByLink        toolsets.Method = "twprojects-list_comments_by_link"
+	MethodCommentCreate toolsets.Method = "twprojects-create_comment"
+	MethodCommentUpdate toolsets.Method = "twprojects-update_comment"
+	MethodCommentDelete toolsets.Method = "twprojects-delete_comment"
+	MethodCommentGet    toolsets.Method = "twprojects-get_comment"
+	MethodCommentList   toolsets.Method = "twprojects-list_comments"
 )
 
 const commentDescription = "In the Teamwork.com context, a comment is a way for users to communicate and collaborate " +
@@ -522,8 +517,10 @@ func CommentGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodCommentList),
-			Description: "List comments in Teamwork.com. " + commentDescription,
+			Name: string(MethodCommentList),
+			Description: "List comments in Teamwork.com. Provide one of task_id, milestone_id, notebook_id, " +
+				"link_id, or file_version_id to scope to a specific object; omit all to list across all objects. " +
+				commentDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Comments",
 				ReadOnlyHint: true,
@@ -531,6 +528,42 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"task_id": {
+						Description: "The ID of the task to retrieve comments for. Provide this to scope comments to a task.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"milestone_id": {
+						Description: "The ID of the milestone to retrieve comments for. Provide this to scope comments to a milestone.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"notebook_id": {
+						Description: "The ID of the notebook to retrieve comments for. Provide this to scope comments to a notebook.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"link_id": {
+						Description: "The ID of the link to retrieve comments for. Provide this to scope comments to a link.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"file_version_id": {
+						Description: "The ID of the file version to retrieve comments for. Each file can have multiple versions, " +
+							"and comments can be associated with specific versions.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter comments by name.",
 						AnyOf: []*jsonschema.Schema{
@@ -574,487 +607,11 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			if commentListRequest.Filters.UpdatedAfter.IsZero() {
-				// default to last 3 months to improve performance
-				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
-			}
-
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list comments")
-			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
-		},
-	}
-}
-
-// CommentListByFileVersion lists comments by file version in Teamwork.com.
-func CommentListByFileVersion(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCommentListByFileVersion),
-			Description: "List comments in Teamwork.com by file version. " + commentDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Comments by File Version",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"file_version_id": {
-						Type: "integer",
-						Description: "The ID of the file version to retrieve comments for. Each file can have multiple versions, " +
-							"and comments can be associated with specific versions.",
-					},
-					"search_term": {
-						Description: "A search term to filter comments by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"file_version_id"},
-			},
-			OutputSchema: commentListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var commentListRequest projects.CommentListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&commentListRequest.Path.FileVersionID, "file_version_id"),
-				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			if commentListRequest.Filters.UpdatedAfter.IsZero() {
-				// default to last 3 months to improve performance
-				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
-			}
-
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list comments")
-			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
-		},
-	}
-}
-
-// CommentListByMilestone lists comments by milestone in Teamwork.com.
-func CommentListByMilestone(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCommentListByMilestone),
-			Description: "List comments in Teamwork.com by milestone. " + commentDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Comments by Milestone",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"milestone_id": {
-						Type:        "integer",
-						Description: "The ID of the milestone to retrieve comments for.",
-					},
-					"search_term": {
-						Description: "A search term to filter comments by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"milestone_id"},
-			},
-			OutputSchema: commentListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var commentListRequest projects.CommentListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&commentListRequest.Path.MilestoneID, "milestone_id"),
-				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			if commentListRequest.Filters.UpdatedAfter.IsZero() {
-				// default to last 3 months to improve performance
-				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
-			}
-
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list comments")
-			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
-		},
-	}
-}
-
-// CommentListByNotebook lists comments by notebook in Teamwork.com.
-func CommentListByNotebook(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCommentListByNotebook),
-			Description: "List comments in Teamwork.com by notebook. " + commentDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Comments by Notebook",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"notebook_id": {
-						Type:        "integer",
-						Description: "The ID of the notebook to retrieve comments for.",
-					},
-					"search_term": {
-						Description: "A search term to filter comments by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"notebook_id"},
-			},
-			OutputSchema: commentListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var commentListRequest projects.CommentListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&commentListRequest.Path.NotebookID, "notebook_id"),
-				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			if commentListRequest.Filters.UpdatedAfter.IsZero() {
-				// default to last 3 months to improve performance
-				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
-			}
-
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list comments")
-			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
-		},
-	}
-}
-
-// CommentListByTask lists comments by task in Teamwork.com.
-func CommentListByTask(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCommentListByTask),
-			Description: "List comments in Teamwork.com by task. " + commentDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Comments by Task",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"task_id": {
-						Type:        "integer",
-						Description: "The ID of the task to retrieve comments for.",
-					},
-					"search_term": {
-						Description: "A search term to filter comments by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"task_id"},
-			},
-			OutputSchema: commentListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var commentListRequest projects.CommentListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&commentListRequest.Path.TaskID, "task_id"),
-				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			if commentListRequest.Filters.UpdatedAfter.IsZero() {
-				// default to last 3 months to improve performance
-				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
-			}
-
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list comments")
-			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
-		},
-	}
-}
-
-// CommentListByLink lists comments by link in Teamwork.com.
-func CommentListByLink(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCommentListByLink),
-			Description: "List comments in Teamwork.com by link. " + commentDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Comments by Link",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"link_id": {
-						Type:        "integer",
-						Description: "The ID of the link to retrieve comments for.",
-					},
-					"search_term": {
-						Description: "A search term to filter comments by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"link_id"},
-			},
-			OutputSchema: commentListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var commentListRequest projects.CommentListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&commentListRequest.Path.LinkID, "link_id"),
+				helpers.OptionalNumericParam(&commentListRequest.Path.TaskID, "task_id"),
+				helpers.OptionalNumericParam(&commentListRequest.Path.MilestoneID, "milestone_id"),
+				helpers.OptionalNumericParam(&commentListRequest.Path.NotebookID, "notebook_id"),
+				helpers.OptionalNumericParam(&commentListRequest.Path.LinkID, "link_id"),
+				helpers.OptionalNumericParam(&commentListRequest.Path.FileVersionID, "file_version_id"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -63,7 +63,7 @@ func TestCommentList(t *testing.T) {
 
 func TestCommentListByFileVersion(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByFileVersion.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
 		"search_term":     "test",
 		"file_version_id": float64(123),
 		"updated_after":   "2025-01-01T00:00:00Z",
@@ -74,7 +74,7 @@ func TestCommentListByFileVersion(t *testing.T) {
 
 func TestCommentListByMilestone(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByMilestone.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
 		"search_term":   "test",
 		"milestone_id":  float64(123),
 		"updated_after": "2025-01-01T00:00:00Z",
@@ -85,7 +85,7 @@ func TestCommentListByMilestone(t *testing.T) {
 
 func TestCommentListByNotebook(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByNotebook.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
 		"search_term":   "test",
 		"notebook_id":   float64(123),
 		"updated_after": "2025-01-01T00:00:00Z",
@@ -96,7 +96,7 @@ func TestCommentListByNotebook(t *testing.T) {
 
 func TestCommentListByTask(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByTask.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
 		"search_term":   "test",
 		"task_id":       float64(123),
 		"updated_after": "2025-01-01T00:00:00Z",
@@ -107,7 +107,7 @@ func TestCommentListByTask(t *testing.T) {
 
 func TestCommentListByLink(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentListByLink.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
 		"search_term":   "test",
 		"link_id":       float64(123),
 		"updated_after": "2025-01-01T00:00:00Z",

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -432,8 +432,11 @@ func MilestoneGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodMilestoneList),
-			Description: "List milestones in Teamwork.com. Provide project_id to scope to a specific project. " + milestoneDescription,
+			Name: string(MethodMilestoneList),
+			Description: `
+				List milestones in Teamwork.com. 
+				Provide project_id to scope to a specific project. 
+			` + milestoneDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Milestones",
 				ReadOnlyHint: true,
@@ -442,7 +445,10 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_id": {
-						Description: "The ID of the project from which to retrieve milestones. Omit to list milestones across all projects.",
+						Description: `
+							The ID of the project from which to retrieve milestones. 
+							Omit to list milestones across all projects.
+						`,
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -18,12 +18,11 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodMilestoneCreate        toolsets.Method = "twprojects-create_milestone"
-	MethodMilestoneUpdate        toolsets.Method = "twprojects-update_milestone"
-	MethodMilestoneDelete        toolsets.Method = "twprojects-delete_milestone"
-	MethodMilestoneGet           toolsets.Method = "twprojects-get_milestone"
-	MethodMilestoneList          toolsets.Method = "twprojects-list_milestones"
-	MethodMilestoneListByProject toolsets.Method = "twprojects-list_milestones_by_project"
+	MethodMilestoneCreate toolsets.Method = "twprojects-create_milestone"
+	MethodMilestoneUpdate toolsets.Method = "twprojects-update_milestone"
+	MethodMilestoneDelete toolsets.Method = "twprojects-delete_milestone"
+	MethodMilestoneGet    toolsets.Method = "twprojects-get_milestone"
+	MethodMilestoneList   toolsets.Method = "twprojects-list_milestones"
 )
 
 const milestoneDescription = "In the context of Teamwork.com, a milestone represents a significant point or goal " +
@@ -434,7 +433,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMilestoneList),
-			Description: "List milestones in Teamwork.com. " + milestoneDescription,
+			Description: "List milestones in Teamwork.com. Provide project_id to scope to a specific project. " + milestoneDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Milestones",
 				ReadOnlyHint: true,
@@ -442,6 +441,13 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Description: "The ID of the project from which to retrieve milestones. Omit to list milestones across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter milestones by name. " +
 							"Each word from the search term is used to match against the milestone name and description. " +
@@ -495,112 +501,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalParam(&milestoneListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericListParam(&milestoneListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalPointerParam(&milestoneListRequest.Filters.MatchAllTags, "match_all_tags"),
-				helpers.OptionalNumericParam(&milestoneListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&milestoneListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			milestoneList, err := projects.MilestoneList(ctx, engine, milestoneListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list milestones")
-			}
-
-			encoded, err := json.Marshal(milestoneList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, milestoneList,
-					helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
-				),
-			}, nil
-		},
-	}
-}
-
-// MilestoneListByProject lists milestones in Teamwork.com by project.
-func MilestoneListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodMilestoneListByProject),
-			Description: "List milestones in Teamwork.com by project. " + milestoneDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Milestones by Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve milestones.",
-					},
-					"search_term": {
-						Description: "A search term to filter milestones by name. " +
-							"Each word from the search term is used to match against the milestone name and description. " +
-							"The milestone will be selected if each word of the term matches the milestone name or description, not " +
-							"requiring that the word matches are in the same field.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter milestones by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match milestones that have all the specified tags. " +
-							"If false, the search will match milestones that have any of the specified tags. " +
-							"Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: milestoneListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var milestoneListRequest projects.MilestoneListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&milestoneListRequest.Path.ProjectID, "project_id"),
+				helpers.OptionalNumericParam(&milestoneListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&milestoneListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&milestoneListRequest.Filters.TagIDs, "tag_ids"),
 				helpers.OptionalPointerParam(&milestoneListRequest.Filters.MatchAllTags, "match_all_tags"),

--- a/internal/twprojects/milestones_test.go
+++ b/internal/twprojects/milestones_test.go
@@ -69,7 +69,7 @@ func TestMilestoneList(t *testing.T) {
 
 func TestMilestoneListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMilestoneListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMilestoneList.String(), map[string]any{
 		"project_id":     float64(123),
 		"search_term":    "test",
 		"tag_ids":        []float64{1, 2, 3},

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -292,8 +292,11 @@ func TasklistGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodTasklistList),
-			Description: "List tasklists in Teamwork.com. Provide project_id to scope to a specific project. " + tasklistDescription,
+			Name: string(MethodTasklistList),
+			Description: `
+				List tasklists in Teamwork.com. 
+				Provide project_id to scope to a specific project. 
+			` + tasklistDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasklists",
 				ReadOnlyHint: true,
@@ -302,7 +305,10 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_id": {
-						Description: "The ID of the project from which to retrieve tasklists. Omit to list tasklists across all projects.",
+						Description: `
+							The ID of the project from which to retrieve tasklists. 
+							Omit to list tasklists across all projects.
+						`,
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -18,12 +18,11 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodTasklistCreate        toolsets.Method = "twprojects-create_tasklist"
-	MethodTasklistUpdate        toolsets.Method = "twprojects-update_tasklist"
-	MethodTasklistDelete        toolsets.Method = "twprojects-delete_tasklist"
-	MethodTasklistGet           toolsets.Method = "twprojects-get_tasklist"
-	MethodTasklistList          toolsets.Method = "twprojects-list_tasklists"
-	MethodTasklistListByProject toolsets.Method = "twprojects-list_tasklists_by_project"
+	MethodTasklistCreate toolsets.Method = "twprojects-create_tasklist"
+	MethodTasklistUpdate toolsets.Method = "twprojects-update_tasklist"
+	MethodTasklistDelete toolsets.Method = "twprojects-delete_tasklist"
+	MethodTasklistGet    toolsets.Method = "twprojects-get_tasklist"
+	MethodTasklistList   toolsets.Method = "twprojects-list_tasklists"
 )
 
 const tasklistDescription = "In the context of Teamwork.com, a task list is a way to group related tasks within a " +
@@ -294,7 +293,7 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistList),
-			Description: "List tasklists in Teamwork.com. " + tasklistDescription,
+			Description: "List tasklists in Teamwork.com. Provide project_id to scope to a specific project. " + tasklistDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasklists",
 				ReadOnlyHint: true,
@@ -302,6 +301,13 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Description: "The ID of the project from which to retrieve tasklists. Omit to list tasklists across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter tasklists by name.",
 						AnyOf: []*jsonschema.Schema{
@@ -336,91 +342,7 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalParam(&tasklistListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericParam(&tasklistListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&tasklistListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			tasklistList, err := projects.TasklistList(ctx, engine, tasklistListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list tasklists")
-			}
-
-			encoded, err := json.Marshal(tasklistList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, tasklistList,
-					helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
-				),
-			}, nil
-		},
-	}
-}
-
-// TasklistListByProject lists tasklists in Teamwork.com by project.
-func TasklistListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTasklistListByProject),
-			Description: "List tasklists in Teamwork.com by project. " + tasklistDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Tasklists By Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve tasklists.",
-					},
-					"search_term": {
-						Description: "A search term to filter tasklists by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: tasklistListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var tasklistListRequest projects.TasklistListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&tasklistListRequest.Path.ProjectID, "project_id"),
+				helpers.OptionalNumericParam(&tasklistListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&tasklistListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&tasklistListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&tasklistListRequest.Filters.PageSize, "page_size"),

--- a/internal/twprojects/tasklists_test.go
+++ b/internal/twprojects/tasklists_test.go
@@ -54,7 +54,7 @@ func TestTasklistList(t *testing.T) {
 
 func TestTasklistListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTasklistListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTasklistList.String(), map[string]any{
 		"search_term": "test",
 		"project_id":  float64(123),
 		"page":        float64(1),

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -18,14 +18,12 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodTaskCreate         toolsets.Method = "twprojects-create_task"
-	MethodTaskUpdate         toolsets.Method = "twprojects-update_task"
-	MethodTaskDelete         toolsets.Method = "twprojects-delete_task"
-	MethodTaskComplete       toolsets.Method = "twprojects-complete_task"
-	MethodTaskGet            toolsets.Method = "twprojects-get_task"
-	MethodTaskList           toolsets.Method = "twprojects-list_tasks"
-	MethodTaskListByTasklist toolsets.Method = "twprojects-list_tasks_by_tasklist"
-	MethodTaskListByProject  toolsets.Method = "twprojects-list_tasks_by_project"
+	MethodTaskCreate   toolsets.Method = "twprojects-create_task"
+	MethodTaskUpdate   toolsets.Method = "twprojects-update_task"
+	MethodTaskDelete   toolsets.Method = "twprojects-delete_task"
+	MethodTaskComplete toolsets.Method = "twprojects-complete_task"
+	MethodTaskGet      toolsets.Method = "twprojects-get_task"
+	MethodTaskList     toolsets.Method = "twprojects-list_tasks"
 )
 
 const taskDescription = "In Teamwork.com, a task represents an individual unit of work assigned to one or more team " +
@@ -966,8 +964,9 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodTaskList),
-			Description: "List tasks in Teamwork.com. " + taskDescription,
+			Name: string(MethodTaskList),
+			Description: "List tasks in Teamwork.com. Provide tasklist_id to scope to a specific tasklist, " +
+				"project_id to scope to a project, or neither to search across all tasks. " + taskDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasks",
 				ReadOnlyHint: true,
@@ -975,6 +974,20 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"tasklist_id": {
+						Description: "The ID of the tasklist from which to retrieve tasks. Takes precedence over project_id.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"project_id": {
+						Description: "The ID of the project from which to retrieve tasks. Omit to list tasks across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter tasks by name.",
 						AnyOf: []*jsonschema.Schema{
@@ -986,6 +999,21 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "A list of user IDs to filter tasks by assigned users",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
+						},
+					},
+					"tag_ids": {
+						Description: "A list of tag IDs to filter tasks by tags",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
+						},
+					},
+					"match_all_tags": {
+						Description: "If true, the search will match tasks that have all the specified tags. If false, the " +
+							"search will match tasks that have any of the specified tags. Defaults to false.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
 							{Type: "null"},
 						},
 					},
@@ -1037,21 +1065,6 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter tasks by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match tasks that have all the specified tags. If false, the " +
-							"search will match tasks that have any of the specified tags. Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
 					"page": {
 						Description: "Page number for pagination of results.",
 						AnyOf: []*jsonschema.Schema{
@@ -1079,8 +1092,12 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
+				helpers.OptionalNumericParam(&taskListRequest.Path.TasklistID, "tasklist_id"),
+				helpers.OptionalNumericParam(&taskListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&taskListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&taskListRequest.Filters.AssigneeUserIDs, "assignee_user_ids"),
+				helpers.OptionalNumericListParam(&taskListRequest.Filters.TagIDs, "tag_ids"),
+				helpers.OptionalPointerParam(&taskListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&taskListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&taskListRequest.Filters.PageSize, "page_size"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CreatedAfter, "created_after"),
@@ -1089,228 +1106,6 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.UpdatedBefore, "updated_before"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedAfter, "completed_after"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedBefore, "completed_before"),
-				helpers.OptionalNumericListParam(&taskListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalPointerParam(&taskListRequest.Filters.MatchAllTags, "match_all_tags"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			taskList, err := projects.TaskList(ctx, engine, taskListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list tasks")
-			}
-
-			encoded, err := json.Marshal(taskList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
-					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-				),
-			}, nil
-		},
-	}
-}
-
-// TaskListByTasklist lists tasks in Teamwork.com by tasklist.
-func TaskListByTasklist(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTaskListByTasklist),
-			Description: "List tasks in Teamwork.com by tasklist. " + taskDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Tasks By Tasklist",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"tasklist_id": {
-						Type:        "integer",
-						Description: "The ID of the tasklist from which to retrieve tasks.",
-					},
-					"search_term": {
-						Description: "A search term to filter tasks by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter tasks by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assignee_user_ids": {
-						Description: "A list of user IDs to filter tasks by assigned users",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match tasks that have all the specified tags. If false, the " +
-							"search will match tasks that have any of the specified tags. Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"tasklist_id"},
-			},
-			OutputSchema: taskListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var taskListRequest projects.TaskListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&taskListRequest.Path.TasklistID, "tasklist_id"),
-				helpers.OptionalParam(&taskListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericListParam(&taskListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalNumericListParam(&taskListRequest.Filters.AssigneeUserIDs, "assignee_user_ids"),
-				helpers.OptionalPointerParam(&taskListRequest.Filters.MatchAllTags, "match_all_tags"),
-				helpers.OptionalNumericParam(&taskListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&taskListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			taskList, err := projects.TaskList(ctx, engine, taskListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list tasks")
-			}
-
-			encoded, err := json.Marshal(taskList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
-					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-				),
-			}, nil
-		},
-	}
-}
-
-// TaskListByProject lists tasks in Teamwork.com by project.
-func TaskListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTaskListByProject),
-			Description: "List tasks in Teamwork.com by project. " + taskDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Tasks By Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve tasks.",
-					},
-					"search_term": {
-						Description: "A search term to filter tasks by name.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter tasks by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assignee_user_ids": {
-						Description: "A list of user IDs to filter tasks by assigned users",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match tasks that have all the specified tags. If false, the " +
-							"search will match tasks that have any of the specified tags. Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: taskListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var taskListRequest projects.TaskListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&taskListRequest.Path.ProjectID, "project_id"),
-				helpers.OptionalParam(&taskListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericListParam(&taskListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalNumericListParam(&taskListRequest.Filters.AssigneeUserIDs, "assignee_user_ids"),
-				helpers.OptionalPointerParam(&taskListRequest.Filters.MatchAllTags, "match_all_tags"),
-				helpers.OptionalNumericParam(&taskListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&taskListRequest.Filters.PageSize, "page_size"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -108,7 +108,7 @@ func TestTaskList(t *testing.T) {
 
 func TestTaskListByTasklist(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskListByTasklist.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskList.String(), map[string]any{
 		"tasklist_id":       float64(123),
 		"search_term":       "test",
 		"tag_ids":           []float64{1, 2, 3},
@@ -121,7 +121,7 @@ func TestTaskListByTasklist(t *testing.T) {
 
 func TestTaskListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskList.String(), map[string]any{
 		"project_id":        float64(123),
 		"search_term":       "test",
 		"assignee_user_ids": []float64{4, 5, 6},

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -366,8 +366,11 @@ func TeamGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodTeamList),
-			Description: "List teams in Teamwork.com. Provide company_id or project_id to scope to a specific company or project. " + teamDescription,
+			Name: string(MethodTeamList),
+			Description: `
+				List teams in Teamwork.com. 
+				Provide company_id or project_id to scope to a specific company or project. 
+			` + teamDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Teams",
 				ReadOnlyHint: true,
@@ -376,7 +379,10 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"company_id": {
-						Description: "The ID of the company from which to retrieve teams. Omit to list teams across all companies.",
+						Description: `
+							The ID of the company from which to retrieve teams. 
+							Omit to list teams across all companies.
+						`,
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -19,13 +19,11 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodTeamCreate        toolsets.Method = "twprojects-create_team"
-	MethodTeamUpdate        toolsets.Method = "twprojects-update_team"
-	MethodTeamDelete        toolsets.Method = "twprojects-delete_team"
-	MethodTeamGet           toolsets.Method = "twprojects-get_team"
-	MethodTeamList          toolsets.Method = "twprojects-list_teams"
-	MethodTeamListByCompany toolsets.Method = "twprojects-list_teams_by_company"
-	MethodTeamListByProject toolsets.Method = "twprojects-list_teams_by_project"
+	MethodTeamCreate toolsets.Method = "twprojects-create_team"
+	MethodTeamUpdate toolsets.Method = "twprojects-update_team"
+	MethodTeamDelete toolsets.Method = "twprojects-delete_team"
+	MethodTeamGet    toolsets.Method = "twprojects-get_team"
+	MethodTeamList   toolsets.Method = "twprojects-list_teams"
 )
 
 const teamDescription = "In the context of Teamwork.com, a team is a group of users who are organized together to " +
@@ -369,7 +367,7 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTeamList),
-			Description: "List teams in Teamwork.com. " + teamDescription,
+			Description: "List teams in Teamwork.com. Provide company_id or project_id to scope to a specific company or project. " + teamDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Teams",
 				ReadOnlyHint: true,
@@ -377,6 +375,20 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"company_id": {
+						Description: "The ID of the company from which to retrieve teams. Omit to list teams across all companies.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"project_id": {
+						Description: "The ID of the project from which to retrieve teams. Omit to list teams across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter teams by name or handle.",
 						AnyOf: []*jsonschema.Schema{
@@ -406,16 +418,13 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var teamListRequest projects.TeamListRequest
 
-			// to simplify the teams logic for the LLM, always return all team types
-			teamListRequest.Filters.IncludeCompanyTeams = true
-			teamListRequest.Filters.IncludeProjectTeams = true
-			teamListRequest.Filters.IncludeSubteams = true
-
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
+				helpers.OptionalNumericParam(&teamListRequest.Path.CompanyID, "company_id"),
+				helpers.OptionalNumericParam(&teamListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&teamListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&teamListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&teamListRequest.Filters.PageSize, "page_size"),
@@ -424,174 +433,11 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			teamList, err := projects.TeamList(ctx, engine, teamListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list teams")
-			}
-
-			encoded, err := json.Marshal(teamList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
-					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-				),
-			}, nil
-		},
-	}
-}
-
-// TeamListByCompany lists teams in Teamwork.com by client/company.
-func TeamListByCompany(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTeamListByCompany),
-			Description: "List teams in Teamwork.com by client/company. " + teamDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Teams By Company",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"company_id": {
-						Type:        "integer",
-						Description: "The ID of the company from which to retrieve teams.",
-					},
-					"search_term": {
-						Description: "A search term to filter teams by name or handle.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"company_id"},
-			},
-			OutputSchema: teamListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var teamListRequest projects.TeamListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&teamListRequest.Path.CompanyID, "company_id"),
-				helpers.OptionalParam(&teamListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericParam(&teamListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&teamListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			teamList, err := projects.TeamList(ctx, engine, teamListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list teams")
-			}
-
-			encoded, err := json.Marshal(teamList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
-					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-				),
-			}, nil
-		},
-	}
-}
-
-// TeamListByProject lists teams in Teamwork.com by project.
-func TeamListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTeamListByProject),
-			Description: "List teams in Teamwork.com by project. " + teamDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Teams By Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve teams.",
-					},
-					"search_term": {
-						Description: "A search term to filter teams by name or handle.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: teamListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var teamListRequest projects.TeamListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&teamListRequest.Path.ProjectID, "project_id"),
-				helpers.OptionalParam(&teamListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalNumericParam(&teamListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&teamListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
+			// when no scoping ID is provided, include all team types for a complete global listing
+			if teamListRequest.Path.CompanyID == 0 && teamListRequest.Path.ProjectID == 0 {
+				teamListRequest.Filters.IncludeCompanyTeams = true
+				teamListRequest.Filters.IncludeProjectTeams = true
+				teamListRequest.Filters.IncludeSubteams = true
 			}
 
 			teamList, err := projects.TeamList(ctx, engine, teamListRequest)

--- a/internal/twprojects/teams_test.go
+++ b/internal/twprojects/teams_test.go
@@ -68,7 +68,7 @@ func TestTeamList(t *testing.T) {
 
 func TestTeamListByCompany(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTeamListByCompany.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTeamList.String(), map[string]any{
 		"company_id":  float64(123),
 		"search_term": "test",
 		"page":        float64(1),
@@ -78,7 +78,7 @@ func TestTeamListByCompany(t *testing.T) {
 
 func TestTeamListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTeamListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTeamList.String(), map[string]any{
 		"project_id":  float64(123),
 		"search_term": "test",
 		"page":        float64(1),

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -405,8 +405,11 @@ func TimelogGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodTimelogList),
-			Description: "List timelogs in Teamwork.com. Provide project_id or task_id to scope to a specific project or task. " + timelogDescription,
+			Name: string(MethodTimelogList),
+			Description: `
+				List timelogs in Teamwork.com. 
+				Provide project_id or task_id to scope to a specific project or task. 
+			` + timelogDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Timelogs",
 				ReadOnlyHint: true,
@@ -415,7 +418,10 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_id": {
-						Description: "The ID of the project from which to retrieve timelogs. Omit to list timelogs across all projects.",
+						Description: `
+							The ID of the project from which to retrieve timelogs. 
+							Omit to list timelogs across all projects.
+						`,
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -18,13 +18,11 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodTimelogCreate        toolsets.Method = "twprojects-create_timelog"
-	MethodTimelogUpdate        toolsets.Method = "twprojects-update_timelog"
-	MethodTimelogDelete        toolsets.Method = "twprojects-delete_timelog"
-	MethodTimelogGet           toolsets.Method = "twprojects-get_timelog"
-	MethodTimelogList          toolsets.Method = "twprojects-list_timelogs"
-	MethodTimelogListByProject toolsets.Method = "twprojects-list_timelogs_by_project"
-	MethodTimelogListByTask    toolsets.Method = "twprojects-list_timelogs_by_task"
+	MethodTimelogCreate toolsets.Method = "twprojects-create_timelog"
+	MethodTimelogUpdate toolsets.Method = "twprojects-update_timelog"
+	MethodTimelogDelete toolsets.Method = "twprojects-delete_timelog"
+	MethodTimelogGet    toolsets.Method = "twprojects-get_timelog"
+	MethodTimelogList   toolsets.Method = "twprojects-list_timelogs"
 )
 
 const timelogDescription = "Timelog refers to a recorded entry that tracks the amount of time a person has spent " +
@@ -408,7 +406,7 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimelogList),
-			Description: "List timelogs in Teamwork.com. " + timelogDescription,
+			Description: "List timelogs in Teamwork.com. Provide project_id or task_id to scope to a specific project or task. " + timelogDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Timelogs",
 				ReadOnlyHint: true,
@@ -416,6 +414,20 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Description: "The ID of the project from which to retrieve timelogs. Omit to list timelogs across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
+					"task_id": {
+						Description: "The ID of the task from which to retrieve timelogs. Omit to list timelogs across all tasks.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"tag_ids": {
 						Description: "A list of tag IDs to filter timelogs by tags",
 						AnyOf: []*jsonschema.Schema{
@@ -500,258 +512,8 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalPointerParam(&timelogListRequest.Filters.MatchAllTags, "match_all_tags"),
-				helpers.OptionalTimePointerParam(&timelogListRequest.Filters.StartDate, "start_date"),
-				helpers.OptionalTimePointerParam(&timelogListRequest.Filters.EndDate, "end_date"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToUserIDs, "assigned_user_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToCompanyIDs, "assigned_company_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToTeamIDs, "assigned_team_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.DeskTicketIDs, "ticketIds"),
-				helpers.OptionalNumericParam(&timelogListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&timelogListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			timelogList, err := projects.TimelogList(ctx, engine, timelogListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list timelogs")
-			}
-			return helpers.NewToolResultJSON(timelogList)
-		},
-	}
-}
-
-// TimelogListByProject lists timelogs in Teamwork.com by project.
-func TimelogListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTimelogListByProject),
-			Description: "List timelogs in Teamwork.com by project. " + timelogDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Timelogs By Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve timelogs.",
-					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter timelogs by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match timelogs that have all the specified tags. If false, the " +
-							"search will match timelogs that have any of the specified tags. Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
-					"start_date": {
-						Description: "Start date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"end_date": {
-						Description: "End date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"assigned_user_ids": {
-						Description: "A list of user IDs to filter timelogs by assigned users",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assigned_company_ids": {
-						Description: "A list of company IDs to filter timelogs by assigned companies",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assigned_team_ids": {
-						Description: "A list of team IDs to filter timelogs by assigned teams",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"ticketIds": {
-						Description: "A list of desk ticket IDs to filter timelogs by associated desk tickets",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: timelogListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var timelogListRequest projects.TimelogListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&timelogListRequest.Path.ProjectID, "project_id"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.TagIDs, "tag_ids"),
-				helpers.OptionalPointerParam(&timelogListRequest.Filters.MatchAllTags, "match_all_tags"),
-				helpers.OptionalTimePointerParam(&timelogListRequest.Filters.StartDate, "start_date"),
-				helpers.OptionalTimePointerParam(&timelogListRequest.Filters.EndDate, "end_date"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToUserIDs, "assigned_user_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToCompanyIDs, "assigned_company_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToTeamIDs, "assigned_team_ids"),
-				helpers.OptionalNumericListParam(&timelogListRequest.Filters.DeskTicketIDs, "ticketIds"),
-				helpers.OptionalNumericParam(&timelogListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&timelogListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			timelogList, err := projects.TimelogList(ctx, engine, timelogListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list timelogs")
-			}
-			return helpers.NewToolResultJSON(timelogList)
-		},
-	}
-}
-
-// TimelogListByTask lists timelogs in Teamwork.com by task.
-func TimelogListByTask(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodTimelogListByTask),
-			Description: "List timelogs in Teamwork.com by task. " + timelogDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Timelogs By Task",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"task_id": {
-						Type:        "integer",
-						Description: "The ID of the task from which to retrieve timelogs.",
-					},
-					"tag_ids": {
-						Description: "A list of tag IDs to filter timelogs by tags",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"match_all_tags": {
-						Description: "If true, the search will match timelogs that have all the specified tags. If false, the " +
-							"search will match timelogs that have any of the specified tags. Defaults to false.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "boolean"},
-							{Type: "null"},
-						},
-					},
-					"start_date": {
-						Description: "Start date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"end_date": {
-						Description: "End date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"assigned_user_ids": {
-						Description: "A list of user IDs to filter timelogs by assigned users",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assigned_company_ids": {
-						Description: "A list of company IDs to filter timelogs by assigned companies",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"assigned_team_ids": {
-						Description: "A list of team IDs to filter timelogs by assigned teams",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"ticketIds": {
-						Description: "A list of desk ticket IDs to filter timelogs by associated desk tickets",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"task_id"},
-			},
-			OutputSchema: timelogListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var timelogListRequest projects.TimelogListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&timelogListRequest.Path.TaskID, "task_id"),
+				helpers.OptionalNumericParam(&timelogListRequest.Path.ProjectID, "project_id"),
+				helpers.OptionalNumericParam(&timelogListRequest.Path.TaskID, "task_id"),
 				helpers.OptionalNumericListParam(&timelogListRequest.Filters.TagIDs, "tag_ids"),
 				helpers.OptionalPointerParam(&timelogListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalTimePointerParam(&timelogListRequest.Filters.StartDate, "start_date"),

--- a/internal/twprojects/timelogs_test.go
+++ b/internal/twprojects/timelogs_test.go
@@ -74,7 +74,7 @@ func TestTimelogList(t *testing.T) {
 
 func TestTimelogListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogList.String(), map[string]any{
 		"project_id":           float64(123),
 		"tag_ids":              []float64{1, 2, 3},
 		"match_all_tags":       true,
@@ -90,7 +90,7 @@ func TestTimelogListByProject(t *testing.T) {
 
 func TestTimelogListByTask(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogListByTask.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogList.String(), map[string]any{
 		"task_id":              float64(123),
 		"tag_ids":              []float64{1, 2, 3},
 		"match_all_tags":       true,

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -92,11 +92,8 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 		AddReadTools(
 			TaskGet(engine),
 			TaskList(engine),
-			TaskListByProject(engine),
-			TaskListByTasklist(engine),
 			TasklistGet(engine),
 			TasklistList(engine),
-			TasklistListByProject(engine),
 			WorkflowGet(engine),
 			WorkflowList(engine),
 			WorkflowStageGet(engine),
@@ -139,12 +136,9 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			SkillList(engine),
 			TeamGet(engine),
 			TeamList(engine),
-			TeamListByCompany(engine),
-			TeamListByProject(engine),
 			UserGet(engine),
 			UserGetMe(engine),
 			UserList(engine),
-			UserListByProject(engine),
 			UsersWorkload(engine),
 		)
 	group.AddToolset(peopleToolset)
@@ -172,8 +166,6 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			TasklistBudgetList(engine),
 			TimelogGet(engine),
 			TimelogList(engine),
-			TimelogListByProject(engine),
-			TimelogListByTask(engine),
 			TimerGet(engine),
 			TimerList(engine),
 		)
@@ -214,17 +206,10 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 		AddWriteTools(contentWriteTools...).
 		AddReadTools(
 			ActivityList(engine),
-			ActivityListByProject(engine),
 			CommentGet(engine),
 			CommentList(engine),
-			CommentListByFileVersion(engine),
-			CommentListByMilestone(engine),
-			CommentListByNotebook(engine),
-			CommentListByTask(engine),
-			CommentListByLink(engine),
 			MilestoneGet(engine),
 			MilestoneList(engine),
-			MilestoneListByProject(engine),
 			NotebookGet(engine),
 			NotebookList(engine),
 			TagGet(engine),

--- a/internal/twprojects/users.go
+++ b/internal/twprojects/users.go
@@ -18,13 +18,12 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodUserCreate        toolsets.Method = "twprojects-create_user"
-	MethodUserUpdate        toolsets.Method = "twprojects-update_user"
-	MethodUserDelete        toolsets.Method = "twprojects-delete_user"
-	MethodUserGet           toolsets.Method = "twprojects-get_user"
-	MethodUserGetMe         toolsets.Method = "twprojects-get_user_me"
-	MethodUserList          toolsets.Method = "twprojects-list_users"
-	MethodUserListByProject toolsets.Method = "twprojects-list_users_by_project"
+	MethodUserCreate toolsets.Method = "twprojects-create_user"
+	MethodUserUpdate toolsets.Method = "twprojects-update_user"
+	MethodUserDelete toolsets.Method = "twprojects-delete_user"
+	MethodUserGet    toolsets.Method = "twprojects-get_user"
+	MethodUserGetMe  toolsets.Method = "twprojects-get_user_me"
+	MethodUserList   toolsets.Method = "twprojects-list_users"
 )
 
 const userDescription = "A user is an individual who has access to one or more projects within a Teamwork site, " +
@@ -401,7 +400,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserList),
-			Description: "List users in Teamwork.com. " + userDescription,
+			Description: "List users in Teamwork.com. Provide project_id to scope to a specific project. " + userDescription,
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Users",
 				ReadOnlyHint: true,
@@ -409,6 +408,13 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Description: "The ID of the project from which to retrieve users. Omit to list users across all projects.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"search_term": {
 						Description: "A search term to filter users by first or last names, or e-mail. " +
 							"The user will be selected if each word of the term matches the first or last name, or e-mail, not " +
@@ -452,103 +458,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 			err := helpers.ParamGroup(arguments,
-				helpers.OptionalParam(&userListRequest.Filters.SearchTerm, "search_term"),
-				helpers.OptionalParam(&userListRequest.Filters.Type, "type",
-					helpers.RestrictValues("account", "collaborator", "contact"),
-				),
-				helpers.OptionalNumericParam(&userListRequest.Filters.Page, "page"),
-				helpers.OptionalNumericParam(&userListRequest.Filters.PageSize, "page_size"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			userList, err := projects.UserList(ctx, engine, userListRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list users")
-			}
-
-			encoded, err := json.Marshal(userList)
-			if err != nil {
-				return nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/people"),
-						)),
-					},
-				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, userList,
-					helpers.WebLinkerWithIDPathBuilder("/app/people"),
-				),
-			}, nil
-		},
-	}
-}
-
-// UserListByProject lists users in Teamwork.com by project.
-func UserListByProject(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodUserListByProject),
-			Description: "List users in Teamwork.com by project. " + userDescription,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Users By Project",
-				ReadOnlyHint: true,
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"project_id": {
-						Type:        "integer",
-						Description: "The ID of the project from which to retrieve users.",
-					},
-					"search_term": {
-						Description: "A search term to filter users by first or last names, or e-mail. " +
-							"The user will be selected if each word of the term matches the first or last name, or e-mail, not " +
-							"requiring that the word matches are in the same field.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"type": {
-						Description: "Type of user to filter by. The available options are account, collaborator or contact.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string"},
-							{Type: "null"},
-						},
-					},
-					"page": {
-						Description: "Page number for pagination of results.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-					"page_size": {
-						Description: "Number of results per page for pagination.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "integer"},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"project_id"},
-			},
-			OutputSchema: userListOutputSchema,
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var userListRequest projects.UserListRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&userListRequest.Path.ProjectID, "project_id"),
+				helpers.OptionalNumericParam(&userListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&userListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalParam(&userListRequest.Filters.Type, "type",
 					helpers.RestrictValues("account", "collaborator", "contact"),

--- a/internal/twprojects/users_test.go
+++ b/internal/twprojects/users_test.go
@@ -68,7 +68,7 @@ func TestUserList(t *testing.T) {
 
 func TestUserListByProject(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodUserListByProject.String(), map[string]any{
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodUserList.String(), map[string]any{
 		"project_id":  float64(123),
 		"search_term": "test",
 		"type":        "account",


### PR DESCRIPTION
Remove 13 redundant scoped list tools from twprojects by making the scoping ID an optional parameter on the base list tool instead. Models no longer need to pre-select a variant before knowing which ID they have — they call one tool and provide the ID when available.

Affected tools (now unified):
- list_activities (+optional project_id)
- list_comments (+optional task_id, milestone_id, notebook_id, link_id, file_version_id)
- list_milestones (+optional project_id)
- list_tasklists (+optional project_id)
- list_tasks (+optional project_id, tasklist_id)
- list_teams (+optional company_id, project_id)
- list_timelogs (+optional project_id, task_id)
- list_users (+optional project_id)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors