### PR TITLE
Chore: Add back user workload schema

### DIFF
--- a/internal/twprojects/workload.go
+++ b/internal/twprojects/workload.go
@@ -3,6 +3,7 @@ package twprojects
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -20,6 +21,22 @@ import (
 const (
 	MethodUsersWorkload toolsets.Method = "twprojects-users_workload"
 )
+
+var (
+	userWorkloadOutputSchema *jsonschema.Schema
+)
+
+func init() {
+	var err error
+
+	// generate the output schemas only once
+	userWorkloadOutputSchema, err = jsonschema.For[projects.WorkloadResponse](&jsonschema.ForOptions{
+		IgnoreInvalidTypes: true,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate JSON schema for WorkloadResponse: %v", err))
+	}
+}
 
 // UsersWorkload retrieves the workload of users in Teamwork.com.
 func UsersWorkload(engine *twapi.Engine) toolsets.ToolWrapper {
@@ -89,6 +106,7 @@ func UsersWorkload(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{"start_date", "end_date"},
 			},
+			OutputSchema: userWorkloadOutputSchema,
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var workloadRequest projects.WorkloadRequest


### PR DESCRIPTION
## Description

The SDK was fixed, and the workload schema can be added back.

<img width="448" height="610" alt="image" src="https://github.com/user-attachments/assets/89d40403-3bf8-40ba-8d2a-2500f298e6aa" />

Related to: https://github.com/Teamwork/mcp/pull/247

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors