### PR TITLE
Fix: Spaces - Allow updating a page content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/localit-io/tiktoken-go v0.2.1
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/teamwork/desksdkgo v1.0.0
-	github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d
+	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
 	github.com/teamwork/twapi-go-sdk v1.17.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teamwork/desksdkgo v1.0.0 h1:m82rwxiQdAtp00XhCRnf5eiq4p0KWI1a5ppvbtkXMJM=
 github.com/teamwork/desksdkgo v1.0.0/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
-github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d h1:C81tRl2LyM5EW2PyqXj8Ral43vZz9cmZM4vjUt4/LSo=
-github.com/teamwork/spacessdkgo v0.0.0-20260422163745-684bf200d31d/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
+github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
+github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
 github.com/teamwork/twapi-go-sdk v1.17.0 h1:BbZE1kgw6YtetsL5aYWT5ZW6yNpbkqxn+mLcWra4/yI=
 github.com/teamwork/twapi-go-sdk v1.17.0/go.mod h1:Vf81EGIYiFPTZnFwekPu7pBw2dOdd1tZysdREJjSJfE=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=

--- a/internal/twspaces/pages.go
+++ b/internal/twspaces/pages.go
@@ -359,6 +359,15 @@ func PageUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"draftVersion": {
+						Description: "Optimistic concurrency token for the page's draft content. Required when updating " +
+							"`content`; optional otherwise. Obtain the current value from the `draftVersion` field with " +
+							"twspaces-get_page or twspaces-list_pages tools.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "integer"},
+							{Type: "null"},
+						},
+					},
 					"parentId": {
 						Description: "The ID of the new parent page (to move the page).",
 						AnyOf: []*jsonschema.Schema{
@@ -433,6 +442,9 @@ func PageUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			}
 			if content := arguments.GetString("content", ""); content != "" {
 				req.Content = &content
+			}
+			if draftVersion := int64(arguments.GetInt("draftVersion", 0)); draftVersion > 0 {
+				req.DraftVersion = &draftVersion
 			}
 			if slug := arguments.GetString("slug", ""); slug != "" {
 				req.Slug = &slug


### PR DESCRIPTION
## Description

Without the `draftVersion` field, the content of a Spaces page cannot be modified.

Related to:
https://github.com/Teamwork/spacessdkgo/pull/1

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors