### PR TITLE
Feature: twprojects - Verbose flag

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build *)",
+      "Bash(go test *)",
+      "Bash(go vet *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Desktop.ini
 *.swo
 *~
 .#*
+
+# AI file
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,9 @@ Common variables (subset; see command READMEs for complete lists):
 - `list_*` tools follow a specific contract — see `TaskList` in `internal/twprojects/tasks.go` as the canonical pattern:
   - Expose a `verbose` parameter (default `true`) via `helpers.VerboseSchema()`.
   - Execute the request with `twapi.ExecuteRaw(ctx, engine, req)` and stream the body straight to the caller, instead of decoding into the typed `*XxxListResponse` (avoids re-marshalling and preserves any fields the SDK struct doesn't model).
-  - When `verbose=false`: set sparse fields on `req.Filters.Fields.<Entity>` to a minimal set (typically `id` + name/title), skip any hardcoded `Filters.Include` sideloads, and **omit `StructuredContent`** from the result (text content only). Sparse responses do not satisfy the auto-generated `OutputSchema`, so populating `StructuredContent` would break clients that strictly validate.
-  - When `verbose=true`: keep the existing typed contract (sideloads + `StructuredContent` populated from the decoded body so output-schema validation continues to work).
+  - When `verbose=false`: set sparse fields on `req.Filters.Fields.<Entity>` to a minimal set (typically `id` + name/title) and skip any hardcoded `Filters.Include` sideloads.
+  - When `verbose=true`: include sideloads and the full field set.
+  - Wrap the published output schema with `helpers.WithOptionalFields(...)` at the `OutputSchema:` line (not in the `init()` block — keep `get_*` schemas strict). This clears every nested `required` array so sparse responses returned when `verbose=false` still validate. `StructuredContent` is always populated in both modes.
 - Run `go test ./internal/twprojects` until green.
 
 ## Security considerations for agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ Common variables (subset; see command READMEs for complete lists):
   - Write tools → `AddWriteTools(...)` (and behind `allowDelete` for deletes)
 - Add tests in the matching `*_test.go` file using `mcpServerMock(...)` and `toolRequest` helpers found in `internal/twprojects/main_test.go`.
 - JSON-Schema gotcha (OpenAI Responses API): every `Type: "array"` node — including inside `AnyOf`/`OneOf`/`AllOf` branches — must declare `Items`. OpenAI rejects bare arrays at tool-registration time even with `strict: false`; Anthropic does not, so Claude Desktop hides the bug. `TestToolInputSchemasArrayItems` in `internal/twprojects/tools_test.go` guards this — if it fires, pick the right item schema rather than weakening the test.
+- `list_*` tools follow a specific contract — see `TaskList` in `internal/twprojects/tasks.go` as the canonical pattern:
+  - Expose a `verbose` parameter (default `true`) via `helpers.VerboseSchema()`.
+  - Execute the request with `twapi.ExecuteRaw(ctx, engine, req)` and stream the body straight to the caller, instead of decoding into the typed `*XxxListResponse` (avoids re-marshalling and preserves any fields the SDK struct doesn't model).
+  - When `verbose=false`: set sparse fields on `req.Filters.Fields.<Entity>` to a minimal set (typically `id` + name/title), skip any hardcoded `Filters.Include` sideloads, and **omit `StructuredContent`** from the result (text content only). Sparse responses do not satisfy the auto-generated `OutputSchema`, so populating `StructuredContent` would break clients that strictly validate.
+  - When `verbose=true`: keep the existing typed contract (sideloads + `StructuredContent` populated from the decoded body so output-schema validation continues to work).
 - Run `go test ./internal/twprojects` until green.
 
 ## Security considerations for agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Common variables (subset; see command READMEs for complete lists):
   - When `verbose=false`: set sparse fields on `req.Filters.Fields.<Entity>` to a minimal set (typically `id` + name/title) and skip any hardcoded `Filters.Include` sideloads.
   - When `verbose=true`: include sideloads and the full field set.
   - Wrap the published output schema with `helpers.WithOptionalFields(...)` at the `OutputSchema:` line (not in the `init()` block — keep `get_*` schemas strict). This clears every nested `required` array so sparse responses returned when `verbose=false` still validate. `StructuredContent` is always populated in both modes.
+  - OpenAI strict-mode caveat: because `verbose=false` returns a sparse subset of fields, `list_*` output schemas cannot satisfy OpenAI's strict structured-output mode (which requires every property to be `required` and forbids `additionalProperties`). Clients targeting `list_*` tools must run with strict mode disabled; `get_*` tools remain strict-compatible.
 - Run `go test ./internal/twprojects` until green.
 
 ## Security considerations for agents

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -60,17 +60,15 @@ Ask an account administrator to enable MCP under **Settings → AI**.
 
 Most `list_*` tools accept an optional `verbose` boolean (default `true`):
 
-- **`verbose=true`** — full entity details. The response conforms to the
-  tool's declared `outputSchema` and `structuredContent` is populated
-  alongside the text content.
+- **`verbose=true`** — full entity details, including any sideloaded related
+  data (custom fields, project categories, etc.).
 - **`verbose=false`** — only a minimal subset of fields (typically `id` and a
   name/title) is returned to reduce response size. Useful when scanning many
-  results to pick an ID before fetching details on a specific one.
+  results to pick an id before fetching details on a specific one via the
+  corresponding `get_*` tool.
 
-> [!IMPORTANT]
-> When `verbose=false`, the response will **not** match the tool's declared
-> `outputSchema` (required fields are intentionally omitted), and
-> `structuredContent` is **not** included — only `content` text. Clients that
-> strictly validate structured output against the schema should fetch each
-> item with `verbose=true` (or the corresponding `get_*` tool) when they need
-> the full payload.
+Structured content (`structuredContent`) is returned in both modes. The
+`outputSchema` published for `list_*` tools marks every property as
+optional, so sparse responses returned when `verbose=false` still validate
+against the schema. Single-entity `get_*` tools keep a strict schema with
+required fields intact.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -51,3 +51,26 @@ Ask an account administrator to enable MCP under **Settings → AI**.
 | **VSCode — GitHub Copilot Chat** | HTTP or STDIO | [vscode-copilot.md](/docs/usage/vscode-copilot.md)   |
 | **Gemini CLI**                   | HTTP          | [gemini-cli.md](/docs/usage/gemini-cli.md)           |
 | **n8n, Appmixer, custom**        | HTTP          | [other-platforms.md](/docs/usage/other-platforms.md) |
+
+---
+
+## Tool Parameters
+
+### `verbose` flag (list tools)
+
+Most `list_*` tools accept an optional `verbose` boolean (default `true`):
+
+- **`verbose=true`** — full entity details. The response conforms to the
+  tool's declared `outputSchema` and `structuredContent` is populated
+  alongside the text content.
+- **`verbose=false`** — only a minimal subset of fields (typically `id` and a
+  name/title) is returned to reduce response size. Useful when scanning many
+  results to pick an ID before fetching details on a specific one.
+
+> [!IMPORTANT]
+> When `verbose=false`, the response will **not** match the tool's declared
+> `outputSchema` (required fields are intentionally omitted), and
+> `structuredContent` is **not** included — only `content` text. Clients that
+> strictly validate structured output against the schema should fetch each
+> item with `verbose=true` (or the corresponding `get_*` tool) when they need
+> the full payload.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -72,3 +72,11 @@ Structured content (`structuredContent`) is returned in both modes. The
 optional, so sparse responses returned when `verbose=false` still validate
 against the schema. Single-entity `get_*` tools keep a strict schema with
 required fields intact.
+
+> [!NOTE]
+>
+> Because `list_*` output schemas mark all fields as optional (to support
+> `verbose=false`), they are **incompatible with OpenAI's strict structured-
+> output mode**, which requires every property to be `required` and forbids
+> `additionalProperties`. Clients targeting `list_*` tools must run with
+> strict mode disabled. `get_*` tools remain strict-compatible.

--- a/docs/usage/chat-gpt.md
+++ b/docs/usage/chat-gpt.md
@@ -49,3 +49,12 @@ If the Teamwork.com tools are available, ChatGPT will use them to answer.
 > If the connection fails during OAuth, try opening the **Apps** settings page
 > again and removing the existing Teamwork.com entry before re-creating it.
 > ChatGPT may have cached a stale token.
+
+> [!IMPORTANT]
+>
+> The `list_*` tools (e.g. `twprojects-list_tasks`, `twprojects-list_projects`)
+> expose a `verbose` flag and publish an output schema with all fields marked
+> optional. This is **incompatible with OpenAI's strict structured-output
+> mode**. Ensure the connector is configured with strict mode **disabled**,
+> otherwise `list_*` tool calls will fail schema validation. Single-entity
+> `get_*` tools are unaffected.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d
 	github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d
-	github.com/teamwork/twapi-go-sdk v1.16.2
+	github.com/teamwork/twapi-go-sdk v1.17.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d h1:6+6U0YuIcEtP
 github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d h1:C81tRl2LyM5EW2PyqXj8Ral43vZz9cmZM4vjUt4/LSo=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.16.2 h1:ZaI0NrArd59wgnmzRB913+uJNa7cWtCCJpGSu+6PrSo=
-github.com/teamwork/twapi-go-sdk v1.16.2/go.mod h1:Vf81EGIYiFPTZnFwekPu7pBw2dOdd1tZysdREJjSJfE=
+github.com/teamwork/twapi-go-sdk v1.17.0 h1:BbZE1kgw6YtetsL5aYWT5ZW6yNpbkqxn+mLcWra4/yI=
+github.com/teamwork/twapi-go-sdk v1.17.0/go.mod h1:Vf81EGIYiFPTZnFwekPu7pBw2dOdd1tZysdREJjSJfE=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -101,16 +101,16 @@ func TagIDsAssociateSchema(entity string) *jsonschema.Schema {
 
 // VerboseSchema returns the schema for a verbose flag controlling response
 // detail level. When true (default), full entity details are returned; when
-// false, sparse fieldsets are applied to reduce response size — in that case
-// the response will not conform to the tool's declared output schema and
-// structured content is omitted.
+// false, sparse fieldsets are applied to reduce response size. Structured
+// content is always returned; list-tool output schemas are relaxed (all
+// fields optional) so sparse payloads still validate.
 func VerboseSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Description: "If true (default), the response includes full entity details and conforms to the tool's " +
-			"output schema, with structured content populated. " +
-			"If false, only a minimal subset of fields is returned to reduce response size; in that case the " +
-			"response will not match the declared output schema and structured content is not returned " +
-			"(text content only).",
+		Description: "If true (default), the response includes full entity details. " +
+			"If false, only a minimal subset of fields (typically an id and a name/title) is returned to " +
+			"reduce response size — useful when scanning many results to pick an id before fetching the full " +
+			"entity. Structured content is returned in both modes; the tool's output schema marks all fields " +
+			"as optional so sparse responses still validate.",
 		AnyOf: []*jsonschema.Schema{
 			{Type: "boolean"},
 			{Type: "null"},

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -108,13 +108,12 @@ func VerboseSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Description: "If true (default), the response includes full entity details. " +
 			"If false, only a minimal subset of fields (typically an id and a name/title) is returned to " +
-			"reduce response size — useful when scanning many results to pick an id before fetching the full " +
-			"entity. Structured content is returned in both modes; the tool's output schema marks all fields " +
-			"as optional so sparse responses still validate.",
+			"reduce response size — useful when scanning many results to pick an id before fetching the full entity.",
 		AnyOf: []*jsonschema.Schema{
 			{Type: "boolean"},
 			{Type: "null"},
 		},
+		Default: []byte(`true`),
 	}
 }
 

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -99,6 +99,25 @@ func TagIDsAssociateSchema(entity string) *jsonschema.Schema {
 	}
 }
 
+// VerboseSchema returns the schema for a verbose flag controlling response
+// detail level. When true (default), full entity details are returned; when
+// false, sparse fieldsets are applied to reduce response size — in that case
+// the response will not conform to the tool's declared output schema and
+// structured content is omitted.
+func VerboseSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: "If true (default), the response includes full entity details and conforms to the tool's " +
+			"output schema, with structured content populated. " +
+			"If false, only a minimal subset of fields is returned to reduce response size; in that case the " +
+			"response will not match the declared output schema and structured content is not returned " +
+			"(text content only).",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "boolean"},
+			{Type: "null"},
+		},
+	}
+}
+
 // MatchAllTagsSchema returns the schema for the boolean flag that switches
 // tag filtering between AND (true) and OR (false) semantics.
 func MatchAllTagsSchema(entity string) *jsonschema.Schema {

--- a/internal/helpers/schema_optional.go
+++ b/internal/helpers/schema_optional.go
@@ -2,12 +2,15 @@ package helpers
 
 import "github.com/google/jsonschema-go/jsonschema"
 
-// WithOptionalFields recursively clears the `required` array on a schema and
-// every nested schema it references (Properties, Items, AdditionalProperties,
-// AnyOf/OneOf/AllOf branches). It is intended for list-tool output schemas
-// where sparse fieldsets may omit otherwise-required fields; clearing
-// `required` lets the structured content payload satisfy the schema even when
-// only a subset of fields is returned by the API.
+// WithOptionalFields recursively relaxes a schema and every nested schema it
+// references (Properties, Items, AdditionalProperties, AnyOf/OneOf/AllOf
+// branches) so it can validate sparse or forward-compatible payloads:
+//
+//   - clears the `required` array, so sparse responses that omit fields still
+//     validate;
+//   - clears `additionalProperties` (reverting to the JSON Schema default of
+//     "allowed"), so fields the SDK response struct doesn't model — for
+//     example, new server-side fields — don't cause validation failures.
 //
 // The schema is mutated in place and returned for convenient chaining at the
 // call site:
@@ -20,6 +23,7 @@ import "github.com/google/jsonschema-go/jsonschema"
 func WithOptionalFields(schema *jsonschema.Schema) *jsonschema.Schema {
 	walkSchema(schema, func(s *jsonschema.Schema) {
 		s.Required = nil
+		s.AdditionalProperties = nil
 	})
 	return schema
 }

--- a/internal/helpers/schema_optional.go
+++ b/internal/helpers/schema_optional.go
@@ -1,0 +1,48 @@
+package helpers
+
+import "github.com/google/jsonschema-go/jsonschema"
+
+// WithOptionalFields recursively clears the `required` array on a schema and
+// every nested schema it references (Properties, Items, AdditionalProperties,
+// AnyOf/OneOf/AllOf branches). It is intended for list-tool output schemas
+// where sparse fieldsets may omit otherwise-required fields; clearing
+// `required` lets the structured content payload satisfy the schema even when
+// only a subset of fields is returned by the API.
+//
+// The schema is mutated in place and returned for convenient chaining at the
+// call site:
+//
+//	OutputSchema: helpers.WithOptionalFields(xxxListOutputSchema),
+//
+// Apply this only to list-tool schemas; single-entity `get_*` schemas should
+// retain their strict `required` arrays so clients still receive useful
+// constraints.
+func WithOptionalFields(schema *jsonschema.Schema) *jsonschema.Schema {
+	walkSchema(schema, func(s *jsonschema.Schema) {
+		s.Required = nil
+	})
+	return schema
+}
+
+// walkSchema invokes fn on s and every schema reachable from it via standard
+// JSON Schema composition keywords. It is nil-safe.
+func walkSchema(s *jsonschema.Schema, fn func(*jsonschema.Schema)) {
+	if s == nil {
+		return
+	}
+	fn(s)
+	for _, p := range s.Properties {
+		walkSchema(p, fn)
+	}
+	walkSchema(s.Items, fn)
+	walkSchema(s.AdditionalProperties, fn)
+	for _, b := range s.AnyOf {
+		walkSchema(b, fn)
+	}
+	for _, b := range s.OneOf {
+		walkSchema(b, fn)
+	}
+	for _, b := range s.AllOf {
+		walkSchema(b, fn)
+	}
+}

--- a/internal/helpers/schema_optional_test.go
+++ b/internal/helpers/schema_optional_test.go
@@ -1,0 +1,151 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/teamwork/mcp/internal/helpers"
+)
+
+func TestWithOptionalFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *jsonschema.Schema
+		check  func(t *testing.T, schema *jsonschema.Schema)
+	}{
+		{
+			name:   "nil schema is a no-op",
+			schema: nil,
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema != nil {
+					t.Error("expected nil schema")
+				}
+			},
+		},
+		{
+			name: "top-level required is cleared",
+			schema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id", "name"},
+				Properties: map[string]*jsonschema.Schema{
+					"id":   {Type: "integer"},
+					"name": {Type: "string"},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Required != nil {
+					t.Errorf("expected nil required, got %v", schema.Required)
+				}
+			},
+		},
+		{
+			name: "nested object required is cleared",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"task": {
+						Type:     "object",
+						Required: []string{"id", "name", "status"},
+						Properties: map[string]*jsonschema.Schema{
+							"id":     {Type: "integer"},
+							"name":   {Type: "string"},
+							"status": {Type: "string"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["task"].Required != nil {
+					t.Errorf("expected nested required to be nil, got %v", schema.Properties["task"].Required)
+				}
+			},
+		},
+		{
+			name: "array items required is cleared",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"tasks": {
+						Type: "array",
+						Items: &jsonschema.Schema{
+							Type:     "object",
+							Required: []string{"id"},
+							Properties: map[string]*jsonschema.Schema{
+								"id": {Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["tasks"].Items.Required != nil {
+					t.Errorf("expected items required to be nil, got %v", schema.Properties["tasks"].Items.Required)
+				}
+			},
+		},
+		{
+			name: "anyOf branches required is cleared",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"value": {
+						AnyOf: []*jsonschema.Schema{
+							{
+								Type:     "object",
+								Required: []string{"a"},
+								Properties: map[string]*jsonschema.Schema{
+									"a": {Type: "string"},
+								},
+							},
+							{Type: "null"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.Properties["value"].AnyOf[0].Required != nil {
+					t.Errorf("expected anyOf branch required to be nil, got %v", schema.Properties["value"].AnyOf[0].Required)
+				}
+			},
+		},
+		{
+			name: "additionalProperties required is cleared",
+			schema: &jsonschema.Schema{
+				Type: "object",
+				AdditionalProperties: &jsonschema.Schema{
+					Type:     "object",
+					Required: []string{"id"},
+					Properties: map[string]*jsonschema.Schema{
+						"id": {Type: "integer"},
+					},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.AdditionalProperties.Required != nil {
+					t.Errorf("expected additionalProperties required to be nil, got %v", schema.AdditionalProperties.Required)
+				}
+			},
+		},
+		{
+			name: "returns same schema for chaining",
+			schema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{"id"},
+			},
+			check: func(_ *testing.T, _ *jsonschema.Schema) {
+				// nothing extra; sameness is checked at the test boundary
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.schema
+			got := helpers.WithOptionalFields(input)
+			if input != nil && got != input {
+				t.Errorf("expected WithOptionalFields to return the same pointer for chaining")
+			}
+			tt.check(t, got)
+		})
+	}
+}

--- a/internal/helpers/schema_optional_test.go
+++ b/internal/helpers/schema_optional_test.go
@@ -109,20 +109,52 @@ func TestWithOptionalFields(t *testing.T) {
 			},
 		},
 		{
-			name: "additionalProperties required is cleared",
+			name: "top-level additionalProperties is cleared",
+			schema: &jsonschema.Schema{
+				Type:                 "object",
+				AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}}, // falseSchema()
+				Properties: map[string]*jsonschema.Schema{
+					"id": {Type: "integer"},
+				},
+			},
+			check: func(t *testing.T, schema *jsonschema.Schema) {
+				if schema.AdditionalProperties != nil {
+					t.Errorf("expected additionalProperties to be nil, got %#v", schema.AdditionalProperties)
+				}
+			},
+		},
+		{
+			name: "nested additionalProperties is cleared",
 			schema: &jsonschema.Schema{
 				Type: "object",
-				AdditionalProperties: &jsonschema.Schema{
-					Type:     "object",
-					Required: []string{"id"},
-					Properties: map[string]*jsonschema.Schema{
-						"id": {Type: "integer"},
+				Properties: map[string]*jsonschema.Schema{
+					"task": {
+						Type:                 "object",
+						AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+						Properties: map[string]*jsonschema.Schema{
+							"id": {Type: "integer"},
+						},
+					},
+					"tasks": {
+						Type: "array",
+						Items: &jsonschema.Schema{
+							Type:                 "object",
+							AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+							Properties: map[string]*jsonschema.Schema{
+								"id": {Type: "integer"},
+							},
+						},
 					},
 				},
 			},
 			check: func(t *testing.T, schema *jsonschema.Schema) {
-				if schema.AdditionalProperties.Required != nil {
-					t.Errorf("expected additionalProperties required to be nil, got %v", schema.AdditionalProperties.Required)
+				if schema.Properties["task"].AdditionalProperties != nil {
+					t.Errorf("expected nested additionalProperties to be nil, got %#v",
+						schema.Properties["task"].AdditionalProperties)
+				}
+				if schema.Properties["tasks"].Items.AdditionalProperties != nil {
+					t.Errorf("expected items additionalProperties to be nil, got %#v",
+						schema.Properties["tasks"].Items.AdditionalProperties)
 				}
 			},
 		},

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -114,7 +114,7 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: activityListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(activityListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var activityListRequest projects.ActivityListRequest
@@ -164,13 +164,11 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -108,6 +110,7 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -120,6 +123,7 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&activityListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalTimeParam(&activityListRequest.Filters.StartDate, "start_date"),
@@ -127,16 +131,47 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalListParam(&activityListRequest.Filters.LogItemTypes, "log_item_types"),
 				helpers.OptionalNumericParam(&activityListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&activityListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			activityList, err := projects.ActivityList(ctx, engine, activityListRequest)
+			if !verbose {
+				activityListRequest.Filters.Fields.Activities = []projects.ActivityField{
+					projects.ActivityFieldID,
+					projects.ActivityFieldDescription,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, activityListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list activities")
 			}
-			return helpers.NewToolResultJSON(activityList)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list activities"), "failed to list activities")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(body)},
+				},
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -86,6 +88,7 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"verbose": helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -98,6 +101,7 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericListParam(&projectBudgetListRequest.Filters.ProjectIDs, "project_ids"),
 				helpers.OptionalParam(
@@ -112,28 +116,49 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericParam(&projectBudgetListRequest.Filters.Limit, "limit"),
 				helpers.OptionalNumericParam(&projectBudgetListRequest.Filters.PageSize, "page_size"),
 				helpers.OptionalParam(&projectBudgetListRequest.Filters.Cursor, "cursor"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
+			if !verbose {
+				projectBudgetListRequest.Filters.Fields.Budgets = []projects.ProjectBudgetField{
+					projects.ProjectBudgetFieldID,
+					projects.ProjectBudgetFieldType,
+				}
+			}
 
-			projectBudgetList, err := projects.ProjectBudgetList(ctx, engine, projectBudgetListRequest)
+			resp, err := twapi.ExecuteRaw(ctx, engine, projectBudgetListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list project budgets")
 			}
-
-			encoded, err := json.Marshal(projectBudgetList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list project budgets"),
+					"failed to list project budgets",
+				)
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: projectBudgetList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }
@@ -157,6 +182,7 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{"project_budget_id"},
 			},
@@ -177,31 +203,53 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 			}
 
 			tasklistBudgetListRequest := projects.NewTasklistBudgetListRequest(projectBudgetID)
+			verbose := true
 			err = helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&tasklistBudgetListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&tasklistBudgetListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
+			if !verbose {
+				tasklistBudgetListRequest.Filters.Fields.TasklistBudgets = []projects.TasklistBudgetField{
+					projects.TasklistBudgetFieldID,
+					projects.TasklistBudgetFieldType,
+				}
+			}
 
-			tasklistBudgetList, err := projects.TasklistBudgetList(ctx, engine, tasklistBudgetListRequest)
+			resp, err := twapi.ExecuteRaw(ctx, engine, tasklistBudgetListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list tasklist budgets")
 			}
-
-			encoded, err := json.Marshal(tasklistBudgetList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list tasklist budgets"),
+					"failed to list tasklist budgets",
+				)
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: tasklistBudgetList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -92,7 +92,7 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: projectBudgetListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(projectBudgetListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			projectBudgetListRequest := projects.NewProjectBudgetListRequest()
@@ -151,13 +151,11 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}
@@ -186,7 +184,7 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{"project_budget_id"},
 			},
-			OutputSchema: tasklistBudgetListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(tasklistBudgetListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var projectBudgetID int64
@@ -242,13 +240,11 @@ func TasklistBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -568,6 +570,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -580,6 +583,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&commentListRequest.Path.TaskID, "task_id"),
 				helpers.OptionalNumericParam(&commentListRequest.Path.MilestoneID, "milestone_id"),
@@ -590,6 +594,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
@@ -600,23 +605,41 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
-			commentList, err := projects.CommentList(ctx, engine, commentListRequest)
+			if !verbose {
+				commentListRequest.Filters.Fields.Comments = []projects.CommentField{
+					projects.CommentFieldID,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, commentListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list comments")
 			}
-
-			encoded, err := json.Marshal(commentList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list comments"), "failed to list comments")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, commentPathBuilder)
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, commentPathBuilder)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, commentList, commentPathBuilder),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -574,7 +574,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: commentListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(commentListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var commentListRequest projects.CommentListRequest
@@ -632,13 +632,11 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/companies.go
+++ b/internal/twprojects/companies.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -521,6 +523,7 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"match_all_tags": helpers.MatchAllTagsSchema("companies"),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
+					"verbose":        helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -529,50 +532,67 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var companyListRequest projects.CompanyListRequest
 
-			// Always include custom fields and values in the response to provide more
-			// context about the company. Custom fields often contain important
-			// metadata relevant to the company.
-			companyListRequest.Filters.Include = []projects.CompanyRequestSideload{
-				projects.CompanyRequestSideloadCustomFields,
-				projects.CompanyRequestSideloadCustomFieldValues,
-			}
-
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&companyListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&companyListRequest.Filters.TagIDs, "tag_ids"),
 				helpers.OptionalPointerParam(&companyListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&companyListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&companyListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			companyList, err := projects.CompanyList(ctx, engine, companyListRequest)
+			if verbose {
+				// Include custom fields and values in the response to provide more
+				// context about the company. Custom fields often contain important
+				// metadata relevant to the company.
+				companyListRequest.Filters.Include = []projects.CompanyRequestSideload{
+					projects.CompanyRequestSideloadCustomFields,
+					projects.CompanyRequestSideloadCustomFieldValues,
+				}
+			} else {
+				companyListRequest.Filters.Fields.Companies = []projects.CompanyField{
+					projects.CompanyFieldID,
+					projects.CompanyFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, companyListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list companies")
 			}
-
-			encoded, err := json.Marshal(companyList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list companies"), "failed to list companies")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/clients"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/clients"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, companyList,
-					helpers.WebLinkerWithIDPathBuilder("/app/clients"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/companies.go
+++ b/internal/twprojects/companies.go
@@ -527,7 +527,7 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: companyListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(companyListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var companyListRequest projects.CompanyListRequest
@@ -585,13 +585,11 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/custom_field_values.go
+++ b/internal/twprojects/custom_field_values.go
@@ -486,7 +486,7 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{"entity", "entity_id"},
 			},
-			OutputSchema: customFieldValueListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(customFieldValueListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var arguments map[string]any
@@ -564,13 +564,11 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/custom_field_values.go
+++ b/internal/twprojects/custom_field_values.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -480,6 +482,7 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{"entity", "entity_id"},
 			},
@@ -495,6 +498,7 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 			var entityID int64
 			var customFieldIDs []int64
 			var page, pageSize int64
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredParam(&entity, "entity",
 					helpers.RestrictValues(
@@ -507,6 +511,7 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericListParam(&customFieldIDs, "custom_field_ids"),
 				helpers.OptionalNumericParam(&page, "page"),
 				helpers.OptionalNumericParam(&pageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
@@ -528,12 +533,45 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if pageSize > 0 {
 				customFieldValueListRequest.Filters.PageSize = pageSize
 			}
+			if !verbose {
+				customFieldValueListRequest.Filters.Fields.CustomFieldValues = []projects.CustomFieldValueField{
+					projects.CustomFieldValueFieldID,
+					projects.CustomFieldValueFieldValue,
+					projects.CustomFieldValueFieldCustomField,
+				}
+			}
 
-			response, err := projects.CustomFieldValueList(ctx, engine, customFieldValueListRequest)
+			resp, err := twapi.ExecuteRaw(ctx, engine, customFieldValueListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list custom field values")
 			}
-			return helpers.NewToolResultJSON(response)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list custom field values"),
+					"failed to list custom field values",
+				)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(body)},
+				},
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/custom_fields.go
+++ b/internal/twprojects/custom_fields.go
@@ -644,7 +644,7 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: customFieldListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(customFieldListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var customFieldListRequest projects.CustomFieldListRequest
@@ -722,13 +722,11 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/custom_fields.go
+++ b/internal/twprojects/custom_fields.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -638,6 +640,7 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -651,6 +654,7 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
 
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&customFieldListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&customFieldListRequest.Filters.IDs, "ids"),
@@ -682,16 +686,50 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 				),
 				helpers.OptionalNumericParam(&customFieldListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&customFieldListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			customFieldList, err := projects.CustomFieldList(ctx, engine, customFieldListRequest)
+			if !verbose {
+				customFieldListRequest.Filters.Fields.CustomFields = []projects.CustomFieldField{
+					projects.CustomFieldFieldID,
+					projects.CustomFieldFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, customFieldListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list custom fields")
 			}
-			return helpers.NewToolResultJSON(customFieldList)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list custom fields"),
+					"failed to list custom fields",
+				)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(body)},
+				},
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/jobroles.go
+++ b/internal/twprojects/jobroles.go
@@ -270,7 +270,7 @@ func JobRoleList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: jobRoleListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(jobRoleListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var jobRoleListRequest projects.JobRoleListRequest
@@ -317,13 +317,11 @@ func JobRoleList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/jobroles.go
+++ b/internal/twprojects/jobroles.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -264,6 +266,7 @@ func JobRoleList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -276,32 +279,52 @@ func JobRoleList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&jobRoleListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&jobRoleListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&jobRoleListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			jobRoleList, err := projects.JobRoleList(ctx, engine, jobRoleListRequest)
+			if !verbose {
+				jobRoleListRequest.Filters.Fields.JobRoles = []projects.JobRoleField{
+					projects.JobRoleFieldID,
+					projects.JobRoleFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, jobRoleListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list job roles")
 			}
-
-			encoded, err := json.Marshal(jobRoleList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list job roles"), "failed to list job roles")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: jobRoleList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/links.go
+++ b/internal/twprojects/links.go
@@ -513,7 +513,7 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: linkListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(linkListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var linkListRequest projects.LinkListRequest
@@ -564,13 +564,11 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/links.go
+++ b/internal/twprojects/links.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 
@@ -507,6 +509,7 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"match_all_tags": helpers.MatchAllTagsSchema("links"),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
+					"verbose":        helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -519,6 +522,7 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&linkListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&linkListRequest.Filters.ProjectID, "project_id"),
@@ -526,32 +530,48 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalPointerParam(&linkListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&linkListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&linkListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			linkList, err := projects.LinkList(ctx, engine, linkListRequest)
+			if !verbose {
+				linkListRequest.Filters.Fields.Links = []projects.LinkField{
+					projects.LinkFieldID,
+					projects.LinkFieldTitle,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, linkListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list links")
 			}
-
-			encoded, err := json.Marshal(linkList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list links"), "failed to list links")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/links"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/links"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, linkList,
-					helpers.WebLinkerWithIDPathBuilder("/app/links"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -457,6 +459,7 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -469,34 +472,56 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&messageReplyListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&messageReplyListRequest.Filters.MessageIDs, "message_ids"),
 				helpers.OptionalNumericListParam(&messageReplyListRequest.Filters.ProjectIDs, "project_ids"),
 				helpers.OptionalNumericParam(&messageReplyListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&messageReplyListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			messageReplyList, err := projects.MessageReplyList(ctx, engine, messageReplyListRequest)
+			if !verbose {
+				messageReplyListRequest.Filters.Fields.MessageReplies = []projects.MessageReplyField{
+					projects.MessageReplyFieldID,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, messageReplyListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list message replies")
 			}
-
-			encoded, err := json.Marshal(messageReplyList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list message replies"),
+					"failed to list message replies",
+				)
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: messageReplyList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -463,7 +463,7 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: messageReplyListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(messageReplyListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var messageReplyListRequest projects.MessageReplyListRequest
@@ -514,13 +514,11 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -476,6 +478,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"match_all_tags": helpers.MatchAllTagsSchema("messages"),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
+					"verbose":        helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -488,6 +491,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&messageListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&messageListRequest.Filters.ProjectIDs, "project_ids"),
@@ -495,32 +499,48 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalPointerParam(&messageListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&messageListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&messageListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			messageList, err := projects.MessageList(ctx, engine, messageListRequest)
+			if !verbose {
+				messageListRequest.Filters.Fields.Messages = []projects.MessageField{
+					projects.MessageFieldID,
+					projects.MessageFieldTitle,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, messageListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list messages")
 			}
-
-			encoded, err := json.Marshal(messageList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list messages"), "failed to list messages")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/messages"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/messages"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, messageList,
-					helpers.WebLinkerWithIDPathBuilder("/app/messages"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -482,7 +482,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: messageListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(messageListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var messageListRequest projects.MessageListRequest
@@ -533,13 +533,11 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -444,6 +446,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"match_all_tags": helpers.MatchAllTagsSchema("milestones"),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
+					"verbose":        helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -456,6 +459,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&milestoneListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&milestoneListRequest.Filters.SearchTerm, "search_term"),
@@ -463,32 +467,48 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalPointerParam(&milestoneListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&milestoneListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&milestoneListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			milestoneList, err := projects.MilestoneList(ctx, engine, milestoneListRequest)
+			if !verbose {
+				milestoneListRequest.Filters.Fields.Milestones = []projects.MilestoneField{
+					projects.MilestoneFieldID,
+					projects.MilestoneFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, milestoneListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list milestones")
 			}
-
-			encoded, err := json.Marshal(milestoneList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list milestones"), "failed to list milestones")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/milestones"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, milestoneList,
-					helpers.WebLinkerWithIDPathBuilder("/app/milestones"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -450,7 +450,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: milestoneListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(milestoneListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var milestoneListRequest projects.MilestoneListRequest
@@ -501,13 +501,11 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/notebooks.go
+++ b/internal/twprojects/notebooks.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -348,6 +350,7 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -360,6 +363,7 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericListParam(&notebookListRequest.Filters.ProjectIDs, "project_ids"),
 				helpers.OptionalParam(&notebookListRequest.Filters.SearchTerm, "search_term"),
@@ -368,32 +372,48 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalPointerParam(&notebookListRequest.Filters.IncludeContents, "include_contents"),
 				helpers.OptionalNumericParam(&notebookListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&notebookListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			notebookList, err := projects.NotebookList(ctx, engine, notebookListRequest)
+			if !verbose {
+				notebookListRequest.Filters.Fields.Notebooks = []projects.NotebookField{
+					projects.NotebookFieldID,
+					projects.NotebookFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, notebookListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list notebooks")
 			}
-
-			encoded, err := json.Marshal(notebookList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list notebooks"), "failed to list notebooks")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/notebooks"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/notebooks"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, notebookList,
-					helpers.WebLinkerWithIDPathBuilder("/app/notebooks"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/notebooks.go
+++ b/internal/twprojects/notebooks.go
@@ -354,7 +354,7 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: notebookListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(notebookListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var notebookListRequest projects.NotebookListRequest
@@ -406,13 +406,11 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/project_categories.go
+++ b/internal/twprojects/project_categories.go
@@ -296,7 +296,7 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: projectCategoryListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(projectCategoryListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var projectCategoryListRequest projects.ProjectCategoryListRequest
@@ -344,13 +344,11 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/project_categories.go
+++ b/internal/twprojects/project_categories.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"reflect"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -290,6 +292,7 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"search_term": helpers.SearchTermSchema("project categories", "name"),
 					"page":        helpers.PageSchema(),
 					"page_size":   helpers.PageSizeSchema(),
+					"verbose":     helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -302,32 +305,53 @@ func ProjectCategoryList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&projectCategoryListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&projectCategoryListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&projectCategoryListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			projectCategoryList, err := projects.ProjectCategoryList(ctx, engine, projectCategoryListRequest)
+			if !verbose {
+				projectCategoryListRequest.Filters.Fields.ProjectCategories = []projects.ProjectCategoryField{
+					projects.ProjectCategoryFieldID,
+					projects.ProjectCategoryFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, projectCategoryListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list projects")
 			}
-
-			encoded, err := json.Marshal(projectCategoryList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list projects"), "failed to list projects")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, projectCategoryPathBuilder)
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded, projectCategoryPathBuilder)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, projectCategoryList, projectCategoryPathBuilder),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -546,6 +548,7 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"match_all_tags": helpers.MatchAllTagsSchema("projects"),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
+					"verbose":        helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -554,20 +557,11 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var projectListRequest projects.ProjectListRequest
 
-			// always include project categories and custom fields in the response to
-			// provide more context about the project, as categories are commonly used
-			// for organizing projects and understanding their purpose, and custom
-			// fields often contain important metadata relevant to the project.
-			projectListRequest.Filters.Include = []projects.ProjectRequestSideload{
-				projects.ProjectRequestSideloadProjectCategories,
-				projects.ProjectRequestSideloadCustomFields,
-				projects.ProjectRequestSideloadCustomFieldValues,
-			}
-
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericListParam(&projectListRequest.Filters.ProjectCategoryIDs, "project_category_ids"),
 				helpers.OptionalParam(&projectListRequest.Filters.SearchTerm, "search_term"),
@@ -575,32 +569,59 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalPointerParam(&projectListRequest.Filters.MatchAllTags, "match_all_tags"),
 				helpers.OptionalNumericParam(&projectListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&projectListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			projectList, err := projects.ProjectList(ctx, engine, projectListRequest)
+			if verbose {
+				// Include project categories and custom fields in the response to
+				// provide more context about the project, as categories are commonly
+				// used for organizing projects and understanding their purpose, and
+				// custom fields often contain important metadata relevant to the
+				// project.
+				projectListRequest.Filters.Include = []projects.ProjectRequestSideload{
+					projects.ProjectRequestSideloadProjectCategories,
+					projects.ProjectRequestSideloadCustomFields,
+					projects.ProjectRequestSideloadCustomFieldValues,
+				}
+			} else {
+				projectListRequest.Filters.Fields.Projects = []projects.ProjectField{
+					projects.ProjectFieldID,
+					projects.ProjectFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, projectListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list projects")
 			}
-
-			encoded, err := json.Marshal(projectList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list projects"), "failed to list projects")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/projects"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/projects"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, projectList,
-					helpers.WebLinkerWithIDPathBuilder("/app/projects"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -552,7 +552,7 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: projectListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(projectListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var projectListRequest projects.ProjectListRequest
@@ -614,13 +614,11 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/skills.go
+++ b/internal/twprojects/skills.go
@@ -286,7 +286,7 @@ func SkillList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: skillListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(skillListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var skillListRequest projects.SkillListRequest
@@ -333,13 +333,11 @@ func SkillList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/skills.go
+++ b/internal/twprojects/skills.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -280,6 +282,7 @@ func SkillList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -292,32 +295,52 @@ func SkillList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&skillListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&skillListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&skillListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			skillList, err := projects.SkillList(ctx, engine, skillListRequest)
+			if !verbose {
+				skillListRequest.Filters.Fields.Skills = []projects.SkillField{
+					projects.SkillFieldID,
+					projects.SkillFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, skillListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list skills")
 			}
-
-			encoded, err := json.Marshal(skillList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list skills"), "failed to list skills")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: skillList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -296,6 +298,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -308,6 +311,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&tagListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalParam(&tagListRequest.Filters.ItemType, "item_type",
@@ -317,16 +321,47 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericListParam(&tagListRequest.Filters.ProjectIDs, "project_ids"),
 				helpers.OptionalNumericParam(&tagListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&tagListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			tagList, err := projects.TagList(ctx, engine, tagListRequest)
+			if !verbose {
+				tagListRequest.Filters.Fields.Tags = []projects.TagField{
+					projects.TagFieldID,
+					projects.TagFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, tagListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list tags")
 			}
-			return helpers.NewToolResultJSON(tagList)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list tags"), "failed to list tags")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(body)},
+				},
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -302,7 +302,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: tagListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(tagListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var tagListRequest projects.TagListRequest
@@ -354,13 +354,11 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -311,7 +311,7 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: tasklistListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(tasklistListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var tasklistListRequest projects.TasklistListRequest
@@ -360,13 +360,11 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/tasklists.go
+++ b/internal/twprojects/tasklists.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -305,6 +307,7 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"search_term": helpers.SearchTermSchema("tasklists", "name"),
 					"page":        helpers.PageSchema(),
 					"page_size":   helpers.PageSizeSchema(),
+					"verbose":     helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -317,37 +320,54 @@ func TasklistList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&tasklistListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&tasklistListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&tasklistListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&tasklistListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			tasklistList, err := projects.TasklistList(ctx, engine, tasklistListRequest)
+			if !verbose {
+				tasklistListRequest.Filters.Fields.Tasklists = []projects.TasklistField{
+					projects.TasklistFieldID,
+					projects.TasklistFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, tasklistListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list tasklists")
 			}
-
-			encoded, err := json.Marshal(tasklistList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list tasklists"), "failed to list tasklists")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/tasklists"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, tasklistList,
-					helpers.WebLinkerWithIDPathBuilder("/app/tasklists"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
-	"github.com/teamwork/twapi-go-sdk"
+	twapi "github.com/teamwork/twapi-go-sdk"
 	"github.com/teamwork/twapi-go-sdk/projects"
 )
 
@@ -1006,6 +1008,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -1014,18 +1017,11 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var taskListRequest projects.TaskListRequest
 
-			// Always include custom fields and values in task list response for
-			// richer context, as they are commonly used in Teamwork projects and
-			// provide valuable information about the task.
-			taskListRequest.Filters.Include = []projects.TaskRequestSideload{
-				projects.TaskRequestSideloadCustomFields,
-				projects.TaskRequestSideloadCustomFieldValues,
-			}
-
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&taskListRequest.Path.TasklistID, "tasklist_id"),
 				helpers.OptionalNumericParam(&taskListRequest.Path.ProjectID, "project_id"),
@@ -1042,32 +1038,57 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.UpdatedBefore, "updated_before"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedAfter, "completed_after"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedBefore, "completed_before"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
+			if verbose {
+				// Include custom fields and values in task list response for richer
+				// context, as they are commonly used in Teamwork projects and provide
+				// valuable information about the task.
+				taskListRequest.Filters.Include = []projects.TaskRequestSideload{
+					projects.TaskRequestSideloadCustomFields,
+					projects.TaskRequestSideloadCustomFieldValues,
+				}
+			} else {
+				taskListRequest.Filters.Fields.Tasks = []projects.TaskField{
+					projects.TaskFieldID,
+					projects.TaskFieldName,
+				}
+			}
 
-			taskList, err := projects.TaskList(ctx, engine, taskListRequest)
+			resp, err := twapi.ExecuteRaw(ctx, engine, taskListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list tasks")
 			}
-
-			encoded, err := json.Marshal(taskList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list tasks"), "failed to list tasks")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/tasks"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
 					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-						)),
+						Text: string(linked),
 					},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, taskList,
-					helpers.WebLinkerWithIDPathBuilder("/app/tasks"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -1012,7 +1012,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: taskListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(taskListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var taskListRequest projects.TaskListRequest
@@ -1081,13 +1081,11 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -392,7 +392,7 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: teamListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(teamListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var teamListRequest projects.TeamListRequest
@@ -449,13 +449,11 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"reflect"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -386,6 +388,7 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"search_term": helpers.SearchTermSchema("teams", "name or handle"),
 					"page":        helpers.PageSchema(),
 					"page_size":   helpers.PageSizeSchema(),
+					"verbose":     helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -398,12 +401,14 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&teamListRequest.Path.CompanyID, "company_id"),
 				helpers.OptionalNumericParam(&teamListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&teamListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&teamListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&teamListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
@@ -416,27 +421,42 @@ func TeamList(engine *twapi.Engine) toolsets.ToolWrapper {
 				teamListRequest.Filters.IncludeSubteams = true
 			}
 
-			teamList, err := projects.TeamList(ctx, engine, teamListRequest)
+			if !verbose {
+				teamListRequest.Filters.Fields.Teams = []projects.TeamField{
+					projects.TeamFieldID,
+					projects.TeamFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, teamListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list teams")
 			}
-
-			encoded, err := json.Marshal(teamList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list teams"), "failed to list teams")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/teams"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, teamList,
-					helpers.WebLinkerWithIDPathBuilder("/app/teams"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -462,7 +462,7 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: timelogListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(timelogListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var timelogListRequest projects.TimelogListRequest
@@ -518,13 +518,11 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -456,6 +458,7 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -468,6 +471,7 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&timelogListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalNumericParam(&timelogListRequest.Path.TaskID, "task_id"),
@@ -481,16 +485,47 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericListParam(&timelogListRequest.Filters.DeskTicketIDs, "ticketIds"),
 				helpers.OptionalNumericParam(&timelogListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&timelogListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			timelogList, err := projects.TimelogList(ctx, engine, timelogListRequest)
+			if !verbose {
+				timelogListRequest.Filters.Fields.Timelogs = []projects.TimelogField{
+					projects.TimelogFieldID,
+					projects.TimelogFieldDescription,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, timelogListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list timelogs")
 			}
-			return helpers.NewToolResultJSON(timelogList)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list timelogs"), "failed to list timelogs")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(body)},
+				},
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -503,6 +505,7 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -515,6 +518,7 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&timerListRequest.Filters.UserID, "user_id"),
 				helpers.OptionalNumericParam(&timerListRequest.Filters.TaskID, "task_id"),
@@ -522,32 +526,48 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalParam(&timerListRequest.Filters.RunningTimersOnly, "running_timers_only"),
 				helpers.OptionalNumericParam(&timerListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&timerListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			timerList, err := projects.TimerList(ctx, engine, timerListRequest)
+			if !verbose {
+				timerListRequest.Filters.Fields.Timers = []projects.TimerField{
+					projects.TimerFieldID,
+					projects.TimerFieldDescription,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, timerListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list timers")
 			}
-
-			encoded, err := json.Marshal(timerList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list timers"), "failed to list timers")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/me/timers"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/timers"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, timerList,
-					helpers.WebLinkerWithIDPathBuilder("/app/timers"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -509,7 +509,7 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: timerListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(timerListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var timerListRequest projects.TimerListRequest
@@ -560,13 +560,11 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/users.go
+++ b/internal/twprojects/users.go
@@ -432,7 +432,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: userListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(userListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var userListRequest projects.UserListRequest
@@ -485,13 +485,11 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(linked)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(linked, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(linked, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/users.go
+++ b/internal/twprojects/users.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -426,6 +428,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -438,6 +441,7 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&userListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&userListRequest.Filters.SearchTerm, "search_term"),
@@ -446,32 +450,49 @@ func UserList(engine *twapi.Engine) toolsets.ToolWrapper {
 				),
 				helpers.OptionalNumericParam(&userListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&userListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			userList, err := projects.UserList(ctx, engine, userListRequest)
+			if !verbose {
+				userListRequest.Filters.Fields.Users = []projects.UserField{
+					projects.UserFieldID,
+					projects.UserFieldFirstName,
+					projects.UserFieldLastName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, userListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list users")
 			}
-
-			encoded, err := json.Marshal(userList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list users"), "failed to list users")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			linked := helpers.WebLinker(ctx, body, helpers.WebLinkerWithIDPathBuilder("/app/people"))
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(helpers.WebLinker(ctx, encoded,
-							helpers.WebLinkerWithIDPathBuilder("/app/people"),
-						)),
-					},
+					&mcp.TextContent{Text: string(linked)},
 				},
-				StructuredContent: helpers.StructuredWebLinker(ctx, userList,
-					helpers.WebLinkerWithIDPathBuilder("/app/people"),
-				),
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(linked, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/workflow_stages.go
+++ b/internal/twprojects/workflow_stages.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -343,6 +345,7 @@ func WorkflowStageList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
+					"verbose":   helpers.VerboseSchema(),
 				},
 				Required: []string{"workflow_id"},
 			},
@@ -355,32 +358,55 @@ func WorkflowStageList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&workflowStageListRequest.Path.WorkflowID, "workflow_id"),
 				helpers.OptionalNumericParam(&workflowStageListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&workflowStageListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			stageList, err := projects.WorkflowStageList(ctx, engine, workflowStageListRequest)
+			if !verbose {
+				workflowStageListRequest.Filters.Fields.Stages = []projects.WorkflowStageField{
+					projects.WorkflowStageFieldID,
+					projects.WorkflowStageFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, workflowStageListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list workflow stages")
 			}
-
-			encoded, err := json.Marshal(stageList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(
+					twapi.NewHTTPError(resp, "failed to list workflow stages"),
+					"failed to list workflow stages",
+				)
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: stageList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/workflow_stages.go
+++ b/internal/twprojects/workflow_stages.go
@@ -349,7 +349,7 @@ func WorkflowStageList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{"workflow_id"},
 			},
-			OutputSchema: workflowStageListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(workflowStageListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var workflowStageListRequest projects.WorkflowStageListRequest
@@ -399,13 +399,11 @@ func WorkflowStageList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}

--- a/internal/twprojects/workflows.go
+++ b/internal/twprojects/workflows.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -305,6 +307,7 @@ func WorkflowList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"search_term": helpers.SearchTermSchema("workflows", "name"),
 					"page":        helpers.PageSchema(),
 					"page_size":   helpers.PageSizeSchema(),
+					"verbose":     helpers.VerboseSchema(),
 				},
 				Required: []string{},
 			},
@@ -317,32 +320,52 @@ func WorkflowList(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalParam(&workflowListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&workflowListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&workflowListRequest.Filters.PageSize, "page_size"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			workflowList, err := projects.WorkflowList(ctx, engine, workflowListRequest)
+			if !verbose {
+				workflowListRequest.Filters.Fields.Workflows = []projects.WorkflowField{
+					projects.WorkflowFieldID,
+					projects.WorkflowFieldName,
+				}
+			}
+
+			resp, err := twapi.ExecuteRaw(ctx, engine, workflowListRequest)
 			if err != nil {
 				return helpers.HandleAPIError(err, "failed to list workflows")
 			}
-
-			encoded, err := json.Marshal(workflowList)
-			if err != nil {
-				return nil, err
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to list workflows"), "failed to list workflows")
 			}
-			return &mcp.CallToolResult{
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(body)},
 				},
-				StructuredContent: workflowList,
-			}, nil
+			}
+			if verbose {
+				var structured any
+				if err := json.Unmarshal(body, &structured); err != nil {
+					return nil, fmt.Errorf("failed to decode response: %w", err)
+				}
+				result.StructuredContent = structured
+			}
+			return result, nil
 		},
 	}
 }

--- a/internal/twprojects/workflows.go
+++ b/internal/twprojects/workflows.go
@@ -311,7 +311,7 @@ func WorkflowList(engine *twapi.Engine) toolsets.ToolWrapper {
 				},
 				Required: []string{},
 			},
-			OutputSchema: workflowListOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(workflowListOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var workflowListRequest projects.WorkflowListRequest
@@ -358,13 +358,11 @@ func WorkflowList(engine *twapi.Engine) toolsets.ToolWrapper {
 					&mcp.TextContent{Text: string(body)},
 				},
 			}
-			if verbose {
-				var structured any
-				if err := json.Unmarshal(body, &structured); err != nil {
-					return nil, fmt.Errorf("failed to decode response: %w", err)
-				}
-				result.StructuredContent = structured
+			var structured any
+			if err := json.Unmarshal(body, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			result.StructuredContent = structured
 			return result, nil
 		},
 	}


### PR DESCRIPTION
## Description

New verbose flag that can be used to load basic or all fields from each entity when listing. By default it's enabled.

Switch all twprojects list tools to twapi.ExecuteRaw so the upstream API body is forwarded without decoding into the typed response struct. ~~When verbose=false, sparse responses no longer match the auto-generated outputSchema, so structured content is omitted (text content only); the verbose schema description and docs are updated to call this out.~~

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors