### PR TITLE
Fix: treat JSON null as absent for optional tool parameters

### DIFF
--- a/internal/helpers/tool_parser.go
+++ b/internal/helpers/tool_parser.go
@@ -94,7 +94,7 @@ func param[T any](
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -205,7 +205,7 @@ func numericParam[T int8 | int16 | int32 | int64 |
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -289,7 +289,7 @@ func timeParam(
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -383,7 +383,7 @@ func timeOnlyParam(
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -479,7 +479,7 @@ func dateParam(
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -576,7 +576,7 @@ func legacyDateParam(
 		return fmt.Errorf("target cannot be nil")
 	}
 	value, ok := params[key]
-	if !ok {
+	if !ok || value == nil {
 		if optional {
 			return nil
 		}
@@ -615,7 +615,7 @@ func OptionalListParam[T any](target *[]T, key string) ParamFunc {
 			return fmt.Errorf("target cannot be nil")
 		}
 		value, ok := params[key]
-		if !ok {
+		if !ok || value == nil {
 			return nil
 		}
 		array, ok := value.([]any)
@@ -673,7 +673,7 @@ func OptionalNumericListParam[T int8 | int16 | int32 | int64 |
 			return fmt.Errorf("target cannot be nil")
 		}
 		value, ok := params[key]
-		if !ok {
+		if !ok || value == nil {
 			return nil
 		}
 		array, ok := value.([]any)
@@ -699,7 +699,7 @@ func OptionalNumericListParam[T int8 | int16 | int32 | int64 |
 func OptionalCustomNumericListParam[T interface{ Add(float64) }](target T, key string) ParamFunc {
 	return func(params map[string]any) error {
 		value, ok := params[key]
-		if !ok {
+		if !ok || value == nil {
 			return nil
 		}
 		array, ok := value.([]any)

--- a/internal/helpers/tool_parser_test.go
+++ b/internal/helpers/tool_parser_test.go
@@ -1,0 +1,72 @@
+package helpers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/teamwork/mcp/internal/helpers"
+)
+
+// TestOptionalParamsAcceptNull verifies that optional parameter parsers treat
+// JSON null (nil) as "not provided" rather than returning a type error. This
+// matters because the input schemas declare optional params as AnyOf([T, null]),
+// so strict-mode clients and some LLMs may explicitly pass null.
+func TestOptionalParamsAcceptNull(t *testing.T) {
+	t.Run("OptionalParam nil", func(t *testing.T) {
+		var s string
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalParam(&s, "k")); err != nil {
+			t.Errorf("expected nil error for null optional string, got: %v", err)
+		}
+	})
+
+	t.Run("OptionalNumericParam nil", func(t *testing.T) {
+		var n int64
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalNumericParam(&n, "k")); err != nil {
+			t.Errorf("expected nil error for null optional int64, got: %v", err)
+		}
+	})
+
+	t.Run("OptionalNumericListParam nil", func(t *testing.T) {
+		var l []int64
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalNumericListParam(&l, "k")); err != nil {
+			t.Errorf("expected nil error for null optional int64 list, got: %v", err)
+		}
+	})
+
+	t.Run("OptionalListParam nil", func(t *testing.T) {
+		var l []string
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalListParam(&l, "k")); err != nil {
+			t.Errorf("expected nil error for null optional string list, got: %v", err)
+		}
+	})
+
+	t.Run("OptionalPointerParam nil leaves pointer unset", func(t *testing.T) {
+		var b *bool
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalPointerParam(&b, "k")); err != nil {
+			t.Errorf("expected nil error for null optional bool pointer, got: %v", err)
+		}
+		if b != nil {
+			t.Errorf("expected pointer to remain nil for null input, got: %v", *b)
+		}
+	})
+
+	t.Run("OptionalNumericPointerParam nil leaves pointer unset", func(t *testing.T) {
+		var n *int64
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalNumericPointerParam(&n, "k")); err != nil {
+			t.Errorf("expected nil error for null optional int64 pointer, got: %v", err)
+		}
+		if n != nil {
+			t.Errorf("expected pointer to remain nil for null input, got: %v", *n)
+		}
+	})
+
+	t.Run("OptionalTimePointerParam nil leaves pointer unset", func(t *testing.T) {
+		var tp *time.Time
+		if err := helpers.ParamGroup(map[string]any{"k": nil}, helpers.OptionalTimePointerParam(&tp, "k")); err != nil {
+			t.Errorf("expected nil error for null optional time pointer, got: %v", err)
+		}
+		if tp != nil {
+			t.Errorf("expected pointer to remain nil for null input, got: %v", *tp)
+		}
+	})
+}


### PR DESCRIPTION
## Description

Optional parameters were declared as AnyOf([T, null]) in input schemas (for OpenAI strict mode), but the parsers failed when a client passed an explicit null — returning a type error instead of treating it as "not provided". This caused the list_tasks tool to return an error response for any null argument, breaking connectors that rely on the structured output.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors