### PR TITLE
Enhancement: Simplify twprojects tool descriptions

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,285 @@
+# Teamwork.com Glossary
+
+Definitions of the core entities exposed by the Teamwork MCP server. Useful as
+context for skills, prompts, or onboarding documentation. Tool descriptions in
+the MCP server itself are intentionally terse — drop any of these blurbs into a
+system prompt or skill if a richer entity definition is needed.
+
+Entries are listed alphabetically.
+
+## Activity
+
+Activity is a record of actions and updates that occur across your projects,
+tasks, and communications, giving you a clear view of what's happening within
+your workspace. Activities capture changes such as task completions, activities
+added, files uploaded, or milestones updated, and present them in a
+chronological feed so teams can stay aligned without needing to check each
+individual project or task. This stream of information helps improve
+transparency, ensures accountability, and keeps everyone aware of progress and
+decisions as they happen.
+
+## Comment
+
+In the Teamwork.com context, a comment is a way for users to communicate and
+collaborate directly within tasks, milestones, files, or other project items.
+Comments allow team members to provide updates, ask questions, give feedback,
+or share relevant information in a centralized and contextual manner. They
+support rich text formatting, file attachments, and @mentions to notify
+specific users or teams, helping keep discussions organized and easily
+accessible within the project. Comments are visible to all users with access
+to the item, promoting transparency and keeping everyone aligned.
+
+## Company (Client)
+
+In the context of Teamwork.com, a company represents an organization or
+business entity that can be associated with users, projects, and tasks within
+the platform, and it is often referred to as a "client." It serves as a way to
+group related users and projects under a single organizational umbrella,
+making it easier to manage permissions, assign responsibilities, and organize
+work. Companies (or clients) are frequently used to distinguish between
+internal teams and external collaborators, enabling teams to work efficiently
+while maintaining clear boundaries around ownership, visibility, and access
+levels across different projects.
+
+## Industry
+
+Industry refers to the business sector or market category that a company
+belongs to, such as technology, healthcare, finance, or education. It helps
+provide context about the nature of a company's work and can be used to better
+organize and filter data across the platform. By associating companies and
+projects with specific industries, Teamwork.com allows teams to gain clearer
+insights, tailor communication, and segment information in ways that make it
+easier to manage relationships and understand the broader business landscape
+in which their clients and partners operate.
+
+## Job role
+
+Job role defines a user's primary function or position within the
+organization, such as developer, designer, project manager, or account
+manager. It provides high-level context about what a person is generally
+responsible for, helping teams understand who does what across projects and
+departments. Job roles are commonly used in resource planning, capacity
+forecasting, and reporting, allowing managers to group work by role, plan
+future demand more accurately, and ensure the right mix of roles is available
+to deliver projects efficiently.
+
+## Link
+
+In the context of Teamwork.com, a link is a saved URL attached to a project,
+task, or other item, allowing users to quickly reference and access external
+resources (such as documents, tools, or websites) directly within their
+workflow.
+
+## Message
+
+In the context of Teamwork.com, a message is a structured communication post
+within a project that allows team members to share updates, discuss topics,
+and document decisions in a centralized, threaded format. It includes a title,
+a detailed message body, and replies from collaborators, all tied to the
+project for clear context and visibility, making it ideal for important
+discussions that need to be organized and easily referenced over time.
+
+## Message reply
+
+In the context of Teamwork.com, a message reply is a response within a project
+message thread that allows team members to contribute to the discussion, ask
+questions, or provide updates while keeping all communication organized under
+the original message. Replies maintain context by staying linked to the main
+topic, include the author and timestamp, and help create a clear, ongoing
+conversation that is easy for everyone involved to follow and reference.
+
+## Milestone
+
+In the context of Teamwork.com, a milestone represents a significant point or
+goal within a project that marks the completion of a major phase or a key
+deliverable. It acts as a high-level indicator of progress, helping teams
+track whether work is advancing according to plan. Milestones are typically
+used to coordinate efforts across different tasks and task lists, providing a
+clear deadline or objective that multiple team members or departments can
+align around. They don't contain individual tasks themselves but serve as
+checkpoints to ensure the project is moving in the right direction.
+
+## Notebook
+
+Notebook is a space where teams can create, share, and organize written
+content in a structured way. It's commonly used for documenting processes,
+storing meeting notes, capturing research, or drafting ideas that need to be
+revisited and refined over time. Unlike quick messages or task comments,
+notebooks provide a more permanent and organized format that can be easily
+searched and referenced, helping teams maintain a centralized source of
+knowledge and ensuring important information remains accessible to everyone
+who needs it.
+
+## Project
+
+The project feature in Teamwork.com serves as the central workspace for
+organizing and managing a specific piece of work or initiative. Each project
+provides a dedicated area where teams can plan tasks, assign responsibilities,
+set deadlines, and track progress toward shared goals. Projects include tools
+for communication, file sharing, milestones, and time tracking, allowing teams
+to stay aligned and informed throughout the entire lifecycle of the work.
+Whether it's a product launch, client engagement, or internal initiative,
+projects in Teamwork.com help teams structure their efforts, collaborate more
+effectively, and deliver results with greater visibility and accountability.
+
+## Project budget
+
+In the context of Teamwork.com, a project budget defines the overall budget
+allocation for a project, including capacity and usage tracking over time. It
+can be scoped by status and project, enabling teams to monitor financial or
+effort limits, track consumption, and understand budget performance across
+active, upcoming, and completed budget periods.
+
+## Project category
+
+The project category is a way to group and label related projects so teams can
+organize their work more clearly across the platform. By assigning a category,
+you create a higher-level structure that makes it easier to filter, report
+on, and navigate multiple projects, ensuring that departments, workflows, or
+strategic areas remain neatly aligned and easier to manage.
+
+## Project member
+
+In the context of Teamwork.com, a project member is a user who is assigned to
+a specific project. Project members can have different roles and permissions
+within the project, allowing them to collaborate on tasks, view project
+details, and contribute to the project's success. Managing project members
+effectively is crucial for ensuring that the right people are involved in the
+right tasks, and it helps maintain accountability and clarity throughout the
+project's lifecycle.
+
+## Project template
+
+The project template is a reusable project structure designed to standardize
+workflows and streamline project setup. It typically includes predefined
+tasks, task lists, milestones, and timelines that reflect a repeatable
+process, allowing teams to quickly spin up new projects with consistent
+organization, clear responsibilities, and efficient execution from the start.
+
+## Search
+
+Search is a feature that allows users to quickly find projects, tasks, files,
+messages, and other items across their workspace by entering keywords, helping
+them locate information and navigate their work efficiently from a single
+place.
+
+## Skill
+
+Skill represents a specific capability, area of expertise, or proficiency that
+can be assigned to users to describe what they are good at or qualified to
+work on. Skills help teams understand the strengths available across the
+organization and make it easier to match the right skills to the right work
+when planning projects, assigning tasks, or managing resources. By associating
+skills with users and leveraging them in planning and reporting, Teamwork
+enables more effective workload distribution, better project outcomes, and
+clearer visibility into whether the team has the capabilities needed to
+deliver upcoming work.
+
+## Tag
+
+In the context of Teamwork.com, a tag is a customizable label that can be
+applied to various items such as tasks, projects, milestones, messages, and
+more, to help categorize and organize work efficiently. Tags provide a
+flexible way to filter, search, and group related items across the platform,
+making it easier for teams to manage complex workflows, highlight priorities,
+or track themes and statuses. Since tags are user-defined, they adapt to each
+team's specific needs and can be color-coded for better visual clarity.
+
+## Task
+
+In Teamwork.com, a task represents an individual unit of work assigned to one
+or more team members within a project. Each task can include details such as
+a title, description, priority, estimated time, assignees, and due date,
+along with the ability to attach files, leave comments, track time, and set
+dependencies on other tasks. Tasks are organized within task lists, helping
+structure and sequence work logically. They serve as the building blocks of
+project management in Teamwork, allowing teams to collaborate, monitor
+progress, and ensure accountability throughout the project's lifecycle.
+
+## Tasklist
+
+In the context of Teamwork.com, a task list is a way to group related tasks
+within a project, helping teams organize their work into meaningful sections
+such as phases, categories, or deliverables. Each task list belongs to a
+specific project and can include multiple tasks that are typically aligned
+with a common goal. Task lists can be associated with milestones, and they
+support privacy settings that control who can view or interact with the tasks
+they contain. This structure helps teams manage progress, assign
+responsibilities, and maintain clarity across complex projects.
+
+## Tasklist budget
+
+In the context of Teamwork.com, a tasklist budget is a budget allocation
+attached to a specific task list within a project budget. It tracks capacity
+(in time or money) assigned to and consumed by a task list, helping teams
+monitor spend and effort at a granular level within a broader project budget.
+
+## Team
+
+In the context of Teamwork.com, a team is a group of users who are organized
+together to collaborate more efficiently on projects and tasks. Teams help
+structure work by grouping individuals with similar roles, responsibilities,
+or departmental functions, making it easier to assign work, track progress,
+and manage communication. By using teams, organizations can streamline
+project planning and ensure the right people are involved in the right parts
+of a project, enhancing clarity and accountability across the platform.
+
+## Timelog
+
+Timelog refers to a recorded entry that tracks the amount of time a person has
+spent working on a specific task, project, or piece of work. These entries
+typically include details such as the duration of time worked, the date and
+time it was logged, who logged it, and any optional notes describing what was
+done during that period. Timelogs are essential for understanding how time is
+being allocated across projects, enabling teams to manage resources more
+effectively, invoice clients accurately, and assess productivity. They can be
+created manually or with timers, and are often used for reporting and billing
+purposes.
+
+## Timer
+
+Timer is a built-in tool that allows users to accurately track the time they
+spend working on specific tasks, projects, or client work. Instead of manually
+recording hours, users can start, pause, and stop timers directly within the
+platform or through the desktop and mobile apps, ensuring precise time logs
+without interrupting their workflow. Once recorded, these entries are
+automatically linked to the relevant task or project, making it easier to
+monitor productivity, manage billable hours, and generate detailed reports for
+both internal tracking and client invoicing.
+
+## User
+
+A user is an individual who has access to one or more projects within a
+Teamwork site, typically as a team member, collaborator, or administrator.
+Users can be assigned tasks, participate in discussions, log time, share
+files, and interact with other members depending on their permission levels.
+Each user has a unique profile that defines their role, visibility, and
+access to features and project data. Users can belong to clients/companies or
+teams within the system, and their permissions can be customized to control
+what actions they can perform or what information they can see.
+
+## Workflow
+
+A workflow is a configurable process template in Teamwork.com that defines a
+series of stages through which tasks progress. Workflows help teams
+standardize their processes, automate stage transitions, and maintain
+consistency across projects by providing a structured path from start to
+completion.
+
+## Workflow stage
+
+A workflow stage is a single step within a workflow in Teamwork.com. Stages
+are ordered and define the progression path for tasks as they move through
+the workflow from start to completion. Each stage belongs to a parent
+workflow.
+
+## Workload
+
+Workload is a visual representation of how tasks are distributed across team
+members, helping you understand who is overloaded, who has capacity, and how
+work is balanced within a project or across multiple projects. It takes into
+account assigned tasks, due dates, estimated time, and working hours to give
+managers and teams a clear picture of availability and resource allocation.
+By providing this insight, workload makes it easier to plan effectively,
+prevent burnout, and ensure that deadlines are met without placing too much
+pressure on any single person.

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -21,13 +21,6 @@ const (
 	MethodActivityList toolsets.Method = "twprojects-list_activities"
 )
 
-const activityDescription = "Activity is a record of actions and updates that occur across your projects, tasks, and " +
-	"communications, giving you a clear view of what’s happening within your workspace. Activities capture changes " +
-	"such as task completions, activities added, files uploaded, or milestones updated, and present them in a " +
-	"chronological feed so teams can stay aligned without needing to check each individual project or task. This " +
-	"stream of information helps improve transparency, ensures accountability, and keeps everyone aware of progress " +
-	"and decisions as they happen."
-
 var (
 	activityListOutputSchema *jsonschema.Schema
 )
@@ -47,9 +40,8 @@ func init() {
 func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodActivityList),
-			Description: "List activities in Teamwork.com. Provide project_id to scope to a specific project. " +
-				activityDescription,
+			Name:        string(MethodActivityList),
+			Description: "List recent activity events. Scope by project_id or omit for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Activities",
 				ReadOnlyHint: true,

--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -22,16 +22,6 @@ const (
 	MethodProjectBudgetList  toolsets.Method = "twprojects-list_project_budgets"
 )
 
-const tasklistBudgetDescription = "In the context of Teamwork.com, a tasklist budget is a budget allocation " +
-	"attached to a specific task list within a project budget. It tracks capacity (in time or money) assigned to " +
-	"and consumed by a task list, helping teams monitor spend and effort at a granular level within a broader " +
-	"project budget."
-
-const projectBudgetDescription = "In the context of Teamwork.com, a project budget defines the overall budget " +
-	"allocation for a project, including capacity and usage tracking over time. It can be scoped by status and " +
-	"project, enabling teams to monitor financial or effort limits, track consumption, and understand budget " +
-	"performance across active, upcoming, and completed budget periods."
-
 var (
 	tasklistBudgetListOutputSchema *jsonschema.Schema
 	projectBudgetListOutputSchema  *jsonschema.Schema
@@ -59,7 +49,7 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectBudgetList),
-			Description: "List project budgets in Teamwork.com. " + projectBudgetDescription,
+			Description: "List project-level budgets.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Project Budgets",
 				ReadOnlyHint: true,
@@ -159,7 +149,7 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistBudgetList),
-			Description: "List tasklist budgets for a project budget in Teamwork.com. " + tasklistBudgetDescription,
+			Description: "List tasklist-level budgets for a project budget.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasklist Budgets",
 				ReadOnlyHint: true,

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -29,13 +29,6 @@ const (
 	MethodCommentList   toolsets.Method = "twprojects-list_comments"
 )
 
-const commentDescription = "In the Teamwork.com context, a comment is a way for users to communicate and collaborate " +
-	"directly within tasks, milestones, files, or other project items. Comments allow team members to provide updates, " +
-	"ask questions, give feedback, or share relevant information in a centralized and contextual manner. They support " +
-	"rich text formatting, file attachments, and @mentions to notify specific users or teams, helping keep " +
-	"discussions organized and easily accessible within the project. Comments are visible to all users with access to " +
-	"the item, promoting transparency and keeping everyone aligned."
-
 var (
 	commentGetOutputSchema  *jsonschema.Schema
 	commentListOutputSchema *jsonschema.Schema
@@ -62,7 +55,7 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCommentCreate),
-			Description: "Create a new comment in Teamwork.com. " + commentDescription,
+			Description: "Create comment on a task, milestone, notebook, file, or link.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Comment",
 			},
@@ -266,7 +259,7 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCommentUpdate),
-			Description: "Update an existing comment in Teamwork.com. " + commentDescription,
+			Description: "Update comment.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Comment",
 			},
@@ -418,7 +411,7 @@ func CommentDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCommentDelete),
-			Description: "Delete an existing comment in Teamwork.com. " + commentDescription,
+			Description: "Delete comment.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Comment",
 			},
@@ -461,7 +454,7 @@ func CommentGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCommentGet),
-			Description: "Get an existing comment in Teamwork.com. " + commentDescription,
+			Description: "Get comment.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Comment",
 				ReadOnlyHint: true,
@@ -518,9 +511,8 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name: string(MethodCommentList),
-			Description: "List comments in Teamwork.com. Provide one of task_id, milestone_id, notebook_id, " +
-				"link_id, or file_version_id to scope to a specific object; omit all to list across all objects. " +
-				commentDescription,
+			Description: "List comments. Scope by one of task_id, milestone_id, notebook_id, link_id, or file_version_id; " +
+				"omit all for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Comments",
 				ReadOnlyHint: true,

--- a/internal/twprojects/companies.go
+++ b/internal/twprojects/companies.go
@@ -25,14 +25,6 @@ const (
 	MethodCompanyList   toolsets.Method = "twprojects-list_companies"
 )
 
-const companyDescription = "In the context of Teamwork.com, a company represents an organization or business entity " +
-	"that can be associated with users, projects, and tasks within the platform, and it is often referred to as a " +
-	"“client.” It serves as a way to group related users and projects under a single organizational umbrella, making " +
-	"it easier to manage permissions, assign responsibilities, and organize work. Companies (or clients) are " +
-	"frequently used to distinguish between internal teams and external collaborators, enabling teams to work " +
-	"efficiently while maintaining clear boundaries around ownership, visibility, and access levels across different " +
-	"projects."
-
 var (
 	companyGetOutputSchema  *jsonschema.Schema
 	companyListOutputSchema *jsonschema.Schema
@@ -59,7 +51,7 @@ func CompanyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCompanyCreate),
-			Description: "Create a new company in Teamwork.com. " + companyDescription,
+			Description: "Create company (aka client).",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Company",
 			},
@@ -230,7 +222,7 @@ func CompanyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCompanyUpdate),
-			Description: "Update an existing company in Teamwork.com. " + companyDescription,
+			Description: "Update company (aka client).",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Company",
 			},
@@ -409,7 +401,7 @@ func CompanyDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCompanyDelete),
-			Description: "Delete an existing company in Teamwork.com. " + companyDescription,
+			Description: "Delete company (aka client).",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Company",
 			},
@@ -452,7 +444,7 @@ func CompanyGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCompanyGet),
-			Description: "Get an existing company in Teamwork.com. " + companyDescription,
+			Description: "Get company (aka client).",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Company",
 				ReadOnlyHint: true,
@@ -513,7 +505,7 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodCompanyList),
-			Description: "List companies in Teamwork.com. " + companyDescription,
+			Description: "List companies (aka clients).",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Companies",
 				ReadOnlyHint: true,

--- a/internal/twprojects/industries.go
+++ b/internal/twprojects/industries.go
@@ -20,13 +20,6 @@ const (
 	MethodIndustryList toolsets.Method = "twprojects-list_industries"
 )
 
-const industryDescription = "Industry refers to the business sector or market category that a company belongs to, " +
-	"such as technology, healthcare, finance, or education. It helps provide context about the nature of a company's " +
-	"work and can be used to better organize and filter data across the platform. By associating companies and " +
-	"projects with specific industries, Teamwork.com allows teams to gain clearer insights, tailor communication, " +
-	"and segment information in ways that make it easier to manage relationships and understand the broader business " +
-	"landscape in which their clients and partners operate."
-
 var (
 	industryListOutputSchema *jsonschema.Schema
 )
@@ -47,7 +40,7 @@ func IndustryList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodIndustryList),
-			Description: "List industries in Teamwork.com. " + industryDescription,
+			Description: "List supported company (aka client) industries.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Industries",
 				ReadOnlyHint: true,

--- a/internal/twprojects/jobroles.go
+++ b/internal/twprojects/jobroles.go
@@ -25,12 +25,6 @@ const (
 	MethodJobRoleList   toolsets.Method = "twprojects-list_jobroles"
 )
 
-const jobRoleDescription = "Job role defines a user's primary function or position within the organization, such as " +
-	"developer, designer, project manager, or account manager. It provides high-level context about what a person is " +
-	"generally responsible for, helping teams understand who does what across projects and departments. Job roles are " +
-	"commonly used in resource planning, capacity forecasting, and reporting, allowing managers to group work by role, " +
-	"plan future demand more accurately, and ensure the right mix of roles is available to deliver projects efficiently."
-
 var (
 	jobRoleGetOutputSchema  *jsonschema.Schema
 	jobRoleListOutputSchema *jsonschema.Schema
@@ -57,7 +51,7 @@ func JobRoleCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodJobRoleCreate),
-			Description: "Create a new job role in Teamwork.com. " + jobRoleDescription,
+			Description: "Create job role.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Job Role",
 			},
@@ -100,7 +94,7 @@ func JobRoleUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodJobRoleUpdate),
-			Description: "Update an existing job role in Teamwork.com. " + jobRoleDescription,
+			Description: "Update job role.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Job Role",
 			},
@@ -151,7 +145,7 @@ func JobRoleDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodJobRoleDelete),
-			Description: "Delete an existing job role in Teamwork.com. " + jobRoleDescription,
+			Description: "Delete job role.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Job Role",
 			},
@@ -194,7 +188,7 @@ func JobRoleGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodJobRoleGet),
-			Description: "Get an existing job role in Teamwork.com. " + jobRoleDescription,
+			Description: "Get job role.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Job Role",
 				ReadOnlyHint: true,
@@ -251,7 +245,7 @@ func JobRoleList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodJobRoleList),
-			Description: "List job roles in Teamwork.com. " + jobRoleDescription,
+			Description: "List job roles.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Job Roles",
 				ReadOnlyHint: true,

--- a/internal/twprojects/links.go
+++ b/internal/twprojects/links.go
@@ -27,10 +27,6 @@ const (
 	MethodLinkList   toolsets.Method = "twprojects-list_links"
 )
 
-const linkDescription = "In the context of Teamwork.com, a link Link is a saved URL attached to a project, task, or " +
-	"other item, allowing users to quickly reference and access external resources (such as documents, tools, or " +
-	"websites) directly within their workflow."
-
 var (
 	linkGetOutputSchema  *jsonschema.Schema
 	linkListOutputSchema *jsonschema.Schema
@@ -71,7 +67,7 @@ func LinkCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodLinkCreate),
-			Description: "Create a new link in Teamwork.com. " + linkDescription,
+			Description: "Create link.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Link",
 			},
@@ -229,7 +225,7 @@ func LinkUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodLinkUpdate),
-			Description: "Update an existing link in Teamwork.com. " + linkDescription,
+			Description: "Update link.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Link",
 			},
@@ -390,7 +386,7 @@ func LinkDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodLinkDelete),
-			Description: "Delete an existing link in Teamwork.com. " + linkDescription,
+			Description: "Delete link.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Link",
 			},
@@ -433,7 +429,7 @@ func LinkGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodLinkGet),
-			Description: "Get an existing link in Teamwork.com. " + linkDescription,
+			Description: "Get link.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Link",
 				ReadOnlyHint: true,
@@ -494,7 +490,7 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodLinkList),
-			Description: "List links in Teamwork.com. " + linkDescription,
+			Description: "List links.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Links",
 				ReadOnlyHint: true,

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -26,12 +26,6 @@ const (
 	MethodMessageReplyList   toolsets.Method = "twprojects-list_message_replies"
 )
 
-const messageReplyDescription = "In the context of Teamwork.com, a message reply is a response within a project " +
-	"message thread that allows team members to contribute to the discussion, ask questions, or provide updates while " +
-	"keeping all communication organized under the original message. Replies maintain context by staying linked to the " +
-	"main topic, include the author and timestamp, and help create a clear, ongoing conversation that is easy for " +
-	"everyone involved to follow and reference."
-
 var (
 	messageReplyGetOutputSchema  *jsonschema.Schema
 	messageReplyListOutputSchema *jsonschema.Schema
@@ -58,7 +52,7 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyCreate),
-			Description: "Create a new message reply in Teamwork.com. " + messageReplyDescription,
+			Description: "Create message reply.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Message Reply",
 			},
@@ -192,7 +186,7 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyUpdate),
-			Description: "Update an existing message reply in Teamwork.com. " + messageReplyDescription,
+			Description: "Update message reply.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update MessageReply",
 			},
@@ -329,7 +323,7 @@ func MessageReplyDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyDelete),
-			Description: "Delete an existing message reply in Teamwork.com. " + messageReplyDescription,
+			Description: "Delete message reply.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Message Reply",
 			},
@@ -372,7 +366,7 @@ func MessageReplyGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyGet),
-			Description: "Get an existing message reply in Teamwork.com. " + messageReplyDescription,
+			Description: "Get message reply.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Message Reply",
 				ReadOnlyHint: true,
@@ -429,7 +423,7 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyList),
-			Description: "List message replies in Teamwork.com. " + messageReplyDescription,
+			Description: "List replies for a message.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Message Replies",
 				ReadOnlyHint: true,

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -26,12 +26,6 @@ const (
 	MethodMessageList   toolsets.Method = "twprojects-list_messages"
 )
 
-const messageDescription = "In the context of Teamwork.com, a message is a structured communication post within a " +
-	"project that allows team members to share updates, discuss topics, and document decisions in a centralized, " +
-	"threaded format. It includes a title, a detailed message body, and replies from collaborators, all tied to the " +
-	"project for clear context and visibility, making it ideal for important discussions that need to be organized " +
-	"and easily referenced over time."
-
 var (
 	messageGetOutputSchema  *jsonschema.Schema
 	messageListOutputSchema *jsonschema.Schema
@@ -58,7 +52,7 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageCreate),
-			Description: "Create a new message in Teamwork.com. " + messageDescription,
+			Description: "Create message in a project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Message",
 			},
@@ -197,7 +191,7 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageUpdate),
-			Description: "Update an existing message in Teamwork.com. " + messageDescription,
+			Description: "Update message.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Message",
 			},
@@ -349,7 +343,7 @@ func MessageDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageDelete),
-			Description: "Delete an existing message in Teamwork.com. " + messageDescription,
+			Description: "Delete message.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Message",
 			},
@@ -392,7 +386,7 @@ func MessageGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageGet),
-			Description: "Get an existing message in Teamwork.com. " + messageDescription,
+			Description: "Get message.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Message",
 				ReadOnlyHint: true,
@@ -453,7 +447,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageList),
-			Description: "List messages in Teamwork.com. " + messageDescription,
+			Description: "List messages.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Messages",
 				ReadOnlyHint: true,

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -25,13 +25,6 @@ const (
 	MethodMilestoneList   toolsets.Method = "twprojects-list_milestones"
 )
 
-const milestoneDescription = "In the context of Teamwork.com, a milestone represents a significant point or goal " +
-	"within a project that marks the completion of a major phase or a key deliverable. It acts as a high-level " +
-	"indicator of progress, helping teams track whether work is advancing according to plan. Milestones are typically " +
-	"used to coordinate efforts across different tasks and task lists, providing a clear deadline or objective that " +
-	"multiple team members or departments can align around. They don't contain individual tasks themselves but serve " +
-	"as checkpoints to ensure the project is moving in the right direction."
-
 var (
 	milestoneGetOutputSchema  *jsonschema.Schema
 	milestoneListOutputSchema *jsonschema.Schema
@@ -58,7 +51,7 @@ func MilestoneCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMilestoneCreate),
-			Description: "Create a new milestone in Teamwork.com. " + milestoneDescription,
+			Description: "Create milestone in a project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Milestone",
 			},
@@ -193,7 +186,7 @@ func MilestoneUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMilestoneUpdate),
-			Description: "Update an existing milestone in Teamwork.com. " + milestoneDescription,
+			Description: "Update milestone.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Milestone",
 			},
@@ -329,7 +322,7 @@ func MilestoneDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMilestoneDelete),
-			Description: "Delete an existing milestone in Teamwork.com. " + milestoneDescription,
+			Description: "Delete milestone.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Milestone",
 			},
@@ -372,7 +365,7 @@ func MilestoneGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMilestoneGet),
-			Description: "Get an existing milestone in Teamwork.com. " + milestoneDescription,
+			Description: "Get milestone.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Milestone",
 				ReadOnlyHint: true,
@@ -432,9 +425,8 @@ func MilestoneGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodMilestoneList),
-			Description: "List milestones in Teamwork.com. Provide project_id to scope to a specific project. " +
-				milestoneDescription,
+			Name:        string(MethodMilestoneList),
+			Description: "List milestones. Scope by project_id or omit for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Milestones",
 				ReadOnlyHint: true,

--- a/internal/twprojects/notebooks.go
+++ b/internal/twprojects/notebooks.go
@@ -25,13 +25,6 @@ const (
 	MethodNotebookList   toolsets.Method = "twprojects-list_notebooks"
 )
 
-const notebookDescription = "Notebook is a space where teams can create, share, and organize written content in a " +
-	"structured way. It’s commonly used for documenting processes, storing meeting notes, capturing research, or " +
-	"drafting ideas that need to be revisited and refined over time. Unlike quick messages or task comments, " +
-	"notebooks provide a more permanent and organized format that can be easily searched and referenced, helping " +
-	"teams maintain a centralized source of knowledge and ensuring important information remains accessible to " +
-	"everyone who needs it."
-
 var (
 	notebookGetOutputSchema  *jsonschema.Schema
 	notebookListOutputSchema *jsonschema.Schema
@@ -58,7 +51,7 @@ func NotebookCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodNotebookCreate),
-			Description: "Create a new notebook in Teamwork.com. " + notebookDescription,
+			Description: "Create notebook in a project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Notebook",
 			},
@@ -138,7 +131,7 @@ func NotebookUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodNotebookUpdate),
-			Description: "Update an existing notebook in Teamwork.com. " + notebookDescription,
+			Description: "Update notebook.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Notebook",
 			},
@@ -226,7 +219,7 @@ func NotebookDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodNotebookDelete),
-			Description: "Delete an existing notebook in Teamwork.com. " + notebookDescription,
+			Description: "Delete notebook.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Notebook",
 			},
@@ -269,7 +262,7 @@ func NotebookGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodNotebookGet),
-			Description: "Get an existing notebook in Teamwork.com. " + notebookDescription,
+			Description: "Get notebook.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Notebook",
 				ReadOnlyHint: true,
@@ -330,7 +323,7 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodNotebookList),
-			Description: "List notebooks in Teamwork.com. " + notebookDescription,
+			Description: "List notebooks.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Notebooks",
 				ReadOnlyHint: true,

--- a/internal/twprojects/project_categories.go
+++ b/internal/twprojects/project_categories.go
@@ -27,11 +27,6 @@ const (
 	MethodProjectCategoryList   toolsets.Method = "twprojects-list_project_categories"
 )
 
-const projectCategoryDescription = "The project category is a way to group and label related projects so teams can " +
-	"organize their work more clearly across the platform. By assigning a category, you create a higher-level " +
-	"structure that makes it easier to filter, report on, and navigate multiple projects, ensuring that departments, " +
-	"workflows, or strategic areas remain neatly aligned and easier to manage."
-
 var (
 	projectCategoryGetOutputSchema  *jsonschema.Schema
 	projectCategoryListOutputSchema *jsonschema.Schema
@@ -58,7 +53,7 @@ func ProjectCategoryCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCategoryCreate),
-			Description: "Create a new project category in Teamwork.com. " + projectCategoryDescription,
+			Description: "Create project category.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Project Category",
 			},
@@ -117,7 +112,7 @@ func ProjectCategoryUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCategoryUpdate),
-			Description: "Update an existing project category in Teamwork.com. " + projectCategoryDescription,
+			Description: "Update project category.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Project Category",
 			},
@@ -184,7 +179,7 @@ func ProjectCategoryDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCategoryDelete),
-			Description: "Delete an existing project category in Teamwork.com. " + projectCategoryDescription,
+			Description: "Delete project category.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Project Category",
 			},
@@ -227,7 +222,7 @@ func ProjectCategoryGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCategoryGet),
-			Description: "Get an existing project category in Teamwork.com. " + projectCategoryDescription,
+			Description: "Get project category.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Project Category",
 				ReadOnlyHint: true,
@@ -284,7 +279,7 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCategoryList),
-			Description: "List project categories in Teamwork.com. " + projectCategoryDescription,
+			Description: "List project categories.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Project Categories",
 				ReadOnlyHint: true,

--- a/internal/twprojects/project_members.go
+++ b/internal/twprojects/project_members.go
@@ -20,18 +20,12 @@ const (
 	MethodProjectMemberAdd toolsets.Method = "twprojects-add_project_member"
 )
 
-const projectMemberDescription = "In the context of Teamwork.com, a project member is a user who is assigned to a " +
-	"specific project. Project members can have different roles and permissions within the project, allowing them to " +
-	"collaborate on tasks, view project details, and contribute to the project's success. Managing project members " +
-	"effectively is crucial for ensuring that the right people are involved in the right tasks, and it helps maintain " +
-	"accountability and clarity throughout the project's lifecycle."
-
 // ProjectMemberAdd adds a user to a project in Teamwork.com.
 func ProjectMemberAdd(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectMemberAdd),
-			Description: "Add a user to a project in Teamwork.com. " + projectMemberDescription,
+			Description: "Add a user to a project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Add Project Member",
 			},

--- a/internal/twprojects/project_templates.go
+++ b/internal/twprojects/project_templates.go
@@ -21,17 +21,12 @@ const (
 	MethodProjectTemplateList   toolsets.Method = "twprojects-list_project_templates"
 )
 
-const projectTemplateDescription = "The project template is a reusable project structure designed to standardize " +
-	"workflows and streamline project setup. It typically includes predefined tasks, task lists, milestones, and " +
-	"timelines that reflect a repeatable process, allowing teams to quickly spin up new projects with consistent " +
-	"organization, clear responsibilities, and efficient execution from the start."
-
 // ProjectTemplateCreate creates a project template in Teamwork.com.
 func ProjectTemplateCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectTemplateCreate),
-			Description: "Create a new project template in Teamwork.com. " + projectTemplateDescription,
+			Description: "Create project template.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Project Template",
 			},
@@ -130,7 +125,7 @@ func ProjectTemplateList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectTemplateList),
-			Description: "List project templates in Teamwork.com. " + projectTemplateDescription,
+			Description: "List project templates.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Project Templates",
 				ReadOnlyHint: true,

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -26,14 +26,6 @@ const (
 	MethodProjectList   toolsets.Method = "twprojects-list_projects"
 )
 
-const projectDescription = "The project feature in Teamwork.com serves as the central workspace for organizing and " +
-	"managing a specific piece of work or initiative. Each project provides a dedicated area where teams can plan " +
-	"tasks, assign responsibilities, set deadlines, and track progress toward shared goals. Projects include tools " +
-	"for communication, file sharing, milestones, and time tracking, allowing teams to stay aligned and informed " +
-	"throughout the entire lifecycle of the work. Whether it's a product launch, client engagement, or internal " +
-	"initiative, projects in Teamwork.com help teams structure their efforts, collaborate more effectively, and " +
-	"deliver results with greater visibility and accountability."
-
 var (
 	projectGetOutputSchema  *jsonschema.Schema
 	projectListOutputSchema *jsonschema.Schema
@@ -60,7 +52,7 @@ func ProjectCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectCreate),
-			Description: "Create a new project in Teamwork.com. " + projectDescription,
+			Description: "Create project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Project",
 			},
@@ -159,7 +151,7 @@ func ProjectUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectUpdate),
-			Description: "Update an existing project in Teamwork.com. " + projectDescription,
+			Description: "Update project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Project",
 			},
@@ -279,7 +271,7 @@ func ProjectDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectDelete),
-			Description: "Delete an existing project in Teamwork.com. " + projectDescription,
+			Description: "Delete project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Project",
 			},
@@ -322,7 +314,7 @@ func ProjectClone(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectClone),
-			Description: "Clone/copy an existing project or generate one from a project template. " + projectDescription,
+			Description: "Clone/copy an existing project or instantiate one from a template.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Clone Project",
 			},
@@ -475,7 +467,7 @@ func ProjectGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectGet),
-			Description: "Get an existing project in Teamwork.com. " + projectDescription,
+			Description: "Get project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Project",
 				ReadOnlyHint: true,
@@ -543,7 +535,7 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectList),
-			Description: "List projects in Teamwork.com. " + projectDescription,
+			Description: "List projects.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Projects",
 				ReadOnlyHint: true,

--- a/internal/twprojects/search.go
+++ b/internal/twprojects/search.go
@@ -21,11 +21,6 @@ const (
 	MethodSearch toolsets.Method = "twprojects-search"
 )
 
-const searchDescription = "Search is a feature that allows users to " +
-	"quickly find projects, tasks, files, messages, and other items across their " +
-	"workspace by entering keywords, helping them locate information and navigate " +
-	"their work efficiently from a single place."
-
 var (
 	searchOutputSchema *jsonschema.Schema
 )
@@ -45,7 +40,7 @@ func Search(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSearch),
-			Description: "Searches in Teamwork.com. " + searchDescription,
+			Description: "Cross-entity keyword search across projects, tasks, files, messages, and more.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Search",
 				ReadOnlyHint: true,

--- a/internal/twprojects/skills.go
+++ b/internal/twprojects/skills.go
@@ -25,13 +25,6 @@ const (
 	MethodSkillList   toolsets.Method = "twprojects-list_skills"
 )
 
-const skillDescription = "Skill represents a specific capability, area of expertise, or proficiency that can be " +
-	"assigned to users to describe what they are good at or qualified to work on. Skills help teams understand the " +
-	"strengths available across the organization and make it easier to match the right skills to the right work when " +
-	"planning projects, assigning tasks, or managing resources. By associating skills with users and leveraging them " +
-	"in planning and reporting, Teamwork enables more effective workload distribution, better project outcomes, and " +
-	"clearer visibility into whether the team has the capabilities needed to deliver upcoming work."
-
 var (
 	skillGetOutputSchema  *jsonschema.Schema
 	skillListOutputSchema *jsonschema.Schema
@@ -58,7 +51,7 @@ func SkillCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSkillCreate),
-			Description: "Create a new skill in Teamwork.com. " + skillDescription,
+			Description: "Create skill.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Skill",
 			},
@@ -109,7 +102,7 @@ func SkillUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSkillUpdate),
-			Description: "Update an existing skill in Teamwork.com. " + skillDescription,
+			Description: "Update skill.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Skill",
 			},
@@ -168,7 +161,7 @@ func SkillDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSkillDelete),
-			Description: "Delete an existing skill in Teamwork.com. " + skillDescription,
+			Description: "Delete skill.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Skill",
 			},
@@ -211,7 +204,7 @@ func SkillGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSkillGet),
-			Description: "Get an existing skill in Teamwork.com. " + skillDescription,
+			Description: "Get skill.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Skill",
 				ReadOnlyHint: true,
@@ -268,7 +261,7 @@ func SkillList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodSkillList),
-			Description: "List skills in Teamwork.com. " + skillDescription,
+			Description: "List skills.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Skills",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -25,12 +25,6 @@ const (
 	MethodTagList   toolsets.Method = "twprojects-list_tags"
 )
 
-const tagDescription = "In the context of Teamwork.com, a tag is a customizable label that can be applied to various " +
-	"items such as tasks, projects, milestones, messages, and more, to help categorize and organize work efficiently. " +
-	"Tags provide a flexible way to filter, search, and group related items across the platform, making it easier for " +
-	"teams to manage complex workflows, highlight priorities, or track themes and statuses. Since tags are " +
-	"user-defined, they adapt to each team’s specific needs and can be color-coded for better visual clarity."
-
 var (
 	tagGetOutputSchema  *jsonschema.Schema
 	tagListOutputSchema *jsonschema.Schema
@@ -57,7 +51,7 @@ func TagCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTagCreate),
-			Description: "Create a new tag in Teamwork.com. " + tagDescription,
+			Description: "Create tag.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Tag",
 			},
@@ -108,7 +102,7 @@ func TagUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTagUpdate),
-			Description: "Update an existing tag in Teamwork.com. " + tagDescription,
+			Description: "Update tag.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Tag",
 			},
@@ -167,7 +161,7 @@ func TagDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTagDelete),
-			Description: "Delete an existing tag in Teamwork.com. " + tagDescription,
+			Description: "Delete tag.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Tag",
 			},
@@ -210,7 +204,7 @@ func TagGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTagGet),
-			Description: "Get an existing tag in Teamwork.com. " + tagDescription,
+			Description: "Get tag.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Tag",
 				ReadOnlyHint: true,
@@ -255,7 +249,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTagList),
-			Description: "List tags in Teamwork.com. " + tagDescription,
+			Description: "List tags.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tags",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -25,13 +25,6 @@ const (
 	MethodTasklistList   toolsets.Method = "twprojects-list_tasklists"
 )
 
-const tasklistDescription = "In the context of Teamwork.com, a task list is a way to group related tasks within a " +
-	"project, helping teams organize their work into meaningful sections such as phases, categories, or deliverables. " +
-	"Each task list belongs to a specific project and can include multiple tasks that are typically aligned with a " +
-	"common goal. Task lists can be associated with milestones, and they support privacy settings that control who " +
-	"can view or interact with the tasks they contain. This structure helps teams manage progress, assign " +
-	"responsibilities, and maintain clarity across complex projects."
-
 var (
 	tasklistGetOutputSchema  *jsonschema.Schema
 	tasklistListOutputSchema *jsonschema.Schema
@@ -58,7 +51,7 @@ func TasklistCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistCreate),
-			Description: "Create a new tasklist in Teamwork.com. " + tasklistDescription,
+			Description: "Create tasklist in a project.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Tasklist",
 			},
@@ -122,7 +115,7 @@ func TasklistUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistUpdate),
-			Description: "Update an existing tasklist in Teamwork.com. " + tasklistDescription,
+			Description: "Update tasklist.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Tasklist",
 			},
@@ -189,7 +182,7 @@ func TasklistDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistDelete),
-			Description: "Delete an existing tasklist in Teamwork.com. " + tasklistDescription,
+			Description: "Delete tasklist.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Tasklist",
 			},
@@ -232,7 +225,7 @@ func TasklistGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistGet),
-			Description: "Get an existing tasklist in Teamwork.com. " + tasklistDescription,
+			Description: "Get tasklist.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Tasklist",
 				ReadOnlyHint: true,
@@ -292,9 +285,8 @@ func TasklistGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodTasklistList),
-			Description: "List tasklists in Teamwork.com. Provide project_id to scope to a specific project. " +
-				tasklistDescription,
+			Name:        string(MethodTasklistList),
+			Description: "List tasklists. Scope by project_id or omit for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasklists",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -26,13 +26,6 @@ const (
 	MethodTaskList     toolsets.Method = "twprojects-list_tasks"
 )
 
-const taskDescription = "In Teamwork.com, a task represents an individual unit of work assigned to one or more team " +
-	"members within a project. Each task can include details such as a title, description, priority, estimated time, " +
-	"assignees, and due date, along with the ability to attach files, leave comments, track time, and set dependencies " +
-	"on other tasks. Tasks are organized within task lists, helping structure and sequence work logically. They serve " +
-	"as the building blocks of project management in Teamwork, allowing teams to collaborate, monitor progress, and " +
-	"ensure accountability throughout the project's lifecycle."
-
 var (
 	taskGetOutputSchema  *jsonschema.Schema
 	taskListOutputSchema *jsonschema.Schema
@@ -59,7 +52,7 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskCreate),
-			Description: "Create a new task in Teamwork.com. " + taskDescription,
+			Description: "Create task in a tasklist.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Task",
 			},
@@ -435,7 +428,7 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskUpdate),
-			Description: "Update an existing task in Teamwork.com. " + taskDescription,
+			Description: "Update task.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Task",
 			},
@@ -818,7 +811,7 @@ func TaskDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskDelete),
-			Description: "Delete an existing task in Teamwork.com. " + taskDescription,
+			Description: "Delete task.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Task",
 			},
@@ -861,7 +854,7 @@ func TaskComplete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskComplete),
-			Description: "Mark an existing task as complete in Teamwork.com. " + taskDescription,
+			Description: "Mark task complete.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Complete Task",
 			},
@@ -904,7 +897,7 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskGet),
-			Description: "Get an existing task in Teamwork.com. " + taskDescription,
+			Description: "Get task.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Task",
 				ReadOnlyHint: true,
@@ -964,9 +957,8 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodTaskList),
-			Description: "List tasks in Teamwork.com. Provide tasklist_id to scope to a specific tasklist, " +
-				"project_id to scope to a project, or neither to search across all tasks. " + taskDescription,
+			Name:        string(MethodTaskList),
+			Description: "List tasks. Scope by tasklist_id, project_id, or neither for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasks",
 				ReadOnlyHint: true,

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -26,12 +26,6 @@ const (
 	MethodTeamList   toolsets.Method = "twprojects-list_teams"
 )
 
-const teamDescription = "In the context of Teamwork.com, a team is a group of users who are organized together to " +
-	"collaborate more efficiently on projects and tasks. Teams help structure work by grouping individuals with " +
-	"similar roles, responsibilities, or departmental functions, making it easier to assign work, track progress, " +
-	"and manage communication. By using teams, organizations can streamline project planning and ensure the right " +
-	"people are involved in the right parts of a project, enhancing clarity and accountability across the platform."
-
 var (
 	teamGetOutputSchema  *jsonschema.Schema
 	teamListOutputSchema *jsonschema.Schema
@@ -72,7 +66,7 @@ func TeamCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTeamCreate),
-			Description: "Create a new team in Teamwork.com. " + teamDescription,
+			Description: "Create team.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Team",
 			},
@@ -164,7 +158,7 @@ func TeamUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTeamUpdate),
-			Description: "Update an existing team in Teamwork.com. " + teamDescription,
+			Description: "Update team.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Team",
 			},
@@ -263,7 +257,7 @@ func TeamDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTeamDelete),
-			Description: "Delete an existing team in Teamwork.com. " + teamDescription,
+			Description: "Delete team.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Team",
 			},
@@ -306,7 +300,7 @@ func TeamGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTeamGet),
-			Description: "Get an existing team in Teamwork.com. " + teamDescription,
+			Description: "Get team.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Team",
 				ReadOnlyHint: true,
@@ -366,9 +360,8 @@ func TeamGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodTeamList),
-			Description: "List teams in Teamwork.com. Provide company_id or project_id to scope to a specific company " +
-				"or project. " + teamDescription,
+			Name:        string(MethodTeamList),
+			Description: "List teams. Scope by company_id or project_id, or omit for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Teams",
 				ReadOnlyHint: true,

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -25,13 +25,6 @@ const (
 	MethodTimelogList   toolsets.Method = "twprojects-list_timelogs"
 )
 
-const timelogDescription = "Timelog refers to a recorded entry that tracks the amount of time a person has spent " +
-	"working on a specific task, project, or piece of work. These entries typically include details such as the " +
-	"duration of time worked, the date and time it was logged, who logged it, and any optional notes describing what " +
-	"was done during that period. Timelogs are essential for understanding how time is being allocated across " +
-	"projects, enabling teams to manage resources more effectively, invoice clients accurately, and assess " +
-	"productivity. They can be created manually or with timers, and are often used for reporting and billing purposes."
-
 var (
 	timelogGetOutputSchema  *jsonschema.Schema
 	timelogListOutputSchema *jsonschema.Schema
@@ -65,7 +58,7 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				"openai/outputTemplate": timelogCreateAppURI,
 			},
 			Name:        string(MethodTimelogCreate),
-			Description: "Create a new timelog in Teamwork.com. " + timelogDescription,
+			Description: "Create timelog entry against a project or task.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Timelog",
 			},
@@ -185,7 +178,7 @@ func TimelogUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimelogUpdate),
-			Description: "Update an existing timelog in Teamwork.com. " + timelogDescription,
+			Description: "Update timelog.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Timelog",
 			},
@@ -318,7 +311,7 @@ func TimelogDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimelogDelete),
-			Description: "Delete an existing timelog in Teamwork.com. " + timelogDescription,
+			Description: "Delete timelog.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Timelog",
 			},
@@ -361,7 +354,7 @@ func TimelogGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimelogGet),
-			Description: "Get an existing timelog in Teamwork.com. " + timelogDescription,
+			Description: "Get timelog.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Timelog",
 				ReadOnlyHint: true,
@@ -405,9 +398,8 @@ func TimelogGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodTimelogList),
-			Description: "List timelogs in Teamwork.com. Provide project_id or task_id to scope to a specific project " +
-				"or task. " + timelogDescription,
+			Name:        string(MethodTimelogList),
+			Description: "List timelogs. Scope by project_id or task_id, or omit for site-wide.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Timelogs",
 				ReadOnlyHint: true,

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -28,13 +28,6 @@ const (
 	MethodTimerList     toolsets.Method = "twprojects-list_timers"
 )
 
-const timerDescription = "Timer is a built-in tool that allows users to accurately track the time they spend working " +
-	"on specific tasks, projects, or client work. Instead of manually recording hours, users can start, pause, and " +
-	"stop timers directly within the platform or through the desktop and mobile apps, ensuring precise time logs " +
-	"without interrupting their workflow. Once recorded, these entries are automatically linked to the relevant task " +
-	"or project, making it easier to monitor productivity, manage billable hours, and generate detailed reports for " +
-	"both internal tracking and client invoicing."
-
 var (
 	timerGetOutputSchema  *jsonschema.Schema
 	timerListOutputSchema *jsonschema.Schema
@@ -61,7 +54,7 @@ func TimerCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerCreate),
-			Description: "Create a new timer in Teamwork.com. " + timerDescription,
+			Description: "Create and start a timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Timer",
 			},
@@ -152,7 +145,7 @@ func TimerUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerUpdate),
-			Description: "Update an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Update timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Timer",
 			},
@@ -235,7 +228,7 @@ func TimerPause(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerPause),
-			Description: "Pause an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Pause a running timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Pause Timer",
 			},
@@ -278,7 +271,7 @@ func TimerResume(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerResume),
-			Description: "Resume an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Resume a paused timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Resume Timer",
 			},
@@ -321,7 +314,7 @@ func TimerComplete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerComplete),
-			Description: "Complete an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Stop a timer and convert it to a timelog.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Complete Timer",
 			},
@@ -364,7 +357,7 @@ func TimerDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerDelete),
-			Description: "Delete an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Delete timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Timer",
 			},
@@ -407,7 +400,7 @@ func TimerGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerGet),
-			Description: "Get an existing timer in Teamwork.com. " + timerDescription,
+			Description: "Get timer.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Timer",
 				ReadOnlyHint: true,
@@ -468,7 +461,7 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerList),
-			Description: "List timers in Teamwork.com. " + timerDescription,
+			Description: "List timers.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Timers",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -6,9 +6,11 @@ import (
 )
 
 const (
-	peopleDescription  = "Users, companies, teams, skills, job roles, and workload management in Teamwork.com."
-	timeDescription    = "Time tracking via timelogs, timers, and budget reporting in Teamwork.com."
-	contentDescription = "Comments, notebooks, milestones, tags, and activity feeds in Teamwork.com."
+	projectsDescription = "Project, category, template, and member management in Teamwork.com."
+	tasksDescription    = "Task, tasklist, and workflow management in Teamwork.com."
+	peopleDescription   = "Users, companies, teams, skills, job roles, and workload management in Teamwork.com."
+	timeDescription     = "Time tracking via timelogs, timers, and budget reporting in Teamwork.com."
+	contentDescription  = "Comments, notebooks, milestones, tags, and activity feeds in Teamwork.com."
 )
 
 // Sub-toolset keys for twprojects. These are the valid values for the
@@ -54,7 +56,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			ProjectDelete(engine),
 		)
 	}
-	projectsToolset := toolsets.NewToolset(ToolsetProjects, projectDescription).
+	projectsToolset := toolsets.NewToolset(ToolsetProjects, projectsDescription).
 		AddWriteTools(projectsWriteTools...).
 		AddReadTools(
 			ProjectCategoryGet(engine),
@@ -87,7 +89,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 			WorkflowStageDelete(engine),
 		)
 	}
-	tasksToolset := toolsets.NewToolset(ToolsetTasks, taskDescription).
+	tasksToolset := toolsets.NewToolset(ToolsetTasks, tasksDescription).
 		AddWriteTools(tasksWriteTools...).
 		AddReadTools(
 			TaskGet(engine),

--- a/internal/twprojects/users.go
+++ b/internal/twprojects/users.go
@@ -26,13 +26,6 @@ const (
 	MethodUserList   toolsets.Method = "twprojects-list_users"
 )
 
-const userDescription = "A user is an individual who has access to one or more projects within a Teamwork site, " +
-	"typically as a team member, collaborator, or administrator. Users can be assigned tasks, participate in " +
-	"discussions, log time, share files, and interact with other members depending on their permission levels. Each " +
-	"user has a unique profile that defines their role, visibility, and access to features and project data. Users " +
-	"can belong to clients/companies or teams within the system, and their permissions can be customized to control " +
-	"what actions they can perform or what information they can see."
-
 var (
 	userGetOutputSchema   *jsonschema.Schema
 	userGetMeOutputSchema *jsonschema.Schema
@@ -65,7 +58,7 @@ func UserCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserCreate),
-			Description: "Create a new user in Teamwork.com. " + userDescription,
+			Description: "Create user.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create User",
 			},
@@ -152,7 +145,7 @@ func UserUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserUpdate),
-			Description: "Update an existing user in Teamwork.com. " + userDescription,
+			Description: "Update user.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update User",
 			},
@@ -253,7 +246,7 @@ func UserDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserDelete),
-			Description: "Delete an existing user in Teamwork.com. " + userDescription,
+			Description: "Delete user.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete User",
 			},
@@ -296,7 +289,7 @@ func UserGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserGet),
-			Description: "Get an existing user in Teamwork.com. " + userDescription,
+			Description: "Get user.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get User",
 				ReadOnlyHint: true,
@@ -357,7 +350,7 @@ func UserGetMe(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserGetMe),
-			Description: "Get the logged user in Teamwork.com. " + userDescription,
+			Description: "Get the currently authenticated user.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Logged User",
 				ReadOnlyHint: true,
@@ -400,7 +393,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUserList),
-			Description: "List users in Teamwork.com. Provide project_id to scope to a specific project. " + userDescription,
+			Description: "List users. Scope by project_id or filter by type (account/collaborator/contact).",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Users",
 				ReadOnlyHint: true,

--- a/internal/twprojects/workflow_stages.go
+++ b/internal/twprojects/workflow_stages.go
@@ -26,10 +26,6 @@ const (
 	MethodWorkflowStageList     toolsets.Method = "twprojects-list_workflow_stages"
 )
 
-const workflowStageDescription = "A workflow stage is a single step within a workflow in Teamwork.com. " +
-	"Stages are ordered and define the progression path for tasks as they move through the workflow " +
-	"from start to completion. Each stage belongs to a parent workflow."
-
 var (
 	workflowStageGetOutputSchema  *jsonschema.Schema
 	workflowStageListOutputSchema *jsonschema.Schema
@@ -56,7 +52,7 @@ func WorkflowStageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowStageCreate),
-			Description: "Create a new stage within a workflow in Teamwork.com. " + workflowStageDescription,
+			Description: "Create workflow stage.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Workflow Stage",
 			},
@@ -104,7 +100,7 @@ func WorkflowStageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowStageUpdate),
-			Description: "Update an existing stage within a workflow in Teamwork.com. " + workflowStageDescription,
+			Description: "Update workflow stage.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Workflow Stage",
 			},
@@ -160,7 +156,7 @@ func WorkflowStageDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowStageDelete),
-			Description: "Delete an existing stage within a workflow in Teamwork.com. " + workflowStageDescription,
+			Description: "Delete workflow stage.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Workflow Stage",
 			},
@@ -217,9 +213,8 @@ func WorkflowStageDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 func WorkflowStageTaskMove(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodWorkflowStageTaskMove),
-			Description: "Move a task to a specific stage within a workflow in Teamwork.com. " +
-				workflowStageDescription,
+			Name:        string(MethodWorkflowStageTaskMove),
+			Description: "Move a task to a workflow stage.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Move Task to Workflow Stage",
 			},
@@ -272,7 +267,7 @@ func WorkflowStageGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowStageGet),
-			Description: "Get an existing stage within a workflow in Teamwork.com. " + workflowStageDescription,
+			Description: "Get workflow stage.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Workflow Stage",
 				ReadOnlyHint: true,
@@ -334,7 +329,7 @@ func WorkflowStageList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowStageList),
-			Description: "List stages within a workflow in Teamwork.com. " + workflowStageDescription,
+			Description: "List workflow stages.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Workflow Stages",
 				ReadOnlyHint: true,

--- a/internal/twprojects/workflows.go
+++ b/internal/twprojects/workflows.go
@@ -26,11 +26,6 @@ const (
 	MethodWorkflowList        toolsets.Method = "twprojects-list_workflows"
 )
 
-const workflowDescription = "A workflow is a configurable process template in Teamwork.com that defines " +
-	"a series of stages through which tasks progress. Workflows help teams standardize their processes, " +
-	"automate stage transitions, and maintain consistency across projects by providing a structured path " +
-	"from start to completion."
-
 var (
 	workflowGetOutputSchema  *jsonschema.Schema
 	workflowListOutputSchema *jsonschema.Schema
@@ -57,7 +52,7 @@ func WorkflowCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowCreate),
-			Description: "Create a new workflow in Teamwork.com. " + workflowDescription,
+			Description: "Create workflow.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Workflow",
 			},
@@ -100,7 +95,7 @@ func WorkflowUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowUpdate),
-			Description: "Update an existing workflow in Teamwork.com. " + workflowDescription,
+			Description: "Update workflow.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Workflow",
 			},
@@ -151,7 +146,7 @@ func WorkflowDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowDelete),
-			Description: "Delete an existing workflow in Teamwork.com. " + workflowDescription,
+			Description: "Delete workflow.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Workflow",
 			},
@@ -193,9 +188,8 @@ func WorkflowDelete(engine *twapi.Engine) toolsets.ToolWrapper {
 func WorkflowProjectLink(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name: string(MethodWorkflowProjectLink),
-			Description: "Link a project to a workflow in Teamwork.com, so that tasks in the project " +
-				"can be tracked through the workflow stages. " + workflowDescription,
+			Name:        string(MethodWorkflowProjectLink),
+			Description: "Link a project to a workflow so its tasks track through workflow stages.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Link Project to Workflow",
 			},
@@ -243,7 +237,7 @@ func WorkflowGet(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowGet),
-			Description: "Get an existing workflow in Teamwork.com. " + workflowDescription,
+			Description: "Get workflow.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Workflow",
 				ReadOnlyHint: true,
@@ -300,7 +294,7 @@ func WorkflowList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodWorkflowList),
-			Description: "List workflows in Teamwork.com. " + workflowDescription,
+			Description: "List workflows.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Workflows",
 				ReadOnlyHint: true,

--- a/internal/twprojects/workload.go
+++ b/internal/twprojects/workload.go
@@ -21,19 +21,12 @@ const (
 	MethodUsersWorkload toolsets.Method = "twprojects-users_workload"
 )
 
-const workloadDescription = "Workload is a visual representation of how tasks are distributed across team members, " +
-	"helping you understand who is overloaded, who has capacity, and how work is balanced within a project or " +
-	"across multiple projects. It takes into account assigned tasks, due dates, estimated time, and working " +
-	"hours to give managers and teams a clear picture of availability and resource allocation. By providing " +
-	"this insight, workload makes it easier to plan effectively, prevent burnout, and ensure that deadlines are " +
-	"met without placing too much pressure on any single person."
-
 // UsersWorkload retrieves the workload of users in Teamwork.com.
 func UsersWorkload(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodUsersWorkload),
-			Description: "Get the workload of users in Teamwork.com. " + workloadDescription,
+			Description: "Get task allocation across users for a date range. (workload of users)",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Users Workload",
 				ReadOnlyHint: true,


### PR DESCRIPTION
## Summary

- Strip per-tool entity blurbs (`taskDescription`, `userDescription`, …) from every twprojects tool description. Tool name + a one-line action phrase is enough signal for LLM tool selection — the marketing-style entity prose was duplicated 4–8× per entity across ~108 CRUD tools and added no value.
- Delete all 28 unused `xxxDescription` constants. Add two short toolset-level descriptions (`projectsDescription`, `tasksDescription`) in `tools.go` to match the existing `peopleDescription` / `timeDescription` / `contentDescription` style — these were the only two constants still referenced after the strip.
- Add `docs/glossary.md` so the deleted entity context is still available to drop into a skill or prompt when richer wording is needed.

## Test plan

- [x] `gofmt -s -w ./internal/twprojects/`
- [x] `go vet ./internal/twprojects/...`
- [x] `go test ./...` (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)