### PR TITLE
Enhancement: Disambiguate confusable twprojects tool descriptions

### DIFF
--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -49,7 +49,7 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodProjectBudgetList),
-			Description: "List project-level budgets.",
+			Description: "List project budgets (top-level project financial budgets). Filter by project_ids or status.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Project Budgets",
 				ReadOnlyHint: true,
@@ -143,7 +143,7 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTasklistBudgetList),
-			Description: "List tasklist-level budgets for a project budget.",
+			Description: "List tasklist budgets nested under a project budget. Requires project_budget_id.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasklist Budgets",
 				ReadOnlyHint: true,

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -423,7 +423,7 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageReplyList),
-			Description: "List replies for a message.",
+			Description: "List replies under a message thread. Filter by message_ids or project_ids.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Message Replies",
 				ReadOnlyHint: true,

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -447,7 +447,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageList),
-			Description: "List messages.",
+			Description: "List project messages (top-level posts). Use list_message_replies for thread replies.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Messages",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -64,12 +64,8 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "The name of the task.",
 					},
 					"tasklist_id": {
-						Type: "integer",
-						Description: "The ID of the tasklist. If you only have the project's name, use the " +
-							string(MethodProjectList) + " method with the search_term parameter to find the project ID, and " +
-							"then the " + string(MethodTasklistList) + " method with the project_id to choose the tasklist ID. If " +
-							"you know the tasklist's name, you may also use the search_term parameter with the " +
-							string(MethodTasklistList) + " method to find the tasklist ID.",
+						Type:        "integer",
+						Description: "Tasklist ID. Use list_tasklists to find one.",
 					},
 					"description": {
 						Description: "The description of the task.",
@@ -946,7 +942,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTaskList),
-			Description: "List tasks. Scope by tasklist_id, project_id, or neither for site-wide.",
+			Description: "List tasks with structured filters (tasklist_id, project_id, or site-wide). For keyword search use search.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasks",
 				ReadOnlyHint: true,

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -941,8 +941,9 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodTaskList),
-			Description: "List tasks with structured filters (tasklist_id, project_id, or site-wide). For keyword search use search.",
+			Name: string(MethodTaskList),
+			Description: "List tasks with structured filters (tasklist_id, project_id, or site-wide). " +
+				"For keyword search use search.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Tasks",
 				ReadOnlyHint: true,

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -228,7 +228,7 @@ func TimerPause(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerPause),
-			Description: "Pause a running timer.",
+			Description: "Pause a running timer; can be resumed later. Use complete_timer to stop permanently.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Pause Timer",
 			},
@@ -271,7 +271,7 @@ func TimerResume(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerResume),
-			Description: "Resume a paused timer.",
+			Description: "Resume a paused timer back to running.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Resume Timer",
 			},
@@ -314,7 +314,7 @@ func TimerComplete(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodTimerComplete),
-			Description: "Stop a timer and convert it to a timelog.",
+			Description: "Stop a timer permanently and convert it to a timelog. Use pause_timer to pause without converting.",
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Complete Timer",
 			},


### PR DESCRIPTION
## Summary
- Cross-reference confusable tool pairs (`pause_timer`/`resume_timer`/`complete_timer`, `list_project_budgets`/`list_tasklist_budgets`, `list_messages`/`list_message_replies`, `list_tasks`/`search`) so the LLM has a non-prefix signal to pick by.
- Shorten the verbose `tasklist_id` pointer in `create_task` (−73 tokens on that tool alone), absorbing the disambiguation additions for a net **−4 token delta** vs `main`.

## Test plan
- [x] `gofmt -s -w .`, `go vet ./...`, `go test ./...` all pass.
- [x] `mcp-tokens -base main` confirms net −4 tokens, no other tools touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)