### PR TITLE
Fix: OAuth DCR flow for servers with profile enabled

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	reBearerToken = regexp.MustCompile(`^Bearer (.+)$`)
-	methods       = cli.Methods([]toolsets.Method{toolsets.MethodAll})
+	methods       = cli.NewMethods(toolsets.MethodAll)
 )
 
 // Limit request body size (e.g., 10MB)
@@ -42,10 +42,10 @@ const maxBodySize = 10 * 1024 * 1024 // 10 MB
 func main() {
 	defer handleExit()
 
-	flag.Var(&methods, "toolsets", "Comma-separated list of toolsets to enable")
+	flag.Var(methods, "toolsets", "Comma-separated list of toolsets to enable")
 	flag.Parse()
 
-	resources, teardown := config.Load(os.Stdout)
+	resources, teardown := config.Load(os.Stdout, methods.Profiles()...)
 	defer teardown()
 
 	done := make(chan os.Signal, 1)
@@ -111,17 +111,17 @@ func main() {
 
 func newMCPServer(resources config.Resources) (*mcp.Server, error) {
 	projectsGroup := twprojects.DefaultToolsetGroup(false, false, resources.TeamworkEngine())
-	if err := projectsGroup.EnableToolsets(methods...); err != nil {
+	if err := projectsGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable toolsets: %w", err)
 	}
 
 	deskGroup := twdesk.DefaultToolsetGroup(false, resources.TeamworkHTTPClient())
-	if err := deskGroup.EnableToolsets(methods...); err != nil {
+	if err := deskGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable desk toolsets: %w", err)
 	}
 
 	spacesGroup := twspaces.DefaultToolsetGroup(false, resources.TeamworkHTTPClient())
-	if err := spacesGroup.EnableToolsets(methods...); err != nil {
+	if err := spacesGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable spaces toolsets: %w", err)
 	}
 
@@ -172,22 +172,44 @@ func newRouter(resources config.Resources) *http.ServeMux {
 }
 
 func addRouterMiddlewares(resources config.Resources, mux *http.ServeMux) http.Handler {
-	return limitBodyMiddleware(
-		requestInfoMiddleware(
-			logMiddleware(resources.Logger(),
-				sentryMiddleware(
-					resources,
-					tracerMiddleware(
+	return stripProfile(resources.Info.MCPProfiles,
+		limitBodyMiddleware(
+			requestInfoMiddleware(
+				logMiddleware(resources.Logger(),
+					sentryMiddleware(
 						resources,
-						authMiddleware(
+						tracerMiddleware(
 							resources,
-							mux,
+							authMiddleware(
+								resources,
+								mux,
+							),
 						),
 					),
 				),
 			),
 		),
 	)
+}
+
+// stripProfile is a middleware that checks if the request path starts with a
+// known profile name, and if so, it strips the profile from the path and sets
+// an "TW-MCP-Profile" header with the profile name. This allows clients to use
+// URLs like "/project-manager/endpoint" to access the same endpoints as
+// "/endpoint" but with a profile context.
+func stripProfile(profiles []string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the path starts with a known profile, strip it and set a header
+		r.Header.Set("TW-MCP-Profile", "")
+		for _, profile := range profiles {
+			if strings.HasPrefix(r.URL.Path, "/"+profile+"/") {
+				r.URL.Path = strings.TrimPrefix(r.URL.Path, "/"+profile)
+				r.Header.Add("TW-MCP-Profile", profile)
+				break
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func limitBodyMiddleware(next http.Handler) http.Handler {

--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	methods   = cli.Methods([]toolsets.Method{toolsets.MethodAll})
+	methods   = cli.NewMethods(toolsets.MethodAll)
 	readOnly  bool
 	logToFile string
 )
@@ -30,7 +30,7 @@ var (
 func main() {
 	defer handleExit()
 
-	flag.Var(&methods, "toolsets", "Comma-separated list of toolsets to enable")
+	flag.Var(methods, "toolsets", "Comma-separated list of toolsets to enable")
 	flag.StringVar(&logToFile, "log-to-file", "", "Path to log file (if empty, logs to stderr)")
 	flag.BoolVar(&readOnly, "read-only", false, "Restrict the server to read-only operations")
 	flag.Parse()
@@ -114,17 +114,17 @@ func main() {
 
 func newMCPServer(resources config.Resources) (*mcp.Server, error) {
 	projectsGroup := twprojects.DefaultToolsetGroup(readOnly, false, resources.TeamworkEngine())
-	if err := projectsGroup.EnableToolsets(methods...); err != nil {
+	if err := projectsGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable projects toolsets: %w", err)
 	}
 
 	deskGroup := twdesk.DefaultToolsetGroup(readOnly, resources.TeamworkHTTPClient())
-	if err := deskGroup.EnableToolsets(methods...); err != nil {
+	if err := deskGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable desk toolsets: %w", err)
 	}
 
 	spacesGroup := twspaces.DefaultToolsetGroup(readOnly, resources.TeamworkHTTPClient())
-	if err := spacesGroup.EnableToolsets(methods...); err != nil {
+	if err := spacesGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable spaces toolsets: %w", err)
 	}
 

--- a/internal/cli/methods.go
+++ b/internal/cli/methods.go
@@ -44,12 +44,22 @@ func init() {
 
 // Methods is a slice of toolsets.Method that implements the flag.Value
 // interface, allowing it to be used as a command-line flag type.
-type Methods []toolsets.Method
+type Methods struct {
+	profiles []string
+	toolsets []toolsets.Method
+}
+
+// NewMethods creates a new Methods instance with the specified initial methods.
+func NewMethods(initial ...toolsets.Method) *Methods {
+	return &Methods{
+		toolsets: initial,
+	}
+}
 
 // String returns a comma-separated string representation of the Methods slice.
 func (m Methods) String() string {
-	methods := make([]string, len(m))
-	for i, method := range m {
+	methods := make([]string, len(m.toolsets))
+	for i, method := range m.toolsets {
 		methods[i] = method.String()
 	}
 	return strings.Join(methods, ", ")
@@ -63,22 +73,33 @@ func (m *Methods) Set(value string) error {
 	if value == "" || m == nil {
 		return nil
 	}
-	*m = (*m)[:0] // reset slice
+	m.toolsets = m.toolsets[:0] // reset slice
 
 	var errs error
 	for token := range strings.SplitSeq(value, ",") {
 		token = strings.TrimSpace(token)
 		// expand named profiles into their constituent methods
 		if profileMethods, ok := toolsets.LookupProfile(token); ok {
-			*m = append(*m, profileMethods...)
+			m.toolsets = append(m.toolsets, profileMethods...)
+			m.profiles = append(m.profiles, token)
 			continue
 		}
 		if method := toolsets.Method(token); method.IsRegistered() {
-			*m = append(*m, method)
+			m.toolsets = append(m.toolsets, method)
 		} else {
 			errs = errors.Join(errs, fmt.Errorf(`invalid toolset: %q (use a sub-toolset key like "twprojects-tasks", a `+
 				`profile like "project-manager", or "all")`, token))
 		}
 	}
 	return errs
+}
+
+// Toolsets returns the list of enabled toolset methods.
+func (m *Methods) Toolsets() []toolsets.Method {
+	return m.toolsets
+}
+
+// Profiles returns the list of enabled profiles.
+func (m *Methods) Profiles() []string {
+	return m.profiles
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,8 @@ const (
 )
 
 // Load loads the configuration for the MCP service.
-func Load(logOutput io.Writer) (Resources, func()) {
-	resources := newResources()
+func Load(logOutput io.Writer, profiles ...string) (Resources, func()) {
+	resources := newResources(profiles...)
 	resources.logger = slog.New(newCustomLogHandler(resources, logOutput))
 	resources.teamworkHTTPClient = new(http.Client)
 

--- a/internal/config/resources.go
+++ b/internal/config/resources.go
@@ -36,6 +36,11 @@ type Resources struct {
 		// MCPURL is the base URL of the MCP server. This is useful for the MCP
 		// server in HTTP mode.
 		MCPURL string
+		// MCPProfiles is the list of profiles to be enabled in the MCP server. This
+		// is useful for the MCP server in HTTP mode, where different profiles can
+		// be accessed via different URL paths (e.g. "/project-manager/endpoint" for
+		// the "project-manager" profile).
+		MCPProfiles []string
 		// APIURL is the base URL of the Teamwork API.
 		APIURL string
 		// HAProxyURL is the URL of the HAProxy instance. This is useful for the MCP
@@ -75,13 +80,14 @@ type Resources struct {
 	}
 }
 
-func newResources() Resources {
+func newResources(profiles ...string) Resources {
 	var resources Resources
 	resources.Info.Version = getEnv("TW_MCP_VERSION", Version)
 	resources.Info.ServerAddress = getEnv("TW_MCP_SERVER_ADDRESS", ":8080")
 	resources.Info.Environment = getEnv("TW_MCP_ENV", "dev")
 	resources.Info.AWSRegion = getEnv("TW_MCP_AWS_REGION", "us-east-1")
 	resources.Info.MCPURL = strings.TrimSuffix(getEnv("TW_MCP_URL", "https://mcp.ai.teamwork.com"), "/")
+	resources.Info.MCPProfiles = profiles
 	resources.Info.APIURL = strings.TrimSuffix(getEnv("TW_MCP_API_URL", "https://teamwork.com"), "/")
 	resources.Info.HAProxyURL = getEnv("TW_MCP_HAPROXY_URL", "")
 	resources.Info.BearerToken = getEnv("TW_MCP_BEARER_TOKEN", "")
@@ -97,6 +103,19 @@ func newResources() Resources {
 	resources.Info.DatadogAPM.StatsdPort = getEnv("DD_DOGSTATSD_PORT", "8125")
 	resources.Info.DatadogAPM.Environment = getEnv("DD_ENV", resources.Info.Environment)
 	resources.Info.DatadogAPM.Version = getEnv("DD_VERSION", resources.Info.Version)
+
+	// only append the profile to the MCP URL if there is exactly one profile, to
+	// avoid confusion with multiple profiles
+	var mcpURLHasProfile bool
+	for _, profile := range profiles {
+		if strings.HasSuffix(resources.Info.MCPURL, "/"+profile) {
+			mcpURLHasProfile = true
+			break
+		}
+	}
+	if len(profiles) == 1 && !mcpURLHasProfile {
+		resources.Info.MCPURL += "/" + profiles[0]
+	}
 
 	return resources
 }


### PR DESCRIPTION
## Description

* Strip the profile from the request path to correctly handle static paths
* Set the correct OAuth protected resources metadata for profile servers

This assumes that profile servers will have the profile as a sub-path. For example, when running:

```
mcp-http -toolsets=project-manager
```

It's expected that the routing to hit this HTTP server will be:

```
https://my-mcp.example.com/project-manager
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors