### PR TITLE
Fix: Projects - Task predecessors not being loaded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/teamwork/desksdkgo v1.0.0
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.18.0
+	github.com/teamwork/twapi-go-sdk v1.18.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.0 h1:m82rwxiQdAtp00XhCRnf5eiq4p0KWI1a5ppvbtkX
 github.com/teamwork/desksdkgo v1.0.0/go.mod h1:nAQ9TiITo1WqNnLsifExR7SH/64rGemPIb7yi7KbQ5I=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.18.0 h1:XnI1Kgir1aqluV5E0wWuGHCNPF7rX1zK3kdmWnuQr30=
-github.com/teamwork/twapi-go-sdk v1.18.0/go.mod h1:CVXbgrqx6stPk+a0D5IWdIAyYix0sWr6Q3xkbqOKjt0=
+github.com/teamwork/twapi-go-sdk v1.18.1 h1:o5nGwwlq1UvcXM+VAmYSPqhXd886I1jh55T9fvtmjjw=
+github.com/teamwork/twapi-go-sdk v1.18.1/go.mod h1:CVXbgrqx6stPk+a0D5IWdIAyYix0sWr6Q3xkbqOKjt0=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -563,6 +563,7 @@ func TaskGet(engine *twapi.Engine) toolsets.ToolWrapper {
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var taskGetRequest projects.TaskGetRequest
+			taskGetRequest.Filters.IncludeRelatedTasks = true
 
 			// Always include custom fields and values in task get response for richer
 			// context, as they are commonly used in Teamwork projects and provide
@@ -746,6 +747,8 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 					projects.TaskRequestSideloadCustomFields,
 					projects.TaskRequestSideloadCustomFieldValues,
 				}
+				// Ensure predecessors are included in the response
+				taskListRequest.Filters.IncludeRelatedTasks = true
 			} else {
 				taskListRequest.Filters.Fields.Tasks = []projects.TaskField{
 					projects.TaskFieldID,


### PR DESCRIPTION
## Description

When loading tasks, include related tasks to ensure predecessors (dependencies) are rendered in the response.

Related to:
https://github.com/Teamwork/twapi-go-sdk/pull/91

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors