### PR TITLE
Remove calendar create and delete tools

### DIFF
--- a/internal/twprojects/calendars.go
+++ b/internal/twprojects/calendars.go
@@ -20,8 +20,7 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodCalendarDelete toolsets.Method = "twprojects-delete_calendar"
-	MethodCalendarList   toolsets.Method = "twprojects-list_calendars"
+	MethodCalendarList toolsets.Method = "twprojects-list_calendars"
 )
 
 var calendarListOutputSchema *jsonschema.Schema
@@ -33,50 +32,6 @@ func init() {
 	calendarListOutputSchema, err = jsonschema.For[projects.CalendarListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CalendarListResponse: %v", err))
-	}
-}
-
-// CalendarDelete deletes a calendar in Teamwork.com.
-func CalendarDelete(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name:        string(MethodCalendarDelete),
-			Description: "Delete calendar.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Delete Calendar",
-				DestructiveHint: new(true),
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"id": {
-						Type:        "integer",
-						Description: "The ID of the calendar to delete.",
-					},
-				},
-				Required: []string{"id"},
-			},
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var calendarDeleteRequest projects.CalendarDeleteRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredNumericParam(&calendarDeleteRequest.Path.ID, "id"),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			_, err = projects.CalendarDelete(ctx, engine, calendarDeleteRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to delete calendar")
-			}
-			return helpers.NewToolResultText("Calendar deleted successfully"), nil
-		},
 	}
 }
 

--- a/internal/twprojects/calendars.go
+++ b/internal/twprojects/calendars.go
@@ -20,7 +20,6 @@ import (
 // The naming convention for methods follows a pattern described here:
 // https://github.com/github/github-mcp-server/issues/333
 const (
-	MethodCalendarCreate toolsets.Method = "twprojects-create_calendar"
 	MethodCalendarDelete toolsets.Method = "twprojects-delete_calendar"
 	MethodCalendarList   toolsets.Method = "twprojects-list_calendars"
 )
@@ -34,66 +33,6 @@ func init() {
 	calendarListOutputSchema, err = jsonschema.For[projects.CalendarListResponse](&jsonschema.ForOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CalendarListResponse: %v", err))
-	}
-}
-
-// CalendarCreate creates a calendar in Teamwork.com.
-func CalendarCreate(engine *twapi.Engine) toolsets.ToolWrapper {
-	return toolsets.ToolWrapper{
-		Tool: &mcp.Tool{
-			Name: string(MethodCalendarCreate),
-			Description: "Create calendar. Calendars hold events such as meetings, out-of-office periods and " +
-				"time-blocking entries. To enable time blocking, create a calendar of type 'blocked_time' named " +
-				"'blocked_time'; there can only be one blocked time calendar per account.",
-			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Calendar",
-			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"name": {
-						Type: "string",
-						Description: "The name of the calendar. When the type is 'blocked_time' the name must be " +
-							"'blocked_time'.",
-					},
-					"type": {
-						Description: "The type of calendar. Defaults to a standard event calendar.",
-						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Enum: []any{"event", "blocked_time", "holiday"}},
-							{Type: "null"},
-						},
-					},
-				},
-				Required: []string{"name"},
-			},
-		},
-		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			var calendarCreateRequest projects.CalendarCreateRequest
-
-			var arguments map[string]any
-			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
-				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
-			}
-			err := helpers.ParamGroup(arguments,
-				helpers.RequiredParam(&calendarCreateRequest.Name, "name"),
-				helpers.OptionalPointerParam(&calendarCreateRequest.Type, "type",
-					helpers.RestrictValues(
-						projects.CalendarTypeEvent,
-						projects.CalendarTypeBlockedTime,
-						projects.CalendarTypeHoliday,
-					),
-				),
-			)
-			if err != nil {
-				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
-			}
-
-			calendar, err := projects.CalendarCreate(ctx, engine, calendarCreateRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to create calendar")
-			}
-			return helpers.NewToolResultText("Calendar created successfully with ID %d", calendar.Calendar.ID), nil
-		},
 	}
 }
 

--- a/internal/twprojects/calendars_test.go
+++ b/internal/twprojects/calendars_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/teamwork/mcp/internal/twprojects"
 )
 
-func TestCalendarCreate(t *testing.T) {
-	mcpServer := mcpServerMock(t, http.StatusCreated, []byte(`{"calendar":{"id":123}}`))
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCalendarCreate.String(), map[string]any{
-		"name": "blocked_time",
-		"type": "blocked_time",
-	})
-}
-
 func TestCalendarDelete(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusNoContent, nil)
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCalendarDelete.String(), map[string]any{

--- a/internal/twprojects/calendars_test.go
+++ b/internal/twprojects/calendars_test.go
@@ -8,13 +8,6 @@ import (
 	"github.com/teamwork/mcp/internal/twprojects"
 )
 
-func TestCalendarDelete(t *testing.T) {
-	mcpServer := mcpServerMock(t, http.StatusNoContent, nil)
-	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCalendarDelete.String(), map[string]any{
-		"id": float64(123),
-	})
-}
-
 func TestCalendarList(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCalendarList.String(), map[string]any{

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -186,7 +186,6 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 	}
 	if allowDelete {
 		timeWriteTools = append(timeWriteTools,
-			CalendarDelete(engine),
 			TimelogDelete(engine),
 			TimerDelete(engine),
 		)

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -176,7 +176,6 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 
 	// --- time sub-toolset ---
 	timeWriteTools := []toolsets.ToolWrapper{
-		CalendarCreate(engine),
 		TimelogCreate(engine),
 		TimelogUpdate(engine),
 		TimerComplete(engine),


### PR DESCRIPTION
## Description
Removes the `twprojects-create_calendar` and `twprojects-delete_calendar` tools. Per review feedback on #349, all calendars in the product are "special", app-managed calendars — while the API allows creating, deleting, and adding events to them, those calendars surface nowhere in-app. There's no real use case for exposing calendar creation or deletion through the MCP server, so we keep only the read side.

The read tools (`twprojects-list_calendars`, `twprojects-list_calendar_events`) are unchanged.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Tool removal (unreleased — no deprecation needed)

## Testing
- [x] Tests pass locally (`go test ./internal/twprojects`)
- [x] `go build ./...` and `go vet ./...` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No new warnings or errors