### PR TITLE
Enhancement: Simplify twdesk and twspaces tool descriptions

### DIFF
--- a/internal/twdesk/companies.go
+++ b/internal/twdesk/companies.go
@@ -34,9 +34,7 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Company",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific company in Teamwork Desk by its ID. " +
-				"Useful for auditing company records, troubleshooting ticket associations, or " +
-				"integrating Desk company data into automation workflows.",
+			Description: "Get Desk company (customer organization).",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -99,9 +97,7 @@ func CompanyList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Companies",
 				ReadOnlyHint: true,
 			},
-			Description: "List all companies in Teamwork Desk, with optional filters for name, domains, and kind. " +
-				"Enables users to audit, analyze, or synchronize company configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List Desk companies. Filter by name, domains, or kind.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -154,9 +150,7 @@ func CompanyCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Company",
 			},
-			Description: "Create a new company in Teamwork Desk by specifying its name, domains, and other attributes. " +
-				"Useful for onboarding new organizations, customizing Desk for business relationships, or " +
-				"adapting support processes.",
+			Description: "Create Desk company.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -270,9 +264,7 @@ func CompanyUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Company",
 			},
-			Description: "Update an existing company in Teamwork Desk by ID, allowing changes to its name, domains, and " +
-				"other attributes. Supports evolving business relationships, rebranding, or correcting company records for " +
-				"improved ticket handling.",
+			Description: "Update Desk company.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -34,9 +34,7 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Customer",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific customer in Teamwork Desk by their ID. " +
-				"Useful for auditing customer records, troubleshooting ticket associations, or " +
-				"integrating Desk customer data into automation workflows.",
+			Description: "Get customer.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -100,9 +98,7 @@ func CustomerList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Customers",
 				ReadOnlyHint: true,
 			},
-			Description: "List all customers in Teamwork Desk, with optional filters for company, email, and other " +
-				"attributes. Enables users to audit, analyze, or synchronize customer configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List customers. Filter by company or email.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -156,9 +152,7 @@ func CustomerCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Customer",
 			},
-			Description: "Create a new customer in Teamwork Desk by specifying their name, contact details, and other " +
-				"attributes. Useful for onboarding new clients, customizing Desk for business relationships, or " +
-				"adapting support processes.",
+			Description: "Create customer.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -309,9 +303,7 @@ func CustomerUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Customer",
 			},
-			Description: "Update an existing customer in Teamwork Desk by ID, allowing changes to their name, " +
-				"contact details, and other attributes. Supports evolving business relationships, " +
-				"correcting customer records, or improving ticket handling.",
+			Description: "Update customer.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/desk.go
+++ b/internal/twdesk/desk.go
@@ -1,9 +1,0 @@
-package twdesk
-
-const projectDescription = "Teamwork Desk is a customer support helpdesk solution that enables teams to manage " +
-	"customer inquiries, support tickets, and service requests in a centralized platform. It provides tools for " +
-	"ticket management, customer communication, knowledge base creation, and performance tracking. Support agents " +
-	"can efficiently handle customer issues through multiple channels including email, and chat, while " +
-	"maintaining a complete history of customer interactions. With features like automated workflows, SLA tracking, " +
-	"ticket prioritization, and team collaboration tools, Teamwork Desk helps support teams deliver exceptional " +
-	"customer service, resolve issues faster, and maintain high levels of customer satisfaction."

--- a/internal/twdesk/files.go
+++ b/internal/twdesk/files.go
@@ -29,8 +29,7 @@ func FileCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create File",
 			},
-			Description: "Upload a new file to Teamwork Desk, enabling attachment to tickets, articles, or " +
-				"other resources.",
+			Description: "Upload file. Attach the returned ID to tickets or messages.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/inboxes.go
+++ b/internal/twdesk/inboxes.go
@@ -31,7 +31,7 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Inbox",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific inbox in Teamwork Desk by its ID.",
+			Description: "Get inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -86,7 +86,7 @@ func InboxList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Inboxes",
 				ReadOnlyHint: true,
 			},
-			Description: "List all inboxes in Teamwork Desk, with optional filters for name and email.",
+			Description: "List inboxes. Filter by name or email.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/messages.go
+++ b/internal/twdesk/messages.go
@@ -28,9 +28,7 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Reply to Ticket",
 			},
-			Description: "Send a reply to a ticket in Teamwork Desk. Supports customer-facing replies and internal agent notes. " +
-				"Useful for automating ticket responses, integrating external communication systems, or " +
-				"customizing support workflows.",
+			Description: "Reply to a ticket. Use threadType=note for internal agent notes.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/priorities.go
+++ b/internal/twdesk/priorities.go
@@ -34,9 +34,7 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Priority",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific priority in Teamwork Desk by its ID. " +
-				"Useful for inspecting priority attributes, troubleshooting ticket routing, or " +
-				"integrating Desk priority data into automation workflows.",
+			Description: "Get ticket priority.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -91,9 +89,7 @@ func PriorityList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Priorities",
 				ReadOnlyHint: true,
 			},
-			Description: "List all available priorities in Teamwork Desk, with optional filters for name and color. " +
-				"Enables users to audit, analyze, or synchronize priority configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List ticket priorities. Filter by name or color.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -140,8 +136,7 @@ func PriorityCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Priority",
 			},
-			Description: "Create a new priority in Teamwork Desk by specifying its name and color. Useful for customizing " +
-				"ticket workflows, introducing new escalation levels, or adapting Desk to evolving support processes.",
+			Description: "Create ticket priority.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -189,9 +184,7 @@ func PriorityUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Priority",
 			},
-			Description: "Update an existing priority in Teamwork Desk by ID, allowing changes to its name and color. " +
-				"Supports evolving support policies, rebranding, or correcting priority attributes for improved " +
-				"ticket handling.",
+			Description: "Update ticket priority.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/statuses.go
+++ b/internal/twdesk/statuses.go
@@ -34,9 +34,7 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Status",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific status in Teamwork Desk by its ID. " +
-				"Useful for auditing status usage, troubleshooting ticket workflows, or " +
-				"integrating Desk status data into automation workflows.",
+			Description: "Get ticket status.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -99,9 +97,7 @@ func StatusList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Statuses",
 				ReadOnlyHint: true,
 			},
-			Description: "List all statuses in Teamwork Desk, with optional filters for name, color, and code. " +
-				"Enables users to audit, analyze, or synchronize status configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List ticket statuses. Filter by name, color, or code.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -152,9 +148,7 @@ func StatusCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Status",
 			},
-			Description: "Create a new status in Teamwork Desk by specifying its name, color, and display order. " +
-				"Useful for customizing ticket workflows, introducing new resolution states, or " +
-				"adapting Desk to evolving support processes.",
+			Description: "Create ticket status.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -210,9 +204,7 @@ func StatusUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Status",
 			},
-			Description: "Update an existing status in Teamwork Desk by ID, allowing changes to its name, color, and " +
-				"display order. Supports evolving support policies, rebranding, or correcting status attributes for improved " +
-				"ticket handling.",
+			Description: "Update ticket status.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/tags.go
+++ b/internal/twdesk/tags.go
@@ -34,9 +34,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Tag",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific tag in Teamwork Desk by its ID. " +
-				"Useful for auditing tag usage, troubleshooting ticket categorization, or " +
-				"integrating Desk tag data into automation workflows.",
+			Description: "Get Desk tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -98,9 +96,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Tags",
 				ReadOnlyHint: true,
 			},
-			Description: "List all tags in Teamwork Desk, with optional filters for name, color, and inbox association. " +
-				"Enables users to audit, analyze, or synchronize tag configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List Desk tags. Filter by name, color, or inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -151,8 +147,7 @@ func TagCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Tag",
 			},
-			Description: "Create a new tag in Teamwork Desk by specifying its name and color. Useful for customizing " +
-				"ticket workflows, introducing new categories, or adapting Desk to evolving support processes.",
+			Description: "Create Desk tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -200,9 +195,7 @@ func TagUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Tag",
 			},
-			Description: "Update an existing tag in Teamwork Desk by ID, allowing changes to its name and color. " +
-				"Supports evolving support policies, rebranding, or correcting tag attributes for improved " +
-				"ticket handling.",
+			Description: "Update Desk tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -35,9 +35,7 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific ticket in Teamwork Desk by its ID. " +
-				"Useful for auditing ticket records, troubleshooting support workflows, or " +
-				"integrating Desk ticket data into automation and reporting systems.",
+			Description: "Get ticket.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -175,9 +173,7 @@ func TicketSearch(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Search Tickets",
 				ReadOnlyHint: true,
 			},
-			Description: "Search tickets in Teamwork Desk using various filters including inbox, customer, company, " +
-				"tag, status, priority, SLA, user, and more. This tool enables users to perform targeted searches " +
-				"for tickets, facilitating efficient support management, reporting, and integration with other systems.",
+			Description: "Search tickets. Filter by inbox, customer, company, tag, status, priority, or user.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -234,8 +230,7 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Ticket",
 			},
-			Description: "Create a new ticket in Teamwork Desk by specifying subject, description, priority, and status. " +
-				"Useful for automating ticket creation, integrating external systems, or customizing support workflows.",
+			Description: "Create ticket.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -484,9 +479,7 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Ticket",
 			},
-			Description: "Update an existing ticket in Teamwork Desk by ID, allowing changes to its attributes. " +
-				"Supports evolving support processes, correcting ticket records, or integrating with automation " +
-				"systems for improved ticket handling.",
+			Description: "Update ticket.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/tools.go
+++ b/internal/twdesk/tools.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	deskTicketsDescription   = "Tickets, messages, files, and inboxes in Teamwork Desk."
 	deskCustomersDescription = "Companies, customers, and user management in Teamwork Desk."
 	deskAdminDescription     = "Inbox configuration: priorities, statuses, types, and tags in Teamwork Desk."
 )
@@ -33,7 +34,7 @@ func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.Tools
 	group := toolsets.NewToolsetGroup(readOnly)
 
 	// --- tickets sub-toolset ---
-	group.AddToolset(toolsets.NewToolset(ToolsetTickets, projectDescription).
+	group.AddToolset(toolsets.NewToolset(ToolsetTickets, deskTicketsDescription).
 		AddWriteTools(
 			FileCreate(httpClient),
 			MessageCreate(httpClient),

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -34,9 +34,7 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket Type",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific ticket type in Teamwork Desk by its ID. " +
-				"Useful for auditing type usage, troubleshooting ticket categorization, or " +
-				"integrating Desk type data into automation workflows.",
+			Description: "Get ticket type.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -91,9 +89,7 @@ func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Ticket Types",
 				ReadOnlyHint: true,
 			},
-			Description: "List all ticket types in Teamwork Desk, with optional filters for name and inbox association. " +
-				"Enables users to audit, analyze, or synchronize type configurations for ticket management, " +
-				"reporting, or integration scenarios.",
+			Description: "List ticket types. Filter by name or inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -140,9 +136,7 @@ func TypeCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Ticket Type",
 			},
-			Description: "Create a new ticket type in Teamwork Desk by specifying its name, display order, and future " +
-				"inbox settings. Useful for customizing ticket workflows, introducing new categories, or " +
-				"adapting Desk to evolving support processes.",
+			Description: "Create ticket type.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -198,9 +192,7 @@ func TypeUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Ticket Type",
 			},
-			Description: "Update an existing ticket type in Teamwork Desk by ID, allowing changes to its name, " +
-				"display order, and future inbox settings. Supports evolving support policies, rebranding, or correcting " +
-				"type attributes for improved ticket handling.",
+			Description: "Update ticket type.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -31,9 +31,7 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get User",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific support agent in Teamwork Desk by their ID. " +
-				"Useful for auditing agent records, troubleshooting ticket assignments, or " +
-				"integrating Desk agent data into automation workflows.",
+			Description: "Get support agent.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -109,11 +107,7 @@ func UserList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Users",
 				ReadOnlyHint: true,
 			},
-			Description: `
-				List all support agents in Teamwork Desk, with optional 
-				filters for name, email, inbox, and part-time status. Agents are the staff 
-				members who handle tickets; customers are managed via the 'twdesk-list_customers' tool.
-			`,
+			Description: "List support agents. For customers, use twdesk-list_customers.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twspaces/categories.go
+++ b/internal/twspaces/categories.go
@@ -31,7 +31,7 @@ func CategoryGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Category",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve a specific space category in Teamwork Spaces by its ID.",
+			Description: "Get space category.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -68,8 +68,7 @@ func CategoryList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Categories",
 				ReadOnlyHint: true,
 			},
-			Description: "List all space categories in Teamwork Spaces. Categories are used to organize spaces " +
-				"into logical groups for easier navigation and management.",
+			Description: "List space categories.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
@@ -102,8 +101,7 @@ func CategoryCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Category",
 			},
-			Description: "Create a new space category in Teamwork Spaces. Categories help organize spaces into " +
-				"logical groups for easier navigation and management.",
+			Description: "Create space category.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -153,7 +151,7 @@ func CategoryUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Category",
 			},
-			Description: "Update an existing space category in Teamwork Spaces by ID.",
+			Description: "Update space category.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -212,7 +210,7 @@ func CategoryDelete(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Category",
 			},
-			Description: "Delete a space category in Teamwork Spaces by its ID.",
+			Description: "Delete space category.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twspaces/comments.go
+++ b/internal/twspaces/comments.go
@@ -31,7 +31,7 @@ func CommentGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Comment",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve a specific comment on a page in Teamwork Spaces by its ID.",
+			Description: "Get page comment.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -80,8 +80,7 @@ func CommentList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Comments",
 				ReadOnlyHint: true,
 			},
-			Description: "List all comments on a page in Teamwork Spaces. Returns top-level comments along " +
-				"with their replies, enabling review of discussions and feedback on documentation.",
+			Description: "List comments on a page. Returns top-level comments with replies.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{
@@ -127,8 +126,7 @@ func CommentCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Comment",
 			},
-			Description: "Create a new comment on a page in Teamwork Spaces. Supports top-level comments and " +
-				"replies to existing comments.",
+			Description: "Create comment on a page. Use parentId for replies.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -198,8 +196,7 @@ func CommentUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Comment",
 			},
-			Description: "Update an existing comment on a page in Teamwork Spaces. Supports modifying content, " +
-				"state, and privacy settings.",
+			Description: "Update page comment.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -282,7 +279,7 @@ func CommentDelete(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Comment",
 			},
-			Description: "Delete a comment from a page in Teamwork Spaces. This action is irreversible.",
+			Description: "Delete page comment. Irreversible.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twspaces/pages.go
+++ b/internal/twspaces/pages.go
@@ -33,8 +33,7 @@ func PageGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Page",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific page within a space in Teamwork Spaces. " +
-				"Returns the page content, metadata, tags, and revision information.",
+			Description: "Get page. Returns content, metadata, tags, and revision info.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -78,9 +77,7 @@ func PageList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Pages",
 				ReadOnlyHint: true,
 			},
-			Description: "List all pages in a space as a hierarchical tree in Teamwork Spaces. " +
-				"Returns the page tree including child pages, useful for understanding content structure " +
-				"and navigation.",
+			Description: "List pages in a space as a hierarchical tree.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{
@@ -119,8 +116,7 @@ func PageHome(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Space Homepage",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve the homepage of a space in Teamwork Spaces. The homepage is the entry point " +
-				"and starting page for a space's content.",
+			Description: "Get a space's homepage.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -156,8 +152,7 @@ func PageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Page",
 			},
-			Description: "Create a new page within a space in Teamwork Spaces. Supports setting title, content, " +
-				"parent page, slug, tags, and publishing options.",
+			Description: "Create page in a space.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -268,8 +263,7 @@ func PageDuplicate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Duplicate Page",
 			},
-			Description: "Duplicate an existing page within a space in Teamwork Spaces. Creates a copy of the " +
-				"page with a new title, optionally under a different parent page.",
+			Description: "Duplicate page with a new title.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -339,8 +333,7 @@ func PageUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Page",
 			},
-			Description: "Update an existing page in Teamwork Spaces. Supports updating title, content, slug, " +
-				"parent page, tags, publishing status, and other page attributes.",
+			Description: "Update page.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -494,7 +487,7 @@ func PageDelete(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Page",
 			},
-			Description: "Delete a page from a space in Teamwork Spaces. This action is irreversible.",
+			Description: "Delete page. Irreversible.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twspaces/search.go
+++ b/internal/twspaces/search.go
@@ -24,9 +24,7 @@ func Search(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Search Spaces",
 				ReadOnlyHint: true,
 			},
-			Description: "Perform a full-text search across pages in Teamwork Spaces. Supports filtering by " +
-				"space, limiting results, and paginating through matches. Returns matching pages with " +
-				"highlighted text snippets.",
+			Description: "Full-text search across pages. Filter by space.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{

--- a/internal/twspaces/spaces.go
+++ b/internal/twspaces/spaces.go
@@ -35,8 +35,7 @@ func SpaceGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Space",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve detailed information about a specific space in Teamwork Spaces by its ID. " +
-				"Useful for inspecting space configuration, metadata, or linking spaces to projects.",
+			Description: "Get space.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -73,8 +72,7 @@ func SpaceList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Spaces",
 				ReadOnlyHint: true,
 			},
-			Description: "List all spaces in Teamwork Spaces. Enables users to discover, audit, or synchronize " +
-				"space data for documentation management, reporting, or integration scenarios.",
+			Description: "List spaces.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
@@ -107,8 +105,7 @@ func SpaceCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Space",
 			},
-			Description: "Create a new space in Teamwork Spaces. Useful for setting up knowledge bases, " +
-				"team wikis, or project documentation areas.",
+			Description: "Create space.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -205,8 +202,7 @@ func SpaceUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Space",
 			},
-			Description: "Update an existing space in Teamwork Spaces by ID. Supports changes to title, code, " +
-				"purpose, color, icon, state, linked project, and category.",
+			Description: "Update space.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -326,8 +322,7 @@ func SpaceDelete(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Space",
 			},
-			Description: "Delete a space in Teamwork Spaces by its ID. This action is irreversible and will " +
-				"remove the space and all its content.",
+			Description: "Delete space. Irreversible; removes all content.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -363,8 +358,7 @@ func SpaceCollaborators(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Space Collaborators",
 				ReadOnlyHint: true,
 			},
-			Description: "List all collaborators (users and teams) for a specific space in Teamwork Spaces. " +
-				"Useful for auditing access, reviewing permissions, or understanding who contributes to a space.",
+			Description: "List space collaborators (users and teams).",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twspaces/spaces_desc.go
+++ b/internal/twspaces/spaces_desc.go
@@ -1,7 +1,0 @@
-package twspaces
-
-const spacesDescription = "Teamwork Spaces is a collaborative wiki and knowledge management platform that enables teams " +
-	"to create, organize, and share documentation, wikis, and internal knowledge bases. It provides structured " +
-	"workspaces for teams to collaborate on pages, track changes, and manage content hierarchies. With features " +
-	"like rich-text editing, page trees, tagging, categorization, and inline commenting, Teamwork Spaces helps " +
-	"teams build and maintain living documentation that stays aligned with their projects and processes."

--- a/internal/twspaces/tags.go
+++ b/internal/twspaces/tags.go
@@ -31,7 +31,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Tag",
 				ReadOnlyHint: true,
 			},
-			Description: "Retrieve a specific tag in Teamwork Spaces by its ID.",
+			Description: "Get Spaces tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -68,8 +68,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Tags",
 				ReadOnlyHint: true,
 			},
-			Description: "List all tags in Teamwork Spaces. Tags can be applied to pages for categorization " +
-				"and filtering.",
+			Description: "List Spaces tags.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: paginationOptions(map[string]*jsonschema.Schema{}),
@@ -102,8 +101,7 @@ func TagCreateBatch(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Tags",
 			},
-			Description: "Create one or more tags in Teamwork Spaces in a single request. Tags can then be " +
-				"applied to pages for organization and filtering.",
+			Description: "Create one or more Spaces tags in a single request.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -179,7 +177,7 @@ func TagUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Tag",
 			},
-			Description: "Update an existing tag in Teamwork Spaces by ID. Supports changing the name and color.",
+			Description: "Update Spaces tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -238,7 +236,7 @@ func TagDelete(httpClient *http.Client) toolsets.ToolWrapper {
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Delete Tag",
 			},
-			Description: "Delete a tag in Teamwork Spaces by its ID.",
+			Description: "Delete Spaces tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/internal/twspaces/tools.go
+++ b/internal/twspaces/tools.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	spacesContentDescription    = "Pages, comments, tags, and categories in Teamwork Spaces."
-	spacesCategoriesDescription = "Space categories in Teamwork Spaces."
+	spacesDescription        = "Space CRUD and collaborators in Teamwork Spaces."
+	pagesDescription         = "Page CRUD, homepage, and duplication in Teamwork Spaces."
+	spacesContentDescription = "Comments, tags, categories, and search in Teamwork Spaces."
 )
 
 // Sub-toolset keys for twspaces. These are the valid values for the
@@ -46,7 +47,7 @@ func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.Tools
 		))
 
 	// --- pages sub-toolset ---
-	group.AddToolset(toolsets.NewToolset(ToolsetPages, spacesDescription).
+	group.AddToolset(toolsets.NewToolset(ToolsetPages, pagesDescription).
 		AddWriteTools(
 			PageCreate(httpClient),
 			PageDuplicate(httpClient),


### PR DESCRIPTION
## Summary

- Strip marketing prose (`Useful for…`, `Enables users to audit/analyze/synchronize…`, `adapting Desk to evolving support processes`) from every twdesk tool description; align twspaces tone with the same terse template.
- Add light-touch product disambiguators (`Desk tag`, `Spaces tag`, `page comment`, `Desk company`) on the few tools that share a bare suffix with twprojects, so the LLM has a non-prefix signal to pick by.
- Delete `twdesk/desk.go` and `twspaces/spaces_desc.go` (now-unused marketing blurbs); replace toolset references with terse constants matching the existing `peopleDescription` / `timeDescription` style.

## Token savings (mcp-tokens vs main)

```
base (main)        33,925
current            32,413
delta              -1,512  (-4.46%)
```

twdesk + twspaces tools alone: 11,937 → 10,405 (**−12.8%**).

## Test plan

- [x] `gofmt -s -w .`, `go vet ./...`, `go build ./...` clean
- [x] `go test ./internal/twdesk/... ./internal/twspaces/...` passes
- [x] `go run ./cmd/mcp-tokens -base main` confirms savings
- [ ] Sanity-check tool descriptions render correctly in MCP inspector / consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)