### PR TITLE
Refactor: Trim tool parameter descriptions

### DIFF
--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -106,9 +106,7 @@ func TagIDsAssociateSchema(entity string) *jsonschema.Schema {
 // fields optional) so sparse payloads still validate.
 func VerboseSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Description: "If true (default), the response includes full entity details. " +
-			"If false, only a minimal subset of fields (typically an id and a name/title) is returned to " +
-			"reduce response size — useful when scanning many results to pick an id before fetching the full entity.",
+		Description: "If false, returns id + name only — useful when scanning many results.",
 		AnyOf: []*jsonschema.Schema{
 			{Type: "boolean"},
 			{Type: "null"},
@@ -119,15 +117,85 @@ func VerboseSchema() *jsonschema.Schema {
 
 // MatchAllTagsSchema returns the schema for the boolean flag that switches
 // tag filtering between AND (true) and OR (false) semantics.
-func MatchAllTagsSchema(entity string) *jsonschema.Schema {
+func MatchAllTagsSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Description: fmt.Sprintf(
-			"If true, the search will match %s that have all the specified tags. "+
-				"If false, the search will match %s that have any of the specified tags. "+
-				"Defaults to false.",
-			entity, entity),
+		Description: "If true, match all tags; if false, match any.",
 		AnyOf: []*jsonschema.Schema{
 			{Type: "boolean"},
+			{Type: "null"},
+		},
+		Default: []byte(`false`),
+	}
+}
+
+// UserGroupsSchema returns the schema for a user/team/company groups
+// parameter. The object accepts user_ids, company_ids, and/or team_ids arrays;
+// at least one (and at most all three) must be supplied with non-empty values.
+// When required is true the returned schema is a bare object; when false it is
+// wrapped in AnyOf with null so the caller can omit the field. The caller
+// supplies the purpose-specific framing as description (pass "" when the helper
+// is used as a branch of an outer schema that already carries a description).
+func UserGroupsSchema(description string, required bool) *jsonschema.Schema {
+	obj := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"user_ids": {
+				Type:     "array",
+				Items:    &jsonschema.Schema{Type: "integer"},
+				MinItems: new(1),
+			},
+			"company_ids": {
+				Type:     "array",
+				Items:    &jsonschema.Schema{Type: "integer"},
+				MinItems: new(1),
+			},
+			"team_ids": {
+				Type:     "array",
+				Items:    &jsonschema.Schema{Type: "integer"},
+				MinItems: new(1),
+			},
+		},
+		MinProperties: new(1),
+		MaxProperties: new(3),
+		AnyOf: []*jsonschema.Schema{
+			{Required: []string{"user_ids"}},
+			{Required: []string{"company_ids"}},
+			{Required: []string{"team_ids"}},
+		},
+	}
+	if required {
+		obj.Description = description
+		return obj
+	}
+	return &jsonschema.Schema{
+		Description: description,
+		AnyOf: []*jsonschema.Schema{
+			obj,
+			{Type: "null"},
+		},
+	}
+}
+
+// DateTimeFilterSchema returns the schema for an optional RFC 3339 date-time
+// filter parameter. The caller supplies the purpose-specific description.
+func DateTimeFilterSchema(description string) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: description,
+		AnyOf: []*jsonschema.Schema{
+			{Type: "string", Format: "date-time"},
+			{Type: "null"},
+		},
+	}
+}
+
+// DateFilterSchema returns the schema for an optional ISO 8601 date
+// (YYYY-MM-DD) filter parameter. The caller supplies the purpose-specific
+// description.
+func DateFilterSchema(description string) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: description,
+		AnyOf: []*jsonschema.Schema{
+			{Type: "string", Format: "date"},
 			{Type: "null"},
 		},
 	}

--- a/internal/helpers/schema_test.go
+++ b/internal/helpers/schema_test.go
@@ -76,16 +76,127 @@ func TestTagIDsSchemas(t *testing.T) {
 	}
 }
 
+func TestVerboseSchema(t *testing.T) {
+	t.Parallel()
+
+	got := helpers.VerboseSchema()
+	if !strings.Contains(got.Description, "id + name only") {
+		t.Errorf("VerboseSchema description = %q, want it to mention 'id + name only'", got.Description)
+	}
+	if got.AnyOf[0].Type != "boolean" {
+		t.Errorf("VerboseSchema first AnyOf type = %q, want boolean", got.AnyOf[0].Type)
+	}
+	if string(got.Default) != "true" {
+		t.Errorf("VerboseSchema Default = %q, want true", string(got.Default))
+	}
+}
+
 func TestMatchAllTagsSchema(t *testing.T) {
 	t.Parallel()
 
-	got := helpers.MatchAllTagsSchema("tasks")
-	if !strings.Contains(got.Description, "tasks that have all the specified tags") ||
-		!strings.Contains(got.Description, "tasks that have any of the specified tags") ||
-		!strings.Contains(got.Description, "Defaults to false") {
+	got := helpers.MatchAllTagsSchema()
+	if !strings.Contains(got.Description, "match all tags") ||
+		!strings.Contains(got.Description, "match any") {
 		t.Errorf("MatchAllTagsSchema description missing expected phrases: %q", got.Description)
 	}
 	if got.AnyOf[0].Type != "boolean" {
 		t.Errorf("MatchAllTagsSchema first AnyOf type = %q, want boolean", got.AnyOf[0].Type)
+	}
+	if string(got.Default) != "false" {
+		t.Errorf("MatchAllTagsSchema Default = %q, want false", string(got.Default))
+	}
+}
+
+func TestUserGroupsSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("required", func(t *testing.T) {
+		got := helpers.UserGroupsSchema("Assignees for the task.", true)
+		if got.Type != "object" {
+			t.Errorf("required UserGroupsSchema type = %q, want object", got.Type)
+		}
+		if got.Description != "Assignees for the task." {
+			t.Errorf("required UserGroupsSchema description = %q", got.Description)
+		}
+		if got.MinProperties == nil || *got.MinProperties != 1 {
+			t.Errorf("required UserGroupsSchema MinProperties = %v, want 1", got.MinProperties)
+		}
+		if got.MaxProperties == nil || *got.MaxProperties != 3 {
+			t.Errorf("required UserGroupsSchema MaxProperties = %v, want 3", got.MaxProperties)
+		}
+		for _, key := range []string{"user_ids", "company_ids", "team_ids"} {
+			prop, ok := got.Properties[key]
+			if !ok {
+				t.Errorf("required UserGroupsSchema missing %q", key)
+				continue
+			}
+			if prop.Type != "array" {
+				t.Errorf("required UserGroupsSchema %q type = %q, want array", key, prop.Type)
+			}
+			if prop.Items == nil || prop.Items.Type != "integer" {
+				t.Errorf("required UserGroupsSchema %q items = %+v, want integer", key, prop.Items)
+			}
+			if prop.MinItems == nil || *prop.MinItems != 1 {
+				t.Errorf("required UserGroupsSchema %q MinItems = %v, want 1", key, prop.MinItems)
+			}
+		}
+		if len(got.AnyOf) != 3 {
+			t.Fatalf("required UserGroupsSchema AnyOf len = %d, want 3", len(got.AnyOf))
+		}
+	})
+
+	t.Run("optional", func(t *testing.T) {
+		got := helpers.UserGroupsSchema("Followers of task changes.", false)
+		if got.Type != "" {
+			t.Errorf("optional UserGroupsSchema outer type = %q, want empty", got.Type)
+		}
+		if got.Description != "Followers of task changes." {
+			t.Errorf("optional UserGroupsSchema description = %q", got.Description)
+		}
+		if len(got.AnyOf) != 2 {
+			t.Fatalf("optional UserGroupsSchema AnyOf len = %d, want 2", len(got.AnyOf))
+		}
+		if got.AnyOf[0].Type != "object" {
+			t.Errorf("optional UserGroupsSchema AnyOf[0].Type = %q, want object", got.AnyOf[0].Type)
+		}
+		if got.AnyOf[1].Type != "null" {
+			t.Errorf("optional UserGroupsSchema AnyOf[1].Type = %q, want null", got.AnyOf[1].Type)
+		}
+	})
+}
+
+func TestDateTimeFilterSchema(t *testing.T) {
+	t.Parallel()
+
+	got := helpers.DateTimeFilterSchema("Filter tasks created after.")
+	if got.Description != "Filter tasks created after." {
+		t.Errorf("DateTimeFilterSchema description = %q", got.Description)
+	}
+	if len(got.AnyOf) != 2 {
+		t.Fatalf("DateTimeFilterSchema AnyOf len = %d, want 2", len(got.AnyOf))
+	}
+	if got.AnyOf[0].Type != "string" || got.AnyOf[0].Format != "date-time" {
+		t.Errorf("DateTimeFilterSchema AnyOf[0] = %+v, want string/date-time", got.AnyOf[0])
+	}
+	if got.AnyOf[1].Type != "null" {
+		t.Errorf("DateTimeFilterSchema AnyOf[1].Type = %q, want null", got.AnyOf[1].Type)
+	}
+}
+
+func TestDateFilterSchema(t *testing.T) {
+	t.Parallel()
+
+	got := helpers.DateFilterSchema("Start of the workload period.")
+	if got.Description != "Start of the workload period." {
+		t.Errorf("DateFilterSchema description = %q", got.Description)
+	}
+	if len(got.AnyOf) != 2 {
+		t.Fatalf("DateFilterSchema AnyOf len = %d, want 2", len(got.AnyOf))
+	}
+	if got.AnyOf[0].Type != "string" || got.AnyOf[0].Format != "date" {
+		t.Errorf("DateFilterSchema AnyOf[0] = %+v, want string/date", got.AnyOf[0])
+	}
+	if got.AnyOf[1].Type != "null" {
+		t.Errorf("DateFilterSchema AnyOf[1].Type = %q, want null", got.AnyOf[1].Type)
 	}
 }

--- a/internal/twdesk/messages.go
+++ b/internal/twdesk/messages.go
@@ -38,10 +38,8 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The ID of the ticket that the message will be sent to.",
 					},
 					"threadType": {
-						Description: `
-							The thread type. Use 'message' for a customer-facing reply (default), 
-							or 'note' for an internal agent note not visible to the customer.
-						`,
+						Description: "'message' is a customer-facing reply; 'note' is an internal agent note.",
+						Default:     []byte(`"message"`),
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"message", "note"}},
 							{Type: "null"},
@@ -52,14 +50,14 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The body of the message.",
 					},
 					"bcc": {
-						Description: "An array of email addresses to BCC on message reply.",
+						Description: "Email addresses to BCC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},
 						},
 					},
 					"cc": {
-						Description: "An array of email addresses to CC on message reply.",
+						Description: "Email addresses to CC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -86,80 +86,56 @@ func TicketGet(httpClient *http.Client) toolsets.ToolWrapper {
 func TicketSearch(httpClient *http.Client) toolsets.ToolWrapper {
 	properties := map[string]*jsonschema.Schema{
 		"search": {
-			Description: `
-				The search term to use for finding tickets.
-				This can be part of the subject, body, or other ticket fields.
-			`,
+			Description: "Search term matched against subject, body, and other ticket fields.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "string"},
 				{Type: "null"},
 			},
 		},
 		"inboxIDs": {
-			Description: `
-				The IDs of the inboxes to filter by.
-				Inbox IDs can be found by using the 'twdesk-list_inboxes' tool.
-			`,
+			Description: "Filter by inbox. Use twdesk-list_inboxes to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"customerIDs": {
-			Description: `
-			The IDs of the customers to filter by.
-			Customer IDs can be found by using the 'twdesk-list_customers' tool.
-		`,
+			Description: "Filter by customer. Use twdesk-list_customers to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"companyIDs": {
-			Description: `
-			The IDs of the companies to filter by.
-			Company IDs can be found by using the 'twdesk-list_companies' tool.
-		`,
+			Description: "Filter by company. Use twdesk-list_companies to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"tagIDs": {
-			Description: `
-			The IDs of the tags to filter by.
-			Tag IDs can be found by using the 'twdesk-list_tags' tool.
-		`,
+			Description: "Filter by tag. Use twdesk-list_tags to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"statusIDs": {
-			Description: `
-				The IDs of the statuses to filter by.
-				Status IDs can be found by using the 'twdesk-list_statuses' tool.
-			`,
+			Description: "Filter by status. Use twdesk-list_statuses to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"priorityIDs": {
-			Description: `
-				The IDs of the priorities to filter by.
-				Priority IDs can be found by using the 'twdesk-list_priorities' tool.
-			`,
+			Description: "Filter by priority. Use twdesk-list_priorities to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
 			},
 		},
 		"userIDs": {
-			Description: `
-				The IDs of the users to filter by.
-				User IDs can be found by using the 'twdesk-list_users' tool.
-			`,
+			Description: "Filter by user. Use twdesk-list_users to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},
@@ -250,11 +226,8 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The body of the ticket.",
 					},
 					"inboxId": {
-						Type: "integer",
-						Description: `
-					The inbox ID of the ticket.
-					Use the 'twdesk-list_inboxes' tool to find valid IDs.
-				`,
+						Type:        "integer",
+						Description: "Inbox of the ticket. Use twdesk-list_inboxes to discover.",
 					},
 					"notifyCustomer": {
 						Description: "Set to true if the customer should be sent a copy of the ticket.",
@@ -264,96 +237,71 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						},
 					},
 					"bcc": {
-						Description: "An array of email addresses to BCC on ticket creation.",
+						Description: "Email addresses to BCC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},
 						},
 					},
 					"cc": {
-						Description: "An array of email addresses to CC on ticket creation.",
+						Description: "Email addresses to CC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},
 						},
 					},
 					"files": {
-						Description: `
-							An array of file IDs to attach to the ticket.
-							Use the 'twdesk-create_file' tool to upload files.
-						`,
+						Description: "File IDs to attach. Use twdesk-create_file to upload.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"tags": {
-						Description: `
-							An array of tag IDs to associate with the ticket.
-							Tag IDs can be found by using the 'twdesk-list_tags' tool.
-						`,
+						Description: "Tags to associate with the ticket. Use twdesk-list_tags to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"priorityId": {
-						Description: `
-					The priority of the ticket.
-					Use the 'twdesk-list_priorities' tool to find valid IDs.
-				`,
+						Description: "Priority of the ticket. Use twdesk-list_priorities to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"statusId": {
-						Description: `
-					The status of the ticket.
-					Use the 'twdesk-list_statuses' tool to find valid IDs.
-				`,
+						Description: "Status of the ticket. Use twdesk-list_statuses to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"customerId": {
-						Description: `
-					The customer ID of the ticket.
-					Use the 'twdesk-list_customers' tool to find valid IDs.
-				`,
+						Description: "Customer of the ticket. Use twdesk-list_customers to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"customerEmail": {
-						Description: `
-							The email address of the customer.
-							This is used to identify the customer in the system.
-							Either the customerId or customerEmail is required to create a ticket.
-							If email is provided we will either find or create the customer.
-						`,
+						Description: "Customer email; required when customerId is not given. Existing customers are matched, " +
+							"otherwise a new customer is created.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
 						},
 					},
 					"typeId": {
-						Description: `
-					The type ID of the ticket.
-					Use the 'twdesk-list_ticket_types' tool to find valid IDs.
-				`,
+						Description: "Ticket type. Use twdesk-list_ticket_types to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"agentId": {
-						Description: `
-							The agent ID that the ticket should be assigned to.
-							Use the 'twdesk-list_users' tool to find valid IDs.
-						`,
+						Description: "Agent the ticket is assigned to. Use twdesk-list_users to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
@@ -516,84 +464,63 @@ func TicketUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						},
 					},
 					"tags": {
-						Description: `
-							An array of tag IDs to associate with the ticket.
-							Tag IDs can be found by using the 'twdesk-list_tags' tool.
-						`,
+						Description: "Tags to associate with the ticket. Use twdesk-list_tags to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"deleteTags": {
-						Description: `
-							An array of tag IDs that should be removed from the ticket.
-							Tag IDs can be found by using the 'twdesk-list_tags' tool.
-						`,
+						Description: "Tags to remove from the ticket. Use twdesk-list_tags to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"bcc": {
-						Description: "An array of email addresses to BCC on ticket update.",
+						Description: "Email addresses to BCC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},
 						},
 					},
 					"cc": {
-						Description: "An array of email addresses to CC on ticket update.",
+						Description: "Email addresses to CC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 							{Type: "null"},
 						},
 					},
 					"inboxId": {
-						Description: `
-							The inbox ID of the ticket.
-							Use the 'twdesk-list_inboxes' tool to find valid IDs.
-						`,
+						Description: "Inbox of the ticket. Use twdesk-list_inboxes to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"priorityId": {
-						Description: `
-							The priority of the ticket.
-							Use the 'twdesk-list_priorities' tool to find valid IDs.
-						`,
+						Description: "Priority of the ticket. Use twdesk-list_priorities to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"statusId": {
-						Description: `
-							The status of the ticket.
-							Use the 'twdesk-list_statuses' tool to find valid IDs.
-						`,
+						Description: "Status of the ticket. Use twdesk-list_statuses to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"typeId": {
-						Description: `
-							The type ID of the ticket.
-							Use the 'twdesk-list_ticket_types' tool to find valid IDs.
-						`,
+						Description: "Ticket type. Use twdesk-list_ticket_types to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"agentId": {
-						Description: `
-							The agent ID that the ticket should be assigned to.
-							Use the 'twdesk-list_users' tool to find valid IDs.
-						`,
+						Description: "Agent the ticket is assigned to. Use twdesk-list_users to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -75,7 +75,7 @@ func TypeList(httpClient *http.Client) toolsets.ToolWrapper {
 			},
 		},
 		"inboxIDs": {
-			Description: "The IDs of the inboxes to filter by. Inbox IDs can be found by using the 'twdesk-list_inboxes' tool.",
+			Description: "Filter by inbox. Use twdesk-list_inboxes to discover.",
 			AnyOf: []*jsonschema.Schema{
 				{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 				{Type: "null"},

--- a/internal/twprojects/activities.go
+++ b/internal/twprojects/activities.go
@@ -58,20 +58,8 @@ func ActivityList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"start_date": {
-						Description: "Start date to filter activities. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"end_date": {
-						Description: "End date to filter activities. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
+					"start_date": helpers.DateTimeFilterSchema("Start of the activity window."),
+					"end_date":   helpers.DateTimeFilterSchema("End of the activity window."),
 					"log_item_types": {
 						Description: "Filter activities by item types.",
 						AnyOf: []*jsonschema.Schema{

--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -60,14 +60,14 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_ids": {
-						Description: "A list of project IDs to filter budgets by project.",
+						Description: "Filter budgets by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"status": {
-						Description: "Filter budgets by status. Allowed values: upcoming, active, complete.",
+						Description: "Filter budgets by status.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"upcoming", "active", "complete"}},
 							{Type: "null"},

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -105,56 +105,22 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new comment. Accepts either 'all', true (followers) or an " +
-							"object specifying user, team, or company IDs. By default, followers are notified.",
-						Default: json.RawMessage(`true`),
+						Description: "Who to notify of the new comment.",
+						Default:     json.RawMessage(`true`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
 									{
 										Type:        "boolean",
 										Description: "Notify all followers of the entity this comment is related to.",
 										Enum:        []any{true},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -291,56 +257,22 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the comment change. Accepts either 'all', true (followers) or " +
-							"an object specifying user, team, or company IDs. By default, followers are notified.",
-						Default: json.RawMessage(`true`),
+						Description: "Who to notify of the comment change.",
+						Default:     json.RawMessage(`true`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
 									{
 										Type:        "boolean",
 										Description: "Notify all followers of the entity this comment is related to.",
 										Enum:        []any{true},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -560,15 +492,9 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"search_term": helpers.SearchTermSchema("comments", "name"),
-					"updated_after": {
-						Description: "Filter comments updated after this date and time. " +
-							"The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ. By default it will only return comments " +
-							"updated on the last 3 months.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
+					"updated_after": helpers.DateTimeFilterSchema(
+						"Filter comments updated after. Defaults to the last 3 months.",
+					),
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
 					"verbose":   helpers.VerboseSchema(),

--- a/internal/twprojects/companies.go
+++ b/internal/twprojects/companies.go
@@ -521,7 +521,7 @@ func CompanyList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("companies"),
-					"match_all_tags": helpers.MatchAllTagsSchema("companies"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 					"verbose":        helpers.VerboseSchema(),

--- a/internal/twprojects/custom_field_values.go
+++ b/internal/twprojects/custom_field_values.go
@@ -475,7 +475,7 @@ func CustomFieldValueList(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "The ID of the task, project or company to list custom field values for.",
 					},
 					"custom_field_ids": {
-						Description: "A list of custom field IDs to filter values by.",
+						Description: "Filter by custom field.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/custom_fields.go
+++ b/internal/twprojects/custom_fields.go
@@ -564,14 +564,14 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"ids": {
-						Description: "A list of custom field IDs to retrieve.",
+						Description: "Custom field IDs to retrieve.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"entities": {
-						Description: "A list of entity types to filter custom fields by.",
+						Description: "Filter custom fields by entity type.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type: "array",
@@ -588,7 +588,7 @@ func CustomFieldList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"project_ids": {
-						Description: "A list of project IDs to filter custom fields by.",
+						Description: "Filter custom fields by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/links.go
+++ b/internal/twprojects/links.go
@@ -107,51 +107,17 @@ func LinkCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new link. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the new link.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -262,51 +228,17 @@ func LinkUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new link. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the link update.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -507,7 +439,7 @@ func LinkList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("links"),
-					"match_all_tags": helpers.MatchAllTagsSchema("links"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 					"verbose":        helpers.VerboseSchema(),

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -77,51 +77,17 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new message reply. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the new reply.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -214,51 +180,17 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new messageReply. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the reply update.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -445,14 +377,14 @@ func MessageReplyList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"message_ids": {
-						Description: "A list of message IDs to filter message replies by messages",
+						Description: "Filter by message.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"project_ids": {
-						Description: "A list of project IDs to filter message replies by projects",
+						Description: "Filter by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -81,51 +81,17 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new message. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the new message.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -233,51 +199,17 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"notify": {
-						Description: "Who should be notified about the new message. Accepts either 'all' or an " +
-							"object specifying user, team, or company IDs. By default, all project members are notified.",
-						Default: json.RawMessage(`"all"`),
+						Description: "Who to notify of the message update.",
+						Default:     json.RawMessage(`"all"`),
 						AnyOf: []*jsonschema.Schema{
 							{
 								AnyOf: []*jsonschema.Schema{
 									{
 										Type:        "string",
 										Description: "Notify all project members.",
-										Enum: []any{
-											"all",
-										},
+										Enum:        []any{"all"},
 									},
-									{
-										Type: "object",
-										Description: "An object containing the users, teams or companies to notify. At least one of the " +
-											"properties (user_ids, team_ids, company_ids) is required.",
-										Properties: map[string]*jsonschema.Schema{
-											"user_ids": {
-												Type:        "array",
-												Description: "List of user IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"company_ids": {
-												Type:        "array",
-												Description: "List of company IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-											"team_ids": {
-												Type:        "array",
-												Description: "List of team IDs to notify.",
-												Items:       &jsonschema.Schema{Type: "integer"},
-												MinItems:    new(1),
-											},
-										},
-										MinProperties: new(1),
-										MaxProperties: new(3),
-										AnyOf: []*jsonschema.Schema{
-											{Required: []string{"user_ids"}},
-											{Required: []string{"company_ids"}},
-											{Required: []string{"team_ids"}},
-										},
-									},
+									helpers.UserGroupsSchema("", true),
 								},
 							},
 							{Type: "null"},
@@ -450,7 +382,7 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
 			Name:        string(MethodMessageList),
-			Description: "List project messages (top-level posts). Use list_message_replies for thread replies.",
+			Description: "List project messages (top-level posts). Use twprojects-list_message_replies for thread replies.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Messages",
 				ReadOnlyHint: true,
@@ -469,14 +401,14 @@ func MessageList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"project_ids": {
-						Description: "A list of project IDs to filter messages by projects",
+						Description: "Filter messages by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("messages"),
-					"match_all_tags": helpers.MatchAllTagsSchema("messages"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 					"verbose":        helpers.VerboseSchema(),

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -77,49 +77,12 @@ func MilestoneCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"due_date": {
 						Type: "string",
-						Description: "The due date of the milestone in the format YYYYMMDD. This date will be used in all tasks " +
-							"without a due date related to this milestone.",
+						Description: "The due date of the milestone (format: YYYYMMDD). " +
+							"Used for related tasks without their own due date.",
 					},
-					"assignees": {
-						Type: "object",
-						Description: "An object containing assignees for the milestone. " +
-							"MUST contain at least one of: user_ids, company_ids or team_ids with non-empty arrays.",
-						Properties: map[string]*jsonschema.Schema{
-							"user_ids": {
-								Type:        "array",
-								Description: "List of user IDs assigned to the milestone.",
-								Items: &jsonschema.Schema{
-									Type: "integer",
-								},
-								MinItems: new(1),
-							},
-							"company_ids": {
-								Type:        "array",
-								Description: "List of company IDs assigned to the milestone.",
-								Items: &jsonschema.Schema{
-									Type: "integer",
-								},
-								MinItems: new(1),
-							},
-							"team_ids": {
-								Type:        "array",
-								Description: "List of team IDs assigned to the milestone.",
-								Items: &jsonschema.Schema{
-									Type: "integer",
-								},
-								MinItems: new(1),
-							},
-						},
-						MinProperties: new(1),
-						MaxProperties: new(3),
-						AnyOf: []*jsonschema.Schema{
-							{Required: []string{"user_ids"}},
-							{Required: []string{"company_ids"}},
-							{Required: []string{"team_ids"}},
-						},
-					},
+					"assignees": helpers.UserGroupsSchema("Assignees for the milestone.", true),
 					"tasklist_ids": {
-						Description: "A list of tasklist IDs to associate with the milestone.",
+						Description: "Tasklists to associate with the milestone.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -208,57 +171,16 @@ func MilestoneUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"due_date": {
-						Description: "The due date of the milestone in the format YYYYMMDD. This date will be used in all tasks " +
-							"without a due date related to this milestone.",
+						Description: "The due date of the milestone (format: YYYYMMDD). " +
+							"Used for related tasks without their own due date.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
 						},
 					},
-					"assignees": {
-						Description: "An object containing assignees for the milestone.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs assigned to the milestone.",
-										Items: &jsonschema.Schema{
-											Type: "integer",
-										},
-										MinItems: new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs assigned to the milestone.",
-										Items: &jsonschema.Schema{
-											Type: "integer",
-										},
-										MinItems: new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs assigned to the milestone.",
-										Items: &jsonschema.Schema{
-											Type: "integer",
-										},
-										MinItems: new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"assignees": helpers.UserGroupsSchema("Assignees for the milestone.", false),
 					"tasklist_ids": {
-						Description: "A list of tasklist IDs to associate with the milestone.",
+						Description: "Tasklists to associate with the milestone.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -444,7 +366,7 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("milestones"),
-					"match_all_tags": helpers.MatchAllTagsSchema("milestones"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 					"verbose":        helpers.VerboseSchema(),

--- a/internal/twprojects/notebooks.go
+++ b/internal/twprojects/notebooks.go
@@ -81,7 +81,7 @@ func NotebookCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"type": {
 						Type:        "string",
-						Description: "The type of the notebook. Valid values are 'MARKDOWN' and 'HTML'.",
+						Description: "The type of the notebook.",
 						Enum:        []any{"MARKDOWN", "HTML"},
 					},
 					"tag_ids": helpers.TagIDsAssociateSchema("notebook"),
@@ -160,7 +160,7 @@ func NotebookUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"type": {
-						Description: "The type of the notebook. Valid values are 'MARKDOWN' and 'HTML'.",
+						Description: "The type of the notebook.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"MARKDOWN", "HTML"}},
 							{Type: "null"},
@@ -323,7 +323,7 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_ids": {
-						Description: "A list of project IDs to filter notebooks by projects",
+						Description: "Filter notebooks by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -339,11 +339,10 @@ func NotebookList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("notebooks"),
-					"match_all_tags": helpers.MatchAllTagsSchema("notebooks"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"include_contents": {
-						Description: "If true, the contents of the notebook will be included in the response. " +
-							"Defaults to true.",
-						Default: json.RawMessage(`true`),
+						Description: "If true, include notebook contents in the response.",
+						Default:     json.RawMessage(`true`),
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},

--- a/internal/twprojects/project_members.go
+++ b/internal/twprojects/project_members.go
@@ -37,7 +37,7 @@ func ProjectMemberAdd(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "The ID of the project to add the member to.",
 					},
 					"user_ids": {
-						Description: "A list of user IDs to add to the project.",
+						Description: "Users to add.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/project_templates.go
+++ b/internal/twprojects/project_templates.go
@@ -45,14 +45,14 @@ func ProjectTemplateCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"start_at": {
-						Description: "The start date of the project template in the format YYYYMMDD.",
+						Description: "Start date of the project template (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
 						},
 					},
 					"end_at": {
-						Description: "The end date of the project template in the format YYYYMMDD.",
+						Description: "End date of the project template (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
@@ -128,7 +128,7 @@ func ProjectTemplateList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_category_ids": {
-						Description: "A list of project category IDs to filter project templates by categories.",
+						Description: "Filter project templates by category.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -136,7 +136,7 @@ func ProjectTemplateList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"search_term":    helpers.SearchTermSchema("project templates", "name or description"),
 					"tag_ids":        helpers.TagIDsFilterSchema("project templates"),
-					"match_all_tags": helpers.MatchAllTagsSchema("project templates"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 				},

--- a/internal/twprojects/projects.go
+++ b/internal/twprojects/projects.go
@@ -73,14 +73,14 @@ func ProjectCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"start_at": {
-						Description: "The start date of the project in the format YYYYMMDD.",
+						Description: "Start date of the project (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
 						},
 					},
 					"end_at": {
-						Description: "The end date of the project in the format YYYYMMDD.",
+						Description: "End date of the project (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
@@ -173,14 +173,14 @@ func ProjectUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"start_at": {
-						Description: "The start date of the project in the format YYYYMMDD.",
+						Description: "Start date of the project (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
 						},
 					},
 					"end_at": {
-						Description: "The end date of the project in the format YYYYMMDD.",
+						Description: "End date of the project (format: YYYYMMDD).",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
@@ -209,7 +209,7 @@ func ProjectUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"tag_ids": helpers.TagIDsAssociateSchema("project"),
 					"status": {
-						Description: "The status of the project. Allowed values: active or archived.",
+						Description: "The status of the project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"active", "archived"}},
 							{Type: "null"},
@@ -365,10 +365,9 @@ func ProjectClone(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"target_date": {
-						Description: "Target date is the desired start or end date for the cloned project " +
-							"(determined by template_date_target). Used only when creating a project from " +
-							"a template (new_from_template=true). Accepted format: YYYYMMDD string. " +
-							"Defaults to the current user date if omitted.",
+						Description: "Desired start or end date for the cloned project (chosen by template_date_target). " +
+							"Only applies when new_from_template=true. Format: YYYYMMDD. " +
+							"Defaults to today.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},
@@ -538,7 +537,7 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"project_category_ids": {
-						Description: "A list of project category IDs to filter projects by categories.",
+						Description: "Filter projects by category.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -546,7 +545,7 @@ func ProjectList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"search_term":    helpers.SearchTermSchema("projects", "name or description"),
 					"tag_ids":        helpers.TagIDsFilterSchema("projects"),
-					"match_all_tags": helpers.MatchAllTagsSchema("projects"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"page":           helpers.PageSchema(),
 					"page_size":      helpers.PageSizeSchema(),
 					"verbose":        helpers.VerboseSchema(),

--- a/internal/twprojects/search.go
+++ b/internal/twprojects/search.go
@@ -70,7 +70,7 @@ func Search(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"updated_after": {
-						Description: "Only include items updated after this date. Must be follow RFC3339 format.",
+						Description: "Only include items updated after this date.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string"},
 							{Type: "null"},

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -269,8 +269,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"item_type": {
-						Description: "The type of item to filter tags by. Valid values are 'project', 'task', 'tasklist', " +
-							"'milestone', 'message', 'timelog', 'notebook', 'file', 'company' and 'link'.",
+						Description: "Filter tags by item type.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type: "string",
@@ -291,7 +290,7 @@ func TagList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"project_ids": {
-						Description: "A list of project IDs to filter tags by projects",
+						Description: "Filter by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -67,7 +67,7 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"tasklist_id": {
 						Type:        "integer",
-						Description: "Tasklist ID. Use list_tasklists to find one.",
+						Description: "Tasklist ID. Use twprojects-list_tasklists to find one.",
 					},
 					"description": {
 						Description: "The description of the task. Support for plain text and Markdown formatting.",
@@ -77,7 +77,7 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"priority": {
-						Description: "The priority of the task. Possible values are: low, medium, high.",
+						Description: "The priority of the task.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"low", "medium", "high"}},
 							{Type: "null"},
@@ -90,21 +90,10 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"start_date": {
-						Description: "The start date of the task in ISO 8601 format (YYYY-MM-DD).",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date"},
-							{Type: "null"},
-						},
-					},
-					"due_date": {
-						Description: "The due date of the task in ISO 8601 format (YYYY-MM-DD). When this is not provided, it " +
-							"will fallback to the milestone due date if a milestone is set.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date"},
-							{Type: "null"},
-						},
-					},
+					"start_date": helpers.DateFilterSchema("The start date of the task."),
+					"due_date": helpers.DateFilterSchema(
+						"The due date of the task. If omitted, falls back to the milestone due date when one is set.",
+					),
 					"estimated_minutes": {
 						Description: "The estimated time to complete the task in minutes.",
 						AnyOf: []*jsonschema.Schema{
@@ -119,46 +108,10 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"assignees": {
-						Description: "An object containing assignees for the task.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"tag_ids": helpers.TagIDsAssociateSchema("task"),
+					"assignees": helpers.UserGroupsSchema("Assignees for the task.", false),
+					"tag_ids":   helpers.TagIDsAssociateSchema("task"),
 					"predecessors": {
-						Description: "List of task dependencies that must be completed before this task can start, defining its " +
-							"position in the project workflow and ensuring proper sequencing of work.",
+						Description: "Task dependencies that must be completed before this task can start.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type: "array",
@@ -171,9 +124,8 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 										},
 										"type": {
 											Type: "string",
-											Description: "The type of dependency. Possible values are: start or complete. 'start' means this " +
-												"task can complete when the predecessor starts, 'complete' means this task can complete when " +
-												"the predecessor completes.",
+											Description: "'start' means this task can complete when the predecessor starts; " +
+												"'complete' means this task can complete when the predecessor completes.",
 											Enum: []any{"start", "complete"},
 										},
 									},
@@ -182,114 +134,9 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"change_followers": {
-						Description: "An object containing the followers of any task changes.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"comment_followers": {
-						Description: "An object containing the followers of any task comments.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"complete_followers": {
-						Description: "An object containing the followers of any task completions.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"change_followers":   helpers.UserGroupsSchema("Followers of any task changes.", false),
+					"comment_followers":  helpers.UserGroupsSchema("Followers of any task comments.", false),
+					"complete_followers": helpers.UserGroupsSchema("Followers of any task completions.", false),
 				},
 				Required: []string{"name", "tasklist_id"},
 			},
@@ -436,7 +283,7 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"priority": {
-						Description: "The priority of the task. Possible values are: low, medium, high.",
+						Description: "The priority of the task.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Enum: []any{"low", "medium", "high"}},
 							{Type: "null"},
@@ -449,21 +296,10 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"start_date": {
-						Description: "The start date of the task in ISO 8601 format (YYYY-MM-DD).",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date"},
-							{Type: "null"},
-						},
-					},
-					"due_date": {
-						Description: "The due date of the task in ISO 8601 format (YYYY-MM-DD). When this is not provided, it " +
-							"will fallback to the milestone due date if a milestone is set.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date"},
-							{Type: "null"},
-						},
-					},
+					"start_date": helpers.DateFilterSchema("The start date of the task."),
+					"due_date": helpers.DateFilterSchema(
+						"The due date of the task. If omitted, falls back to the milestone due date when one is set.",
+					),
 					"estimated_minutes": {
 						Description: "The estimated time to complete the task in minutes.",
 						AnyOf: []*jsonschema.Schema{
@@ -478,46 +314,10 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"assignees": {
-						Description: "An object containing assignees for the task.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs assigned to the task.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"tag_ids": helpers.TagIDsAssociateSchema("task"),
+					"assignees": helpers.UserGroupsSchema("Assignees for the task.", false),
+					"tag_ids":   helpers.TagIDsAssociateSchema("task"),
 					"predecessors": {
-						Description: "List of task dependencies that must be completed before this task can start, defining its " +
-							"position in the project workflow and ensuring proper sequencing of work.",
+						Description: "Task dependencies that must be completed before this task can start.",
 						AnyOf: []*jsonschema.Schema{
 							{
 								Type: "array",
@@ -530,9 +330,8 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 										},
 										"type": {
 											Type: "string",
-											Description: "The type of dependency. Possible values are: start or complete. 'start' means this " +
-												"task can complete when the predecessor starts, 'complete' means this task can complete when the " +
-												"predecessor completes.",
+											Description: "'start' means this task can complete when the predecessor starts; " +
+												"'complete' means this task can complete when the predecessor completes.",
 											Enum: []any{"start", "complete"},
 										},
 									},
@@ -541,114 +340,9 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"change_followers": {
-						Description: "An object containing the followers of any task changes.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task changes.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"comment_followers": {
-						Description: "An object containing the followers of any task comments.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task comments.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
-					"complete_followers": {
-						Description: "An object containing the followers of any task completions.",
-						AnyOf: []*jsonschema.Schema{
-							{
-								Type: "object",
-								Properties: map[string]*jsonschema.Schema{
-									"user_ids": {
-										Type:        "array",
-										Description: "List of user IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"company_ids": {
-										Type:        "array",
-										Description: "List of company IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-									"team_ids": {
-										Type:        "array",
-										Description: "List of team IDs following the task completions.",
-										Items:       &jsonschema.Schema{Type: "integer"},
-										MinItems:    new(1),
-									},
-								},
-								MinProperties: new(1),
-								MaxProperties: new(3),
-								AnyOf: []*jsonschema.Schema{
-									{Required: []string{"user_ids"}},
-									{Required: []string{"company_ids"}},
-									{Required: []string{"team_ids"}},
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"change_followers":   helpers.UserGroupsSchema("Followers of any task changes.", false),
+					"comment_followers":  helpers.UserGroupsSchema("Followers of any task comments.", false),
+					"complete_followers": helpers.UserGroupsSchema("Followers of any task completions.", false),
 				},
 				Required: []string{"id"},
 			},
@@ -944,16 +638,16 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"search_term": helpers.SearchTermSchema("tasks", "name"),
 					"assignee_user_ids": {
-						Description: "A list of user IDs to filter tasks by assigned users",
+						Description: "Filter tasks by assignee.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("tasks"),
-					"match_all_tags": helpers.MatchAllTagsSchema("tasks"),
+					"match_all_tags": helpers.MatchAllTagsSchema(),
 					"created_after": {
-						Description: "Filter tasks created after this date and time in RFC 3339 format.",
+						Description: "Filter tasks created after.",
 						Examples:    []any{"2023-01-01T00:00:00Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},
@@ -961,7 +655,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"created_before": {
-						Description: "Filter tasks created before this date and time in RFC 3339 format.",
+						Description: "Filter tasks created before.",
 						Examples:    []any{"2023-12-31T23:59:59Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},
@@ -969,14 +663,14 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"created_by_user_ids": {
-						Description: "A list of user IDs to filter tasks by creator",
+						Description: "Filter tasks by creator.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"updated_after": {
-						Description: "Filter tasks updated after this date and time in RFC 3339 format.",
+						Description: "Filter tasks updated after.",
 						Examples:    []any{"2023-01-01T00:00:00Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},
@@ -984,7 +678,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"updated_before": {
-						Description: "Filter tasks updated before this date and time in RFC 3339 format.",
+						Description: "Filter tasks updated before.",
 						Examples:    []any{"2023-12-31T23:59:59Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},
@@ -992,7 +686,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"completed_after": {
-						Description: "Filter tasks completed after this date and time in RFC 3339 format.",
+						Description: "Filter tasks completed after.",
 						Examples:    []any{"2023-01-01T00:00:00Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},
@@ -1000,7 +694,7 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"completed_before": {
-						Description: "Filter tasks completed before this date and time in RFC 3339 format.",
+						Description: "Filter tasks completed before.",
 						Examples:    []any{"2023-12-31T23:59:59Z"},
 						AnyOf: []*jsonschema.Schema{
 							{Type: "string", Format: "date-time"},

--- a/internal/twprojects/teams.go
+++ b/internal/twprojects/teams.go
@@ -116,7 +116,7 @@ func TeamCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"user_ids": {
-						Description: "A list of user IDs to add to the team.",
+						Description: "Users to add to the team.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
@@ -215,7 +215,7 @@ func TeamUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"user_ids": {
-						Description: "A list of user IDs to add to the team.",
+						Description: "Users to add to the team.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -77,7 +77,7 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					"date": {
 						Type:        "string",
 						Format:      "date",
-						Description: "The date of the timelog in the format YYYY-MM-DD.",
+						Description: "The date of the timelog.",
 					},
 					"time": {
 						Type:        "string",
@@ -85,11 +85,12 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						Description: "The time of the timelog in the format HH:MM:SS.",
 					},
 					"is_utc": {
-						Description: "If true, the time is in UTC. Defaults to false.",
+						Description: "If true, the time is in UTC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"hours": {
 						Type:        "integer",
@@ -97,35 +98,33 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"minutes": {
 						Type: "integer",
-						Description: "The number of minutes spent on the timelog. Must be a positive integer less than 60, " +
-							"otherwise the hours attribute should be incremented.",
+						Description: "Minutes spent on the timelog. Must be a positive integer less than 60; " +
+							"otherwise increment hours instead.",
 					},
 					"billable": {
-						Description: "If true, the timelog is billable. Defaults to false.",
+						Description: "If true, the timelog is billable.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"project_id": {
-						Description: "The ID of the project to associate the timelog with. Either project_id or task_id must be " +
-							"provided, but not both.",
+						Description: "Project the timelog is logged against. Provide exactly one of project_id or task_id.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"task_id": {
-						Description: "The ID of the task to associate the timelog with. Either project_id or task_id must be " +
-							"provided, but not both.",
+						Description: "Task the timelog is logged against. Provide exactly one of project_id or task_id.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"user_id": {
-						Description: "The ID of the user to associate the timelog with. Defaults to the authenticated user if " +
-							"not provided.",
+						Description: "User the timelog is logged for. Defaults to the authenticated user.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
@@ -192,13 +191,7 @@ func TimelogUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"date": {
-						Description: "The date of the timelog in the format YYYY-MM-DD.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date"},
-							{Type: "null"},
-						},
-					},
+					"date": helpers.DateFilterSchema("The date of the timelog."),
 					"time": {
 						Description: "The time of the timelog in the format HH:MM:SS.",
 						AnyOf: []*jsonschema.Schema{
@@ -207,11 +200,12 @@ func TimelogUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"is_utc": {
-						Description: "If true, the time is in UTC. Defaults to false.",
+						Description: "If true, the time is in UTC.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"hours": {
 						Description: "The number of hours spent on the timelog. Must be a positive integer.",
@@ -221,39 +215,37 @@ func TimelogUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"minutes": {
-						Description: "The number of minutes spent on the timelog. Must be a positive integer less than 60, " +
-							"otherwise the hours attribute should be incremented.",
+						Description: "Minutes spent on the timelog. Must be a positive integer less than 60; " +
+							"otherwise increment hours instead.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"billable": {
-						Description: "If true, the timelog is billable. Defaults to false.",
+						Description: "If true, the timelog is billable.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"project_id": {
-						Description: "The ID of the project to associate the timelog with. Either project_id or task_id must be " +
-							"provided, but not both.",
+						Description: "Project the timelog is logged against. Provide exactly one of project_id or task_id.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"task_id": {
-						Description: "The ID of the task to associate the timelog with. Either project_id or task_id must be " +
-							"provided, but not both.",
+						Description: "Task the timelog is logged against. Provide exactly one of project_id or task_id.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
 						},
 					},
 					"user_id": {
-						Description: "The ID of the user to associate the timelog with. Defaults to the authenticated user if " +
-							"not provided.",
+						Description: "User the timelog is logged for. Defaults to the authenticated user.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
@@ -414,44 +406,32 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("timelogs"),
-					"match_all_tags": helpers.MatchAllTagsSchema("timelogs"),
-					"start_date": {
-						Description: "Start date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
-					"end_date": {
-						Description: "End date to filter timelogs. The date format follows RFC3339 - YYYY-MM-DDTHH:MM:SSZ.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Format: "date-time"},
-							{Type: "null"},
-						},
-					},
+					"match_all_tags": helpers.MatchAllTagsSchema(),
+					"start_date":     helpers.DateTimeFilterSchema("Start of the timelog window."),
+					"end_date":       helpers.DateTimeFilterSchema("End of the timelog window."),
 					"assigned_user_ids": {
-						Description: "A list of user IDs to filter timelogs by assigned users",
+						Description: "Filter timelogs by assigned user.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"assigned_company_ids": {
-						Description: "A list of company IDs to filter timelogs by assigned companies",
+						Description: "Filter timelogs by assigned company.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"assigned_team_ids": {
-						Description: "A list of team IDs to filter timelogs by assigned teams",
+						Description: "Filter timelogs by assigned team.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"ticketIds": {
-						Description: "A list of desk ticket IDs to filter timelogs by associated desk tickets",
+						Description: "Filter timelogs by associated desk ticket.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twprojects/timers.go
+++ b/internal/twprojects/timers.go
@@ -71,11 +71,12 @@ func TimerCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"billable": {
-						Description: "If true, the timer is billable. Defaults to false.",
+						Description: "If true, the timer is billable.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"running": {
 						Description: "If true, the timer will start running immediately.",
@@ -497,12 +498,12 @@ func TimerList(engine *twapi.Engine) toolsets.ToolWrapper {
 						},
 					},
 					"running_timers_only": {
-						Description: "If true, only running timers will be returned. " +
-							"Defaults to false, which returns all timers.",
+						Description: "If true, only running timers are returned.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "boolean"},
 							{Type: "null"},
 						},
+						Default: []byte("false"),
 					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),

--- a/internal/twprojects/workload.go
+++ b/internal/twprojects/workload.go
@@ -54,36 +54,36 @@ func UsersWorkload(engine *twapi.Engine) toolsets.ToolWrapper {
 					"start_date": {
 						Type:        "string",
 						Format:      "date",
-						Description: "The start date of the workload period. The date must be in the format YYYY-MM-DD.",
+						Description: "Start of the workload period.",
 					},
 					"end_date": {
 						Type:        "string",
 						Format:      "date",
-						Description: "The end date of the workload period. The date must be in the format YYYY-MM-DD.",
+						Description: "End of the workload period.",
 					},
 					"user_ids": {
-						Description: "List of user IDs to filter the workload by.",
+						Description: "Filter workload by user.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"user_company_ids": {
-						Description: "List of users' client/company IDs to filter the workload by.",
+						Description: "Filter workload by users' client/company.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"user_team_ids": {
-						Description: "List of users' team IDs to filter the workload by.",
+						Description: "Filter workload by users' team.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},
 						},
 					},
 					"project_ids": {
-						Description: "List of project IDs to filter the workload by.",
+						Description: "Filter workload by project.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twspaces/search.go
+++ b/internal/twspaces/search.go
@@ -33,7 +33,7 @@ func Search(httpClient *http.Client) toolsets.ToolWrapper {
 						Description: "The search query string.",
 					},
 					"spaceIds": {
-						Description: "Limit search to specific space IDs. Use 'twspaces-list_spaces' to find valid IDs.",
+						Description: "Limit search to specific spaces. Use twspaces-list_spaces to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
 							{Type: "null"},

--- a/internal/twspaces/spaces.go
+++ b/internal/twspaces/spaces.go
@@ -146,8 +146,7 @@ func SpaceCreate(httpClient *http.Client) toolsets.ToolWrapper {
 						},
 					},
 					"categoryId": {
-						Description: "The ID of the category to assign to this space. " +
-							"Use the 'twspaces-list_categories' tool to find valid IDs.",
+						Description: "Category to assign. Use twspaces-list_categories to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
@@ -260,8 +259,7 @@ func SpaceUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 						},
 					},
 					"categoryId": {
-						Description: "The ID of the category to assign to this space. " +
-							"Use the 'twspaces-list_categories' tool to find valid IDs.",
+						Description: "Category to assign. Use twspaces-list_categories to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},

--- a/internal/twspaces/tags.go
+++ b/internal/twspaces/tags.go
@@ -107,7 +107,7 @@ func TagCreateBatch(httpClient *http.Client) toolsets.ToolWrapper {
 				Properties: map[string]*jsonschema.Schema{
 					"tags": {
 						Type:        "array",
-						Description: "An array of tags to create.",
+						Description: "Tags to create.",
 						Items: &jsonschema.Schema{
 							Type: "object",
 							Properties: map[string]*jsonschema.Schema{


### PR DESCRIPTION
## Summary
Builds on #293, #303, #306. Where a JSON Schema field (`Default`, `Format`, `AnyOf.Required`, `MinProperties`) already carries a constraint, delete the duplicate English prose; add the schema field at the few sites where prose was the only enforcement.

- New helpers: `UserGroupsSchema`, `DateTimeFilterSchema`, `DateFilterSchema`.
- Trimmed helpers: `VerboseSchema`, `MatchAllTagsSchema` (drop `entity` arg, add `Default: false`).
- Sweep applied across `twprojects`, `twdesk`, `twspaces`.
- No behavioural change — descriptions only.

## mcp-tokens delta vs main
```
base (main)        38,515
current            34,744
delta              -3,771  (-9.79%)
```

## Test plan
- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [x] `TestToolInputSchemasArrayItems` passes
- [x] `cmd/mcp-tokens -base main` shows expected reduction
- [ ] Spot-check a few representative tool schemas via `cmd/mcp-http-cli list-tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)