### PR TITLE
Fix: Projects timelog - Billable should always be optional

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.19.2
+	github.com/teamwork/twapi-go-sdk v1.19.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.19.2 h1:44RXG4Q0mFobfheB2338MX5xjN8imNP7rig+BtivCf8=
-github.com/teamwork/twapi-go-sdk v1.19.2/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
+github.com/teamwork/twapi-go-sdk v1.19.3 h1:kR02Y6tZPeV6/0Rsi00r0HYUHYZPp59WV1+h2fBfdZ8=
+github.com/teamwork/twapi-go-sdk v1.19.3/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -107,7 +107,6 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "boolean"},
 							{Type: "null"},
 						},
-						Default: []byte("false"),
 					},
 					"project_id": {
 						Description: "Project the timelog is logged against. Provide exactly one of project_id or task_id.",
@@ -151,7 +150,7 @@ func TimelogCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalParam(&timelogCreateRequest.IsUTC, "is_utc"),
 				helpers.RequiredNumericParam(&timelogCreateRequest.Hours, "hours"),
 				helpers.RequiredNumericParam(&timelogCreateRequest.Minutes, "minutes"),
-				helpers.OptionalParam(&timelogCreateRequest.Billable, "billable"),
+				helpers.OptionalPointerParam(&timelogCreateRequest.Billable, "billable"),
 				helpers.OptionalNumericPointerParam(&timelogCreateRequest.UserID, "user_id"),
 				helpers.OptionalNumericListParam(&timelogCreateRequest.TagIDs, "tag_ids"),
 			)
@@ -228,7 +227,6 @@ func TimelogUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "boolean"},
 							{Type: "null"},
 						},
-						Default: []byte("false"),
 					},
 					"project_id": {
 						Description: "Project the timelog is logged against. Provide exactly one of project_id or task_id.",


### PR DESCRIPTION
## Description

To allow using the task list and project settings, the billable flag should be optional.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors