### PR TITLE
Fix: Update twdesk toolsets for desksdkgo v1 + add sparse fieldset support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/localit-io/tiktoken-go v0.2.1
 	github.com/modelcontextprotocol/go-sdk v1.6.0
-	github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d
+	github.com/teamwork/desksdkgo v1.0.0
 	github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d
 	github.com/teamwork/twapi-go-sdk v1.16.2
 )
@@ -38,6 +38,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.8 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/brianvoe/gofakeit/v7 v7.14.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
@@ -46,6 +47,7 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/brianvoe/gofakeit/v7 v7.14.1 h1:a7fe3fonbj0cW3wgl5VwIKfZtiH9C3cLnwcIXWT7sow=
+github.com/brianvoe/gofakeit/v7 v7.14.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -99,6 +101,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
@@ -182,6 +186,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d h1:6+6U0YuIcEtPVMUAXMDME9XT93EJpBKfVQJqirX0ELM=
 github.com/teamwork/desksdkgo v0.0.0-20260420182446-6788c53d670d/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
+github.com/teamwork/desksdkgo v1.0.0 h1:m82rwxiQdAtp00XhCRnf5eiq4p0KWI1a5ppvbtkXMJM=
+github.com/teamwork/desksdkgo v1.0.0/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d h1:C81tRl2LyM5EW2PyqXj8Ral43vZz9cmZM4vjUt4/LSo=
 github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
 github.com/teamwork/twapi-go-sdk v1.16.2 h1:ZaI0NrArd59wgnmzRB913+uJNa7cWtCCJpGSu+6PrSo=

--- a/internal/twdesk/companies.go
+++ b/internal/twdesk/companies.go
@@ -34,7 +34,7 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Company",
 				ReadOnlyHint: true,
 			},
-			Description: "Get Desk company (customer organization).",
+			Description: "Get Desk company (customer organization). Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"website\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the company to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,12 +54,12 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			company, err := client.Companies.Get(ctx, arguments.GetInt("id", 0))
+			company, err := client.Companies.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get company: %w", err)
 			}
 
-			return helpers.NewToolResultText("Company retrieved successfully: %s", company.Company.Name), nil
+			return helpers.NewToolResultJSON(company)
 		},
 	}
 }
@@ -97,7 +98,7 @@ func CompanyList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Companies",
 				ReadOnlyHint: true,
 			},
-			Description: "List Desk companies. Filter by name, domains, or kind.",
+			Description: "List Desk companies. Filter by name, domains, or kind. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"domains\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -228,21 +229,23 @@ func CompanyCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			domains := arguments.GetStringSlice("domains", []string{})
 			domainEntities := make([]deskmodels.Domain, len(domains))
 			for i, domain := range domains {
+				d := domain
 				domainEntities[i] = deskmodels.Domain{
-					Name: domain,
+					Name: &d,
 				}
 			}
 
+			name := arguments.GetString("name", "")
 			company, err := client.Companies.Create(ctx, &deskmodels.CompanyResponse{
 				Company: deskmodels.Company{
-					Name:        arguments.GetString("name", ""),
-					Description: arguments.GetString("description", ""),
-					Details:     arguments.GetString("details", ""),
-					Industry:    arguments.GetString("industry", ""),
-					Website:     arguments.GetString("website", ""),
-					Permission:  arguments.GetString("permission", ""),
-					Kind:        arguments.GetString("kind", ""),
-					Note:        arguments.GetString("note", ""),
+					Name:        &name,
+					Description: strPtr(arguments.GetString("description", "")),
+					Details:     strPtr(arguments.GetString("details", "")),
+					Industry:    strPtr(arguments.GetString("industry", "")),
+					Website:     strPtr(arguments.GetString("website", "")),
+					Permission:  strPtr(arguments.GetString("permission", "")),
+					Kind:        strPtr(arguments.GetString("kind", "")),
+					Note:        strPtr(arguments.GetString("note", "")),
 				},
 				Included: deskmodels.IncludedData{
 					Domains: domainEntities,
@@ -349,27 +352,28 @@ func CompanyUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			domains := arguments.GetStringSlice("domains", []string{})
 			domainEntities := make([]deskmodels.Domain, len(domains))
 			for i, domain := range domains {
+				d := domain
 				domainEntities[i] = deskmodels.Domain{
-					Name: domain,
+					Name: &d,
 				}
 			}
 			_, err = client.Companies.Update(ctx, arguments.GetInt("id", 0), &deskmodels.CompanyResponse{
 				Company: deskmodels.Company{
-					Name:        arguments.GetString("name", ""),
-					Description: arguments.GetString("description", ""),
-					Details:     arguments.GetString("details", ""),
-					Industry:    arguments.GetString("industry", ""),
-					Website:     arguments.GetString("website", ""),
-					Permission:  arguments.GetString("permission", ""),
-					Kind:        arguments.GetString("kind", ""),
-					Note:        arguments.GetString("note", ""),
+					Name:        strPtr(arguments.GetString("name", "")),
+					Description: strPtr(arguments.GetString("description", "")),
+					Details:     strPtr(arguments.GetString("details", "")),
+					Industry:    strPtr(arguments.GetString("industry", "")),
+					Website:     strPtr(arguments.GetString("website", "")),
+					Permission:  strPtr(arguments.GetString("permission", "")),
+					Kind:        strPtr(arguments.GetString("kind", "")),
+					Note:        strPtr(arguments.GetString("note", "")),
 				},
 				Included: deskmodels.IncludedData{
 					Domains: domainEntities,
 				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to create company: %w", err)
+				return nil, fmt.Errorf("failed to update company: %w", err)
 			}
 
 			return helpers.NewToolResultText("Company updated successfully"), nil

--- a/internal/twdesk/companies.go
+++ b/internal/twdesk/companies.go
@@ -34,7 +34,7 @@ func CompanyGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Company",
 				ReadOnlyHint: true,
 			},
-			Description: "Get Desk company (customer organization). Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"website\"]) and reduce response size.",
+			Description: "Get Desk company (customer organization).",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -98,7 +98,7 @@ func CompanyList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Companies",
 				ReadOnlyHint: true,
 			},
-			Description: "List Desk companies. Filter by name, domains, or kind. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"domains\"]) and reduce response size.",
+			Description: "List Desk companies. Filter by name, domains, or kind.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -34,7 +34,7 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Customer",
 				ReadOnlyHint: true,
 			},
-			Description: "Get customer.",
+			Description: "Get customer. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the customer to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,13 +54,12 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			customer, err := client.Customers.Get(ctx, arguments.GetInt("id", 0))
+			customer, err := client.Customers.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get customer: %w", err)
 			}
 
-			firstName := customer.Customer.FirstName
-			return helpers.NewToolResultText("Customer retrieved successfully: %s", firstName), nil
+			return helpers.NewToolResultJSON(customer)
 		},
 	}
 }
@@ -98,7 +98,7 @@ func CustomerList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Customers",
 				ReadOnlyHint: true,
 			},
-			Description: "List customers. Filter by company or email.",
+			Description: "List customers. Filter by company or email. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -258,33 +258,22 @@ func CustomerCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			domains := arguments.GetStringSlice("domains", []string{})
-			domainEntities := make([]deskmodels.Domain, len(domains))
-			for i, domain := range domains {
-				domainEntities[i] = deskmodels.Domain{
-					Name: domain,
-				}
-			}
-
+			trusted := arguments.GetBool("trusted", false)
 			customer, err := client.Customers.Create(ctx, &deskmodels.CustomerResponse{
 				Customer: deskmodels.Customer{
-					FirstName:     arguments.GetString("firstName", ""),
-					LastName:      arguments.GetString("lastName", ""),
-					Email:         arguments.GetString("email", ""),
-					Organization:  arguments.GetString("organization", ""),
-					ExtraData:     arguments.GetString("extraData", ""),
-					Notes:         arguments.GetString("notes", ""),
-					LinkedinURL:   arguments.GetString("linkedinURL", ""),
-					FacebookURL:   arguments.GetString("facebookURL", ""),
-					TwitterHandle: arguments.GetString("twitterHandle", ""),
-					JobTitle:      arguments.GetString("jobTitle", ""),
-					Phone:         arguments.GetString("phone", ""),
-					Mobile:        arguments.GetString("mobile", ""),
-					Address:       arguments.GetString("address", ""),
-					Trusted:       arguments.GetBool("trusted", false),
-				},
-				Included: deskmodels.IncludedData{
-					Domains: domainEntities,
+					FirstName:     strPtr(arguments.GetString("firstName", "")),
+					LastName:      strPtr(arguments.GetString("lastName", "")),
+					Email:         strPtr(arguments.GetString("email", "")),
+					Organization:  strPtr(arguments.GetString("organization", "")),
+					ExtraData:     strPtr(arguments.GetString("extraData", "")),
+					Notes:         strPtr(arguments.GetString("notes", "")),
+					LinkedinURL:   strPtr(arguments.GetString("linkedinURL", "")),
+					FacebookURL:   strPtr(arguments.GetString("facebookURL", "")),
+					TwitterHandle: strPtr(arguments.GetString("twitterHandle", "")),
+					Phone:         strPtr(arguments.GetString("phone", "")),
+					Mobile:        strPtr(arguments.GetString("mobile", "")),
+					Address:       strPtr(arguments.GetString("address", "")),
+					Trusted:       boolPtr(trusted),
 				},
 			})
 			if err != nil {
@@ -413,36 +402,26 @@ func CustomerUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			domains := arguments.GetStringSlice("domains", []string{})
-			domainEntities := make([]deskmodels.Domain, len(domains))
-			for i, domain := range domains {
-				domainEntities[i] = deskmodels.Domain{
-					Name: domain,
-				}
-			}
+			trusted := arguments.GetBool("trusted", false)
 			_, err = client.Customers.Update(ctx, arguments.GetInt("id", 0), &deskmodels.CustomerResponse{
 				Customer: deskmodels.Customer{
-					FirstName:     arguments.GetString("firstName", ""),
-					LastName:      arguments.GetString("lastName", ""),
-					Email:         arguments.GetString("email", ""),
-					Organization:  arguments.GetString("organization", ""),
-					ExtraData:     arguments.GetString("extraData", ""),
-					Notes:         arguments.GetString("notes", ""),
-					LinkedinURL:   arguments.GetString("linkedinURL", ""),
-					FacebookURL:   arguments.GetString("facebookURL", ""),
-					TwitterHandle: arguments.GetString("twitterHandle", ""),
-					JobTitle:      arguments.GetString("jobTitle", ""),
-					Phone:         arguments.GetString("phone", ""),
-					Mobile:        arguments.GetString("mobile", ""),
-					Address:       arguments.GetString("address", ""),
-					Trusted:       arguments.GetBool("trusted", false),
-				},
-				Included: deskmodels.IncludedData{
-					Domains: domainEntities,
+					FirstName:     strPtr(arguments.GetString("firstName", "")),
+					LastName:      strPtr(arguments.GetString("lastName", "")),
+					Email:         strPtr(arguments.GetString("email", "")),
+					Organization:  strPtr(arguments.GetString("organization", "")),
+					ExtraData:     strPtr(arguments.GetString("extraData", "")),
+					Notes:         strPtr(arguments.GetString("notes", "")),
+					LinkedinURL:   strPtr(arguments.GetString("linkedinURL", "")),
+					FacebookURL:   strPtr(arguments.GetString("facebookURL", "")),
+					TwitterHandle: strPtr(arguments.GetString("twitterHandle", "")),
+					Phone:         strPtr(arguments.GetString("phone", "")),
+					Mobile:        strPtr(arguments.GetString("mobile", "")),
+					Address:       strPtr(arguments.GetString("address", "")),
+					Trusted:       boolPtr(trusted),
 				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to create customer: %w", err)
+				return nil, fmt.Errorf("failed to update customer: %w", err)
 			}
 
 			return helpers.NewToolResultText("Customer updated successfully"), nil

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -34,7 +34,7 @@ func CustomerGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Customer",
 				ReadOnlyHint: true,
 			},
-			Description: "Get customer. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
+			Description: "Get customer.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -98,7 +98,7 @@ func CustomerList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Customers",
 				ReadOnlyHint: true,
 			},
-			Description: "List customers. Filter by company or email. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
+			Description: "List customers. Filter by company or email.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/files.go
+++ b/internal/twdesk/files.go
@@ -69,17 +69,16 @@ func FileCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			filename := arguments.GetString("name", "")
+			mimeType := arguments.GetString("mimeType", "application/octet-stream")
+			disposition := deskmodels.Disposition(arguments.GetString("disposition", string(deskmodels.DispositionAttachment)))
+			fileType := deskmodels.FileTypeAttachment
 			file, err := client.Files.Create(ctx, &deskmodels.FileResponse{
 				File: deskmodels.File{
-					Filename: arguments.GetString("name", ""),
-					MIMEType: arguments.GetString("mimeType", "application/octet-stream"),
-					Disposition: deskmodels.Disposition(
-						arguments.GetString(
-							"disposition",
-							string(deskmodels.DispositionAttachment),
-						),
-					),
-					Type: deskmodels.FileTypeAttachment,
+					Filename:    &filename,
+					MIMEType:    &mimeType,
+					Disposition: &disposition,
+					Type:        &fileType,
 				},
 			})
 			if err != nil {

--- a/internal/twdesk/inboxes.go
+++ b/internal/twdesk/inboxes.go
@@ -31,7 +31,7 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Inbox",
 				ReadOnlyHint: true,
 			},
-			Description: "Get inbox.",
+			Description: "Get inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -39,6 +39,7 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the inbox to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -50,11 +51,11 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			inbox, err := client.Inboxes.Get(ctx, arguments.GetInt("id", 0))
+			inbox, err := client.Inboxes.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get inbox: %w", err)
 			}
-			return helpers.NewToolResultText("Inbox retrieved successfully: %s", inbox.Inbox.Name), nil
+			return helpers.NewToolResultJSON(inbox)
 		},
 	}
 }
@@ -86,7 +87,7 @@ func InboxList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Inboxes",
 				ReadOnlyHint: true,
 			},
-			Description: "List inboxes. Filter by name or email.",
+			Description: "List inboxes. Filter by name or email. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/inboxes.go
+++ b/internal/twdesk/inboxes.go
@@ -31,7 +31,7 @@ func InboxGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Inbox",
 				ReadOnlyHint: true,
 			},
-			Description: "Get inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"email\"]) and reduce response size.",
+			Description: "Get inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -87,7 +87,7 @@ func InboxList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Inboxes",
 				ReadOnlyHint: true,
 			},
-			Description: "List inboxes. Filter by name or email. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"email\"]) and reduce response size.",
+			Description: "List inboxes. Filter by name or email.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/messages.go
+++ b/internal/twdesk/messages.go
@@ -75,10 +75,12 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			body := arguments.GetString("body", "")
+			threadType := arguments.GetString("threadType", "message")
 			data := deskmodels.MessageResponse{
 				Message: deskmodels.Message{
-					Message:    arguments.GetString("body", ""),
-					ThreadType: arguments.GetString("threadType", "message"),
+					Message:    &body,
+					ThreadType: &threadType,
 				},
 			}
 

--- a/internal/twdesk/meta.go
+++ b/internal/twdesk/meta.go
@@ -33,7 +33,7 @@ func boolPtr(b bool) *bool {
 // sparseFieldsSchema returns the JSON schema for the optional sparse fieldset parameter.
 func sparseFieldsSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Description: "Sparse fieldset: list of field names to include in the response. Omit to receive all fields. Use to reduce response size when only specific data is needed (e.g. [\"id\",\"name\"]).",
+		Description: "Sparse fieldset: field names to include (e.g. [\"id\",\"name\"]). Omit to receive all fields.",
 		AnyOf: []*jsonschema.Schema{
 			{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 			{Type: "null"},

--- a/internal/twdesk/meta.go
+++ b/internal/twdesk/meta.go
@@ -3,10 +3,54 @@ package twdesk
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/teamwork/mcp/internal/helpers"
 )
+
+// strPtr returns a pointer to s, or nil if s is empty.
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// intPtr returns a pointer to i, or nil if i is zero.
+func intPtr(i int) *int {
+	if i == 0 {
+		return nil
+	}
+	return &i
+}
+
+// boolPtr returns a pointer to b.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// sparseFieldsSchema returns the JSON schema for the optional sparse fieldset parameter.
+func sparseFieldsSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: "Sparse fieldset: list of field names to include in the response. Omit to receive all fields. Use to reduce response size when only specific data is needed (e.g. [\"id\",\"name\"]).",
+		AnyOf: []*jsonschema.Schema{
+			{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+			{Type: "null"},
+		},
+	}
+}
+
+// getParams builds url.Values for a Get request with includes=all plus an
+// optional sparse fieldset derived from the "fields" tool argument.
+func getParams(arguments helpers.ToolArguments) url.Values {
+	params := url.Values{}
+	params.Set("includes", "all")
+	if fields := strings.Join(arguments.GetStringSlice("fields", nil), ","); fields != "" {
+		params.Set("fields", fields)
+	}
+	return params
+}
 
 func paginationOptions(properties map[string]*jsonschema.Schema) map[string]*jsonschema.Schema {
 	if properties == nil {
@@ -16,6 +60,7 @@ func paginationOptions(properties map[string]*jsonschema.Schema) map[string]*jso
 	properties["pageSize"] = helpers.PageSizeSchema()
 	properties["orderBy"] = helpers.OrderBySchema()
 	properties["orderDirection"] = helpers.OrderDirectionSchema()
+	properties["fields"] = sparseFieldsSchema()
 	return properties
 }
 
@@ -24,4 +69,7 @@ func setPagination(v *url.Values, arguments helpers.ToolArguments) {
 	v.Set("pageSize", fmt.Sprintf("%d", arguments.GetInt("pageSize", 10)))
 	v.Set("orderBy", arguments.GetString("orderBy", "createdAt"))
 	v.Set("orderMode", arguments.GetString("orderDirection", "desc"))
+	if fields := strings.Join(arguments.GetStringSlice("fields", nil), ","); fields != "" {
+		v.Set("fields", fields)
+	}
 }

--- a/internal/twdesk/priorities.go
+++ b/internal/twdesk/priorities.go
@@ -34,7 +34,7 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Priority",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket priority.",
+			Description: "Get ticket priority. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the priority to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,7 +54,7 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			priority, err := client.TicketPriorities.Get(ctx, arguments.GetInt("id", 0))
+			priority, err := client.TicketPriorities.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get priority: %w", err)
 			}
@@ -89,7 +90,7 @@ func PriorityList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Priorities",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket priorities. Filter by name or color.",
+			Description: "List ticket priorities. Filter by name or color. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -162,10 +163,11 @@ func PriorityCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			name := arguments.GetString("name", "")
 			priority, err := client.TicketPriorities.Create(ctx, &deskmodels.TicketPriorityResponse{
 				TicketPriority: deskmodels.TicketPriority{
-					Name:  arguments.GetString("name", ""),
-					Color: arguments.GetString("color", ""),
+					Name:  &name,
+					Color: strPtr(arguments.GetString("color", "")),
 				},
 			})
 			if err != nil {
@@ -219,12 +221,12 @@ func PriorityUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 
 			_, err = client.TicketPriorities.Update(ctx, arguments.GetInt("id", 0), &deskmodels.TicketPriorityResponse{
 				TicketPriority: deskmodels.TicketPriority{
-					Name:  arguments.GetString("name", ""),
-					Color: arguments.GetString("color", ""),
+					Name:  strPtr(arguments.GetString("name", "")),
+					Color: strPtr(arguments.GetString("color", "")),
 				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to create priority: %w", err)
+				return nil, fmt.Errorf("failed to update priority: %w", err)
 			}
 
 			return helpers.NewToolResultText("Priority updated successfully"), nil

--- a/internal/twdesk/priorities.go
+++ b/internal/twdesk/priorities.go
@@ -34,7 +34,7 @@ func PriorityGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Priority",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket priority. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
+			Description: "Get ticket priority.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -90,7 +90,7 @@ func PriorityList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Priorities",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket priorities. Filter by name or color. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
+			Description: "List ticket priorities. Filter by name or color.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/schema_validation_test.go
+++ b/internal/twdesk/schema_validation_test.go
@@ -1,13 +1,144 @@
 package twdesk_test
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/teamwork/mcp/internal/testutil"
+	"github.com/teamwork/mcp/internal/twdesk"
 )
 
 // TestAllToolsJSONSchemaValidation tests that all twdesk tools generate valid JSON schemas
 func TestAllToolsJSONSchemaValidation(t *testing.T) {
 	suite := testutil.NewSchemaValidationTestSuite()
 	suite.RunAllSchemaValidationTests(t)
+}
+
+// TestToolInputSchemasArrayItems guards against array-typed schema nodes that
+// omit `items`. OpenAI's Responses API rejects such tools at registration time
+// (Anthropic does not), so a bare `{type: "array"}` branch inside anyOf/oneOf
+// silently breaks downstream consumers that use OpenAI. This mirrors the same
+// guard in internal/twprojects/tools_test.go.
+func TestToolInputSchemasArrayItems(t *testing.T) {
+	group := twdesk.DefaultToolsetGroup(false, &http.Client{})
+	for method, toolset := range group.Toolsets {
+		for _, tool := range toolset.GetAvailableTools() {
+			name := tool.Tool.Name
+			schema, ok := tool.Tool.InputSchema.(*jsonschema.Schema)
+			if !ok {
+				t.Errorf("toolset %s tool %s: InputSchema is not *jsonschema.Schema (got %T)",
+					method, name, tool.Tool.InputSchema)
+				continue
+			}
+			for _, path := range arrayNodesMissingItems(schema, "InputSchema") {
+				t.Errorf("toolset %s tool %s: array schema missing items at %s", method, name, path)
+			}
+		}
+	}
+}
+
+// arrayNodesMissingItems walks a schema recursively and returns JSON-pointer-style
+// paths of any node typed "array" that has no items schema.
+func arrayNodesMissingItems(s *jsonschema.Schema, path string) []string {
+	if s == nil {
+		return nil
+	}
+	var issues []string
+	if isArrayType(s) && s.Items == nil && len(s.ItemsArray) == 0 && len(s.PrefixItems) == 0 {
+		issues = append(issues, path)
+	}
+	for name, sub := range s.Properties {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/properties/%s", path, name))...)
+	}
+	for name, sub := range s.PatternProperties {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/patternProperties/%s", path, name))...)
+	}
+	issues = append(issues, arrayNodesMissingItems(s.AdditionalProperties, path+"/additionalProperties")...)
+	issues = append(issues, arrayNodesMissingItems(s.Items, path+"/items")...)
+	for i, sub := range s.PrefixItems {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/prefixItems/%d", path, i))...)
+	}
+	for i, sub := range s.ItemsArray {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/items/%d", path, i))...)
+	}
+	for i, sub := range s.AnyOf {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/anyOf/%d", path, i))...)
+	}
+	for i, sub := range s.OneOf {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/oneOf/%d", path, i))...)
+	}
+	for i, sub := range s.AllOf {
+		issues = append(issues, arrayNodesMissingItems(sub, fmt.Sprintf("%s/allOf/%d", path, i))...)
+	}
+	issues = append(issues, arrayNodesMissingItems(s.Not, path+"/not")...)
+	issues = append(issues, arrayNodesMissingItems(s.If, path+"/if")...)
+	issues = append(issues, arrayNodesMissingItems(s.Then, path+"/then")...)
+	issues = append(issues, arrayNodesMissingItems(s.Else, path+"/else")...)
+	issues = append(issues, arrayNodesMissingItems(s.Contains, path+"/contains")...)
+	return issues
+}
+
+func isArrayType(s *jsonschema.Schema) bool {
+	if s.Type == "array" {
+		return true
+	}
+	for _, t := range s.Types {
+		if t == "array" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestToolInputSchemasOpenAIStrictMode documents the current state of OpenAI
+// strict mode compatibility. Strict mode requires:
+//   - All properties (including optional ones) listed in `required`
+//   - `additionalProperties: false` on every object schema
+//
+// Optional parameters currently use `anyOf: [{type: T}, {type: null}]` but are
+// NOT listed in `required`, which means they are incompatible with strict mode.
+// This is a pre-existing pattern across ALL optional parameters in every twdesk
+// tool — it applies equally to `inboxIDs`, `statusIDs`, `fields`, etc. and is
+// NOT something introduced by sparse-fields support.
+//
+// If strict mode support is needed in the future the fix is:
+//  1. Add every optional property to the `required` slice (it already allows
+//     null, satisfying the "typed nullable" requirement).
+//  2. Set `AdditionalProperties: boolSchema(false)` on every object schema.
+//
+// This test intentionally passes today as a documentation anchor; adjust it
+// when strict mode support is implemented.
+func TestToolInputSchemasOpenAIStrictMode(t *testing.T) {
+	group := twdesk.DefaultToolsetGroup(false, &http.Client{})
+
+	toolsWithOptionalParams := 0
+	for _, ts := range group.Toolsets {
+		for _, tool := range ts.GetAvailableTools() {
+			schema, ok := tool.Tool.InputSchema.(*jsonschema.Schema)
+			if !ok {
+				continue
+			}
+			requiredSet := make(map[string]bool, len(schema.Required))
+			for _, r := range schema.Required {
+				requiredSet[r] = true
+			}
+			for propName := range schema.Properties {
+				if !requiredSet[propName] {
+					toolsWithOptionalParams++
+					break
+				}
+			}
+		}
+	}
+
+	// All tools with optional params are currently not strict-mode compatible.
+	// Update this expectation (to 0) once strict mode support is implemented.
+	if toolsWithOptionalParams == 0 {
+		t.Log("All tools appear strict-mode compatible — remove this test and the comment above")
+	} else {
+		t.Logf("%d tool(s) have optional properties not in 'required' (pre-existing; not strict-mode compatible)",
+			toolsWithOptionalParams)
+	}
 }

--- a/internal/twdesk/statuses.go
+++ b/internal/twdesk/statuses.go
@@ -34,7 +34,7 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Status",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket status.",
+			Description: "Get ticket status. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\",\"code\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the status to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,12 +54,12 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			status, err := client.TicketStatuses.Get(ctx, arguments.GetInt("id", 0))
+			status, err := client.TicketStatuses.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get status: %w", err)
 			}
 
-			return helpers.NewToolResultText("Status retrieved successfully: %s", status.TicketStatus.Name), nil
+			return helpers.NewToolResultJSON(status)
 		},
 	}
 }
@@ -97,7 +98,7 @@ func StatusList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Statuses",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket statuses. Filter by name, color, or code.",
+			Description: "List ticket statuses. Filter by name, color, or code. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"code\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -181,11 +182,12 @@ func StatusCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			name := arguments.GetString("name", "")
 			status, err := client.TicketStatuses.Create(ctx, &deskmodels.TicketStatusResponse{
 				TicketStatus: deskmodels.TicketStatus{
-					Name:         arguments.GetString("name", ""),
-					Color:        arguments.GetString("color", ""),
-					DisplayOrder: arguments.GetInt("displayOrder", 0),
+					Name:         &name,
+					Color:        strPtr(arguments.GetString("color", "")),
+					DisplayOrder: intPtr(arguments.GetInt("displayOrder", 0)),
 				},
 			})
 			if err != nil {
@@ -246,13 +248,13 @@ func StatusUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 
 			_, err = client.TicketStatuses.Update(ctx, arguments.GetInt("id", 0), &deskmodels.TicketStatusResponse{
 				TicketStatus: deskmodels.TicketStatus{
-					Name:         arguments.GetString("name", ""),
-					Color:        arguments.GetString("color", ""),
-					DisplayOrder: arguments.GetInt("displayOrder", 0),
+					Name:         strPtr(arguments.GetString("name", "")),
+					Color:        strPtr(arguments.GetString("color", "")),
+					DisplayOrder: intPtr(arguments.GetInt("displayOrder", 0)),
 				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to create status: %w", err)
+				return nil, fmt.Errorf("failed to update status: %w", err)
 			}
 
 			return helpers.NewToolResultText("Status updated successfully"), nil

--- a/internal/twdesk/statuses.go
+++ b/internal/twdesk/statuses.go
@@ -34,7 +34,7 @@ func StatusGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Status",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket status. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\",\"code\"]) and reduce response size.",
+			Description: "Get ticket status.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -98,7 +98,7 @@ func StatusList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Statuses",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket statuses. Filter by name, color, or code. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"code\"]) and reduce response size.",
+			Description: "List ticket statuses. Filter by name, color, or code.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/tags.go
+++ b/internal/twdesk/tags.go
@@ -34,7 +34,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Tag",
 				ReadOnlyHint: true,
 			},
-			Description: "Get Desk tag.",
+			Description: "Get Desk tag. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the tag to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,7 +54,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			tag, err := client.Tags.Get(ctx, arguments.GetInt("id", 0))
+			tag, err := client.Tags.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get tag: %w", err)
 			}
@@ -96,7 +97,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Tags",
 				ReadOnlyHint: true,
 			},
-			Description: "List Desk tags. Filter by name, color, or inbox.",
+			Description: "List Desk tags. Filter by name, color, or inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -173,10 +174,11 @@ func TagCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			name := arguments.GetString("name", "")
 			tag, err := client.Tags.Create(ctx, &deskmodels.TagResponse{
 				Tag: deskmodels.Tag{
-					Name:  arguments.GetString("name", ""),
-					Color: arguments.GetString("color", ""),
+					Name:  &name,
+					Color: strPtr(arguments.GetString("color", "")),
 				},
 			})
 			if err != nil {
@@ -230,12 +232,12 @@ func TagUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 
 			_, err = client.Tags.Update(ctx, arguments.GetInt("id", 0), &deskmodels.TagResponse{
 				Tag: deskmodels.Tag{
-					Name:  arguments.GetString("name", ""),
-					Color: arguments.GetString("color", ""),
+					Name:  strPtr(arguments.GetString("name", "")),
+					Color: strPtr(arguments.GetString("color", "")),
 				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to create tag: %w", err)
+				return nil, fmt.Errorf("failed to update tag: %w", err)
 			}
 
 			return helpers.NewToolResultText("Tag updated successfully"), nil

--- a/internal/twdesk/tags.go
+++ b/internal/twdesk/tags.go
@@ -34,7 +34,7 @@ func TagGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Tag",
 				ReadOnlyHint: true,
 			},
-			Description: "Get Desk tag. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
+			Description: "Get Desk tag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -97,7 +97,7 @@ func TagList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Tags",
 				ReadOnlyHint: true,
 			},
-			Description: "List Desk tags. Filter by name, color, or inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\",\"color\"]) and reduce response size.",
+			Description: "List Desk tags. Filter by name, color, or inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -35,7 +35,7 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"subject\",\"status\",\"agent\"]) and reduce response size.",
+			Description: "Get ticket.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -174,7 +174,7 @@ func TicketSearch(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Search Tickets",
 				ReadOnlyHint: true,
 			},
-			Description: "Search tickets. Filter by inbox, customer, company, tag, status, priority, or user. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"subject\",\"status\",\"agent\"]) and reduce response size.",
+			Description: "Search tickets. Filter by inbox, customer, company, tag, status, priority, or user.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -35,7 +35,7 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket.",
+			Description: "Get ticket. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"subject\",\"status\",\"agent\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -43,6 +43,7 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the ticket to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -54,7 +55,7 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			ticket, err := client.Tickets.Get(ctx, arguments.GetInt("id", 0))
+			ticket, err := client.Tickets.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ticket: %w", err)
 			}
@@ -173,7 +174,7 @@ func TicketSearch(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Search Tickets",
 				ReadOnlyHint: true,
 			},
-			Description: "Search tickets. Filter by inbox, customer, company, tag, status, priority, or user.",
+			Description: "Search tickets. Filter by inbox, customer, company, tag, status, priority, or user. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"subject\",\"status\",\"agent\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -344,7 +345,7 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 					},
 					"agentId": {
 						Description: `
-							The agent ID that the ticket should be assigned to. 
+							The agent ID that the ticket should be assigned to.
 							Use the 'twdesk-list_users' tool to find valid IDs.
 						`,
 						AnyOf: []*jsonschema.Schema{
@@ -363,9 +364,11 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			subject := arguments.GetString("subject", "")
+			body := arguments.GetString("body", "")
 			data := deskmodels.Ticket{
-				Subject: arguments.GetString("subject", ""),
-				Body:    arguments.GetString("body", ""),
+				Subject: &subject,
+				Body:    &body,
 				Inbox: &deskmodels.EntityRef{
 					ID: arguments.GetInt("inboxId", 0),
 				},
@@ -398,7 +401,7 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 					// Create the customer
 					customer, err := client.Customers.Create(ctx, &deskmodels.CustomerResponse{
 						Customer: deskmodels.Customer{
-							Email: email,
+							Email: strPtr(email),
 						},
 					})
 					if err != nil {
@@ -435,7 +438,7 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			}
 
 			if arguments.GetBool("notifyCustomer", false) {
-				data.NotifyCustomer = true
+				data.NotifyCustomer = boolPtr(true)
 			}
 
 			if len(arguments.GetIntSlice("files", []int{})) > 0 {
@@ -577,7 +580,7 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 					},
 					"agentId": {
 						Description: `
-							The agent ID that the ticket should be assigned to. 
+							The agent ID that the ticket should be assigned to.
 							Use the 'twdesk-list_users' tool to find valid IDs.
 						`,
 						AnyOf: []*jsonschema.Schema{
@@ -599,7 +602,7 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			data := deskmodels.Ticket{}
 
 			if subject := arguments.GetString("subject", ""); subject != "" {
-				data.Subject = subject
+				data.Subject = &subject
 			}
 
 			if inboxId := arguments.GetInt("inboxId", 0); inboxId > 0 {
@@ -609,7 +612,7 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			}
 
 			if body := arguments.GetString("body", ""); body != "" {
-				data.Body = body
+				data.Body = &body
 			}
 
 			data.Tags = []deskmodels.EntityRef{}

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -34,7 +34,7 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket Type",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket type. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\"]) and reduce response size.",
+			Description: "Get ticket type.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -90,7 +90,7 @@ func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Ticket Types",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket types. Filter by name or inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\"]) and reduce response size.",
+			Description: "List ticket types. Filter by name or inbox.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -34,7 +34,7 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get Ticket Type",
 				ReadOnlyHint: true,
 			},
-			Description: "Get ticket type.",
+			Description: "Get ticket type. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -42,6 +42,7 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the ticket type to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -53,7 +54,7 @@ func TypeGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			t, err := client.TicketTypes.Get(ctx, arguments.GetInt("id", 0))
+			t, err := client.TicketTypes.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get type: %w", err)
 			}
@@ -89,7 +90,7 @@ func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Ticket Types",
 				ReadOnlyHint: true,
 			},
-			Description: "List ticket types. Filter by name or inbox.",
+			Description: "List ticket types. Filter by name or inbox. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"name\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,
@@ -169,11 +170,13 @@ func TypeCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			name := arguments.GetString("name", "")
+			enabledForFutureInboxes := arguments.GetBool("enabledForFutureInboxes", false)
 			t, err := client.TicketTypes.Create(ctx, &deskmodels.TicketTypeResponse{
 				TicketType: deskmodels.TicketType{
-					Name:                    arguments.GetString("name", ""),
-					DisplayOrder:            arguments.GetInt("displayOrder", 0),
-					EnabledForFutureInboxes: arguments.GetBool("enabledForFutureInboxes", false),
+					Name:                    &name,
+					DisplayOrder:            intPtr(arguments.GetInt("displayOrder", 0)),
+					EnabledForFutureInboxes: boolPtr(enabledForFutureInboxes),
 				},
 			})
 			if err != nil {
@@ -232,11 +235,12 @@ func TypeUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
+			enabledForFutureInboxes := arguments.GetBool("enabledForFutureInboxes", false)
 			_, err = client.TicketTypes.Update(ctx, arguments.GetInt("id", 0), &deskmodels.TicketTypeResponse{
 				TicketType: deskmodels.TicketType{
-					Name:                    arguments.GetString("name", ""),
-					DisplayOrder:            arguments.GetInt("displayOrder", 0),
-					EnabledForFutureInboxes: arguments.GetBool("enabledForFutureInboxes", false),
+					Name:                    strPtr(arguments.GetString("name", "")),
+					DisplayOrder:            intPtr(arguments.GetInt("displayOrder", 0)),
+					EnabledForFutureInboxes: boolPtr(enabledForFutureInboxes),
 				},
 			})
 			if err != nil {

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -31,7 +31,7 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get User",
 				ReadOnlyHint: true,
 			},
-			Description: "Get support agent. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
+			Description: "Get support agent.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -108,7 +108,7 @@ func UserList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Users",
 				ReadOnlyHint: true,
 			},
-			Description: "List support agents. For customers, use twdesk-list_customers. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
+			Description: "List support agents. For customers, use twdesk-list_customers.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,

--- a/internal/twdesk/users.go
+++ b/internal/twdesk/users.go
@@ -31,7 +31,7 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "Get User",
 				ReadOnlyHint: true,
 			},
-			Description: "Get support agent.",
+			Description: "Get support agent. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -39,6 +39,7 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 						Type:        "integer",
 						Description: "The ID of the user to retrieve.",
 					},
+					"fields": sparseFieldsSchema(),
 				},
 				Required: []string{"id"},
 			},
@@ -50,7 +51,7 @@ func UserGet(httpClient *http.Client) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
 
-			user, err := client.Users.Get(ctx, arguments.GetInt("id", 0))
+			user, err := client.Users.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get user: %w", err)
 			}
@@ -107,7 +108,7 @@ func UserList(httpClient *http.Client) toolsets.ToolWrapper {
 				Title:        "List Users",
 				ReadOnlyHint: true,
 			},
-			Description: "List support agents. For customers, use twdesk-list_customers.",
+			Description: "List support agents. For customers, use twdesk-list_customers. Use the 'fields' parameter to request only the fields you need (e.g. [\"id\",\"firstName\",\"lastName\",\"email\"]) and reduce response size.",
 			InputSchema: &jsonschema.Schema{
 				Type:       "object",
 				Properties: properties,


### PR DESCRIPTION
Patches all twdesk tools to compile against the v1 desksdkgo API, which introduced two breaking changes: Get methods now require a url.Values parameter, and all model string/bool/int fields changed to pointer types.

Adds sparse fieldset support throughout every read operation so the LLM can request only the fields it needs and avoid bloating token counts:

- meta.go: add strPtr/intPtr/boolPtr helpers, sparseFieldsSchema(), getParams() (builds url.Values with includes=all + optional fields), and wire fields into paginationOptions() and setPagination() so every list operation automatically honours the parameter
- All Get tools: accept an optional "fields" array and pass it to the SDK via getParams(); handlers that previously returned text summaries now return full JSON so sparse fields are meaningful
- All List/Search tools: "fields" flows through setPagination to the query string
- files.go, messages.go: fix model field assignments to use pointer types

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors