### PR TITLE
Enhancement: Order tool list by usage so truncating clients keep key tools

### DIFF
--- a/internal/cli/methods.go
+++ b/internal/cli/methods.go
@@ -40,6 +40,33 @@ func init() {
 	toolsets.RegisterProfile("ops", []toolsets.Method{
 		toolsets.MethodAll,
 	})
+
+	// RegisterToolOrder defines the order in which tools are presented to MCP
+	// clients, with the most commonly used tools first. Clients that truncate
+	// the tool list at a fixed size keep the most useful tools; any tool not
+	// listed here follows alphabetically.
+	toolsets.RegisterToolOrder([]toolsets.Method{
+		twprojects.MethodTaskGet,
+		twprojects.MethodTaskList,
+		twprojects.MethodTaskCreate,
+		twprojects.MethodCommentList,
+		twprojects.MethodTaskUpdate,
+		twprojects.MethodProjectList,
+		twprojects.MethodTimelogCreate,
+		twprojects.MethodTimelogList,
+		twprojects.MethodSearch,
+		twprojects.MethodTasklistList,
+		twprojects.MethodCommentCreate,
+		twprojects.MethodTasklistGet,
+		twprojects.MethodProjectGet,
+		twdesk.MethodTicketGet,
+		twprojects.MethodTimelogUpdate,
+		twprojects.MethodActivityList,
+		twprojects.MethodWorkflowStageTaskMove,
+		twprojects.MethodTaskComplete,
+		twdesk.MethodTicketSearch,
+		twprojects.MethodUserList,
+	})
 }
 
 // Methods is a slice of toolsets.Method that implements the flag.Value

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -244,22 +245,24 @@ func NewMCPServer(resources Resources, groups ...*toolsets.ToolsetGroup) *mcp.Se
 			}
 
 			// filter tools based on scopes
-			scopes := scopes(ctx)
-			if len(scopes) == 0 {
-				return result, err
+			if scopes := scopes(ctx); len(scopes) > 0 {
+				projectsScope := slices.Contains(scopes, "projects")
+				deskScope := slices.Contains(scopes, "desk")
+				spacesScope := slices.Contains(scopes, "spaces")
+				chatScope := slices.Contains(scopes, "chat")
+
+				listToolsResult.Tools = slices.DeleteFunc(listToolsResult.Tools, func(tool *mcp.Tool) bool {
+					return (strings.HasPrefix(tool.Name, "twprojects") && !projectsScope) ||
+						(strings.HasPrefix(tool.Name, "twdesk") && !deskScope) ||
+						(strings.HasPrefix(tool.Name, "twspaces") && !spacesScope) ||
+						(strings.HasPrefix(tool.Name, "twchat") && !chatScope)
+				})
 			}
 
-			projectsScope := slices.Contains(scopes, "projects")
-			deskScope := slices.Contains(scopes, "desk")
-			spacesScope := slices.Contains(scopes, "spaces")
-			chatScope := slices.Contains(scopes, "chat")
-
-			listToolsResult.Tools = slices.DeleteFunc(listToolsResult.Tools, func(tool *mcp.Tool) bool {
-				return (strings.HasPrefix(tool.Name, "twprojects") && !projectsScope) ||
-					(strings.HasPrefix(tool.Name, "twdesk") && !deskScope) ||
-					(strings.HasPrefix(tool.Name, "twspaces") && !spacesScope) ||
-					(strings.HasPrefix(tool.Name, "twchat") && !chatScope)
-			})
+			// order tools so the most commonly used appear first. This helps MCP
+			// clients that truncate the tool list at a fixed size to keep the most
+			// useful tools. Tools not in the preferred list follow alphabetically.
+			orderTools(listToolsResult.Tools)
 			return listToolsResult, nil
 		}
 	})
@@ -270,6 +273,33 @@ func NewMCPServer(resources Resources, groups ...*toolsets.ToolsetGroup) *mcp.Se
 	}
 
 	return mcpServer
+}
+
+// orderTools sorts tools in place so that those registered via
+// toolsets.RegisterToolOrder appear first (in that order), followed by the
+// remaining tools alphabetically by name. This helps MCP clients that truncate
+// the tool list at a fixed size keep the most useful tools.
+func orderTools(tools []*mcp.Tool) {
+	order := toolsets.ToolOrder()
+	ranks := make(map[string]int, len(order))
+	for i, method := range order {
+		ranks[method.String()] = i
+	}
+
+	slices.SortStableFunc(tools, func(a, b *mcp.Tool) int {
+		rankA, okA := ranks[a.Name]
+		rankB, okB := ranks[b.Name]
+		switch {
+		case okA && okB:
+			return cmp.Compare(rankA, rankB)
+		case okA:
+			return -1
+		case okB:
+			return 1
+		default:
+			return strings.Compare(a.Name, b.Name)
+		}
+	})
 }
 
 // NewMCPClient creates a new MCP client.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/teamwork/mcp/internal/toolsets"
+)
+
+func TestOrderTools(t *testing.T) {
+	toolsets.RegisterToolOrder([]toolsets.Method{
+		"twprojects-get_task",
+		"twprojects-list_tasks",
+		"twprojects-complete_task",
+		"twdesk-search_tickets",
+		"twprojects-list_users",
+	})
+
+	// Preferred tools arrive out of order and mixed with unlisted ones.
+	tools := []*mcp.Tool{
+		{Name: "twprojects-zebra"},
+		{Name: "twprojects-complete_task"},
+		{Name: "twprojects-get_task"},
+		{Name: "twprojects-alpha"},
+		{Name: "twprojects-list_tasks"},
+		{Name: "twdesk-search_tickets"},
+		{Name: "twprojects-list_users"},
+	}
+
+	orderTools(tools)
+
+	got := make([]string, len(tools))
+	for i, tool := range tools {
+		got[i] = tool.Name
+	}
+
+	want := []string{
+		// preferred tools, in registered order
+		"twprojects-get_task",
+		"twprojects-list_tasks",
+		"twprojects-complete_task",
+		"twdesk-search_tickets",
+		"twprojects-list_users",
+		// remaining tools, alphabetically
+		"twprojects-alpha",
+		"twprojects-zebra",
+	}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("orderTools() = %v, want %v", got, want)
+	}
+}
+
+// TestOrderToolsNoRegistration ensures tools fall back to alphabetical order
+// when no preferred order has been registered.
+func TestOrderToolsNoRegistration(t *testing.T) {
+	toolsets.RegisterToolOrder(nil)
+
+	tools := []*mcp.Tool{
+		{Name: "twprojects-zebra"},
+		{Name: "twprojects-alpha"},
+		{Name: "twprojects-mango"},
+	}
+
+	orderTools(tools)
+
+	got := make([]string, len(tools))
+	for i, tool := range tools {
+		got[i] = tool.Name
+	}
+
+	want := []string{"twprojects-alpha", "twprojects-mango", "twprojects-zebra"}
+	if !slices.Equal(got, want) {
+		t.Errorf("orderTools() = %v, want %v", got, want)
+	}
+}

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -20,6 +20,9 @@ var (
 
 	registeredProfiles      = make(map[string][]Method)
 	registeredProfilesMutex sync.RWMutex
+
+	registeredToolOrder      []Method
+	registeredToolOrderMutex sync.RWMutex
 )
 
 // Method identifies the name of a logical unit of operation or action that can
@@ -72,6 +75,24 @@ func RegisterProfiles(names []string, methods []Method) {
 	for _, name := range names {
 		registeredProfiles[name] = methods
 	}
+}
+
+// RegisterToolOrder sets the preferred display order for tools. Methods that
+// appear earlier in the list are presented first to MCP clients; this helps
+// clients that truncate the tool list at a fixed size keep the most useful
+// tools. Methods not listed here fall back to alphabetical order.
+func RegisterToolOrder(methods []Method) {
+	registeredToolOrderMutex.Lock()
+	defer registeredToolOrderMutex.Unlock()
+	registeredToolOrder = methods
+}
+
+// ToolOrder returns the registered preferred tool order. The returned slice
+// must not be modified.
+func ToolOrder() []Method {
+	registeredToolOrderMutex.RLock()
+	defer registeredToolOrderMutex.RUnlock()
+	return registeredToolOrder
 }
 
 // LookupProfile returns the methods associated with a named profile, and


### PR DESCRIPTION
## Description

MCP clients that cap the tool list at a fixed size were dropping commonly used tools, since the go-sdk returns tools sorted alphabetically by name. Reorder the tools/list response to surface the most useful tools first, falling back to alphabetical order for the rest.

The preferred order is registered via the new toolsets.RegisterToolOrder registry (mirroring the existing profile registry) from internal/cli, which references the concrete Method constants. This keeps config free of the twdesk -> config import cycle and avoids hard-coded tool-name strings.

<img width="730" height="650" alt="image" src="https://github.com/user-attachments/assets/80790f60-8c66-4a5c-ab30-55666ef45633" />

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors