### PR TITLE
Fix: Update Get and List tasks schemas type overrides

### DIFF
--- a/internal/helpers/schema_date.go
+++ b/internal/helpers/schema_date.go
@@ -1,0 +1,37 @@
+package helpers
+
+import (
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	twapi "github.com/teamwork/twapi-go-sdk"
+)
+
+// WithDateTypeSchema registers a JSON-schema override for the twapi.Date type
+// on the given generation options. twapi.Date is defined as `type Date
+// time.Time`, so the reflection-based generator would otherwise emit a useless
+// object schema for time.Time's unexported fields. This override forces it to a
+// nullable, date-only string.
+//
+// Use it whenever generating an output schema from a response type that carries
+// (or sideloads) twapi.Date fields:
+//
+//	schema, err = jsonschema.For[Response](helpers.WithDateTypeSchema(&jsonschema.ForOptions{}))
+//
+// Any other options already set on opts (including pre-existing TypeSchemas
+// entries) are preserved. The options value is modified in place and also
+// returned for convenient chaining.
+func WithDateTypeSchema(opts *jsonschema.ForOptions) *jsonschema.ForOptions {
+	if opts == nil {
+		opts = &jsonschema.ForOptions{}
+	}
+	if opts.TypeSchemas == nil {
+		opts.TypeSchemas = make(map[reflect.Type]*jsonschema.Schema)
+	}
+	opts.TypeSchemas[reflect.TypeFor[twapi.Date]()] = &jsonschema.Schema{
+		Types:       []string{"null", "string"},
+		Format:      "date",
+		Description: "Null or date-only date string",
+	}
+	return opts
+}

--- a/internal/twprojects/calendar_events.go
+++ b/internal/twprojects/calendar_events.go
@@ -29,7 +29,9 @@ func init() {
 	var err error
 
 	// generate the output schema only once
-	calendarEventListOutputSchema, err = jsonschema.For[projects.CalendarEventListResponse](&jsonschema.ForOptions{})
+	calendarEventListOutputSchema, err = jsonschema.For[projects.CalendarEventListResponse](
+		helpers.WithDateTypeSchema(&jsonschema.ForOptions{}),
+	)
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for CalendarEventListResponse: %v", err))
 	}

--- a/internal/twprojects/search.go
+++ b/internal/twprojects/search.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	var err error
 
-	searchOutputSchema, err = jsonschema.For[projects.SearchResponse](&jsonschema.ForOptions{})
+	searchOutputSchema, err = jsonschema.For[projects.SearchResponse](helpers.WithDateTypeSchema(&jsonschema.ForOptions{}))
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for SearchResponse: %v", err))
 	}

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -37,12 +38,26 @@ func init() {
 	var err error
 
 	// generate the output schemas only once
-	taskGetOutputSchema, err = jsonschema.For[projects.TaskGetResponse](&jsonschema.ForOptions{})
+	taskGetOutputSchema, err = jsonschema.For[projects.TaskGetResponse](&jsonschema.ForOptions{
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[twapi.Date](): {
+				Types:       []string{"null", "string"},
+				Description: "Null or date-only date string",
+			},
+		},
+	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskGetResponse: %v", err))
 	}
 	helpers.WithMetaWebLinkSchema(taskGetOutputSchema)
-	taskListOutputSchema, err = jsonschema.For[projects.TaskListResponse](&jsonschema.ForOptions{})
+	taskListOutputSchema, err = jsonschema.For[projects.TaskListResponse](&jsonschema.ForOptions{
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[twapi.Date](): {
+				Types:       []string{"null", "string"},
+				Description: "Null or date-only date string",
+			},
+		},
+	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskListResponse: %v", err))
 	}

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -38,26 +37,12 @@ func init() {
 	var err error
 
 	// generate the output schemas only once
-	taskGetOutputSchema, err = jsonschema.For[projects.TaskGetResponse](&jsonschema.ForOptions{
-		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
-			reflect.TypeFor[twapi.Date](): {
-				Types:       []string{"null", "string"},
-				Description: "Null or date-only date string",
-			},
-		},
-	})
+	taskGetOutputSchema, err = jsonschema.For[projects.TaskGetResponse](helpers.WithDateTypeSchema(&jsonschema.ForOptions{}))
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskGetResponse: %v", err))
 	}
 	helpers.WithMetaWebLinkSchema(taskGetOutputSchema)
-	taskListOutputSchema, err = jsonschema.For[projects.TaskListResponse](&jsonschema.ForOptions{
-		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
-			reflect.TypeFor[twapi.Date](): {
-				Types:       []string{"null", "string"},
-				Description: "Null or date-only date string",
-			},
-		},
-	})
+	taskListOutputSchema, err = jsonschema.For[projects.TaskListResponse](helpers.WithDateTypeSchema(&jsonschema.ForOptions{}))
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate JSON schema for TaskListResponse: %v", err))
 	}


### PR DESCRIPTION
Add schema generation type override for `twapi.Date` for tasks Get and List responses.

Connected to changes in [twapi-go-sdk](https://github.com/Teamwork/twapi-go-sdk/pull/94).

## Description
<!-- Briefly describe what this PR does and why it's needed -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors