### PR TITLE
Feature: Allow clearing task assignees and support job-role assignees

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.19.3
+	github.com/teamwork/twapi-go-sdk v1.19.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.19.3 h1:kR02Y6tZPeV6/0Rsi00r0HYUHYZPp59WV1+h2fBfdZ8=
-github.com/teamwork/twapi-go-sdk v1.19.3/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
+github.com/teamwork/twapi-go-sdk v1.19.4 h1:s7+gzMWrwprOxamv/I/mJug02sdPioSq7RWUM6QLoKk=
+github.com/teamwork/twapi-go-sdk v1.19.4/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -128,13 +128,14 @@ func MatchAllTagsSchema() *jsonschema.Schema {
 	}
 }
 
-// UserGroupsSchema returns the schema for a user/team/company groups
-// parameter. The object accepts user_ids, company_ids, and/or team_ids arrays;
-// at least one (and at most all three) must be supplied with non-empty values.
-// When required is true the returned schema is a bare object; when false it is
-// wrapped in AnyOf with null so the caller can omit the field. The caller
-// supplies the purpose-specific framing as description (pass "" when the helper
-// is used as a branch of an outer schema that already carries a description).
+// UserGroupsSchema returns the schema for a user/team/company/job-role groups
+// parameter. The object accepts user_ids, company_ids, team_ids, and/or
+// job_role_ids arrays; at least one (and at most all four) must be supplied with
+// non-empty values. When required is true the returned schema is a bare object;
+// when false it is wrapped in AnyOf with null so the caller can omit the field.
+// The caller supplies the purpose-specific framing as description (pass "" when
+// the helper is used as a branch of an outer schema that already carries a
+// description).
 func UserGroupsSchema(description string, required bool) *jsonschema.Schema {
 	obj := &jsonschema.Schema{
 		Type: "object",
@@ -154,13 +155,19 @@ func UserGroupsSchema(description string, required bool) *jsonschema.Schema {
 				Items:    &jsonschema.Schema{Type: "integer"},
 				MinItems: new(1),
 			},
+			"job_role_ids": {
+				Type:     "array",
+				Items:    &jsonschema.Schema{Type: "integer"},
+				MinItems: new(1),
+			},
 		},
 		MinProperties: new(1),
-		MaxProperties: new(3),
+		MaxProperties: new(4),
 		AnyOf: []*jsonschema.Schema{
 			{Required: []string{"user_ids"}},
 			{Required: []string{"company_ids"}},
 			{Required: []string{"team_ids"}},
+			{Required: []string{"job_role_ids"}},
 		},
 	}
 	if required {

--- a/internal/helpers/schema_test.go
+++ b/internal/helpers/schema_test.go
@@ -121,10 +121,10 @@ func TestUserGroupsSchema(t *testing.T) {
 		if got.MinProperties == nil || *got.MinProperties != 1 {
 			t.Errorf("required UserGroupsSchema MinProperties = %v, want 1", got.MinProperties)
 		}
-		if got.MaxProperties == nil || *got.MaxProperties != 3 {
-			t.Errorf("required UserGroupsSchema MaxProperties = %v, want 3", got.MaxProperties)
+		if got.MaxProperties == nil || *got.MaxProperties != 4 {
+			t.Errorf("required UserGroupsSchema MaxProperties = %v, want 4", got.MaxProperties)
 		}
-		for _, key := range []string{"user_ids", "company_ids", "team_ids"} {
+		for _, key := range []string{"user_ids", "company_ids", "team_ids", "job_role_ids"} {
 			prop, ok := got.Properties[key]
 			if !ok {
 				t.Errorf("required UserGroupsSchema missing %q", key)
@@ -140,8 +140,8 @@ func TestUserGroupsSchema(t *testing.T) {
 				t.Errorf("required UserGroupsSchema %q MinItems = %v, want 1", key, prop.MinItems)
 			}
 		}
-		if len(got.AnyOf) != 3 {
-			t.Fatalf("required UserGroupsSchema AnyOf len = %d, want 3", len(got.AnyOf))
+		if len(got.AnyOf) != 4 {
+			t.Fatalf("required UserGroupsSchema AnyOf len = %d, want 4", len(got.AnyOf))
 		}
 	})
 

--- a/internal/testutil/mcp.go
+++ b/internal/testutil/mcp.go
@@ -67,12 +67,47 @@ func DeskClientMock(status int, response []byte) (*deskclient.Client, *httptest.
 
 // ProjectsMCPServerMock creates a mock MCP server for twprojects testing
 func ProjectsMCPServerMock(t *testing.T, status int, response []byte) *mcp.Server {
+	return projectsMCPServer(t, ProjectsEngineMock(status, response))
+}
+
+// ProjectsMCPServerMockWithRequestBody is like ProjectsMCPServerMock but also
+// captures the body of the most recent HTTP request the engine sent, so tests
+// can assert on the serialized request payload. The returned pointer is
+// populated after a tool invokes the engine.
+func ProjectsMCPServerMockWithRequestBody(t *testing.T, status int, response []byte) (*mcp.Server, *[]byte) {
+	var lastBody []byte
+	engine := twapi.NewEngine(ProjectsSessionMock{}, twapi.WithMiddleware(func(twapi.HTTPClient) twapi.HTTPClient {
+		return twapi.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Body != nil {
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				lastBody = body
+			}
+			return &http.Response{
+				StatusCode: status,
+				Status:     http.StatusText(status),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(string(response))),
+			}, nil
+		})
+	}))
+	return projectsMCPServer(t, engine), &lastBody
+}
+
+// projectsMCPServer wires a twprojects toolset group backed by the given engine
+// into a fresh in-memory MCP server.
+func projectsMCPServer(t *testing.T, engine *twapi.Engine) *mcp.Server {
 	mcpServer := mcp.NewServer(&mcp.Implementation{
 		Name:    "test-server",
 		Version: "1.0.0",
 	}, &mcp.ServerOptions{})
 
-	toolsetGroup := twprojects.DefaultToolsetGroup(false, true, ProjectsEngineMock(status, response))
+	toolsetGroup := twprojects.DefaultToolsetGroup(false, true, engine)
 	if err := toolsetGroup.EnableToolsets(toolsets.MethodAll); err != nil {
 		t.Fatalf("failed to enable toolsets: %v", err)
 	}

--- a/internal/twprojects/helpers.go
+++ b/internal/twprojects/helpers.go
@@ -27,6 +27,7 @@ func parseUserGroups(
 		helpers.OptionalNumericListParam(&userGroups.UserIDs, "user_ids"),
 		helpers.OptionalNumericListParam(&userGroups.CompanyIDs, "company_ids"),
 		helpers.OptionalNumericListParam(&userGroups.TeamIDs, "team_ids"),
+		helpers.OptionalNumericListParam(&userGroups.JobRoleIDs, "job_role_ids"),
 	)
 	if err != nil {
 		return nil, helpers.NewToolResultTextError("invalid %s: %s", label, err)
@@ -55,6 +56,7 @@ func parseLegacyUserGroups(
 		helpers.OptionalNumericListParam(&userGroups.UserIDs, "user_ids"),
 		helpers.OptionalNumericListParam(&userGroups.CompanyIDs, "company_ids"),
 		helpers.OptionalNumericListParam(&userGroups.TeamIDs, "team_ids"),
+		helpers.OptionalNumericListParam(&userGroups.JobRoleIDs, "job_role_ids"),
 	)
 	if err != nil {
 		return nil, helpers.NewToolResultTextError("invalid %s: %s", label, err)

--- a/internal/twprojects/main_test.go
+++ b/internal/twprojects/main_test.go
@@ -6,5 +6,6 @@ import (
 
 // Re-export the shared utilities for convenience
 var (
-	mcpServerMock = testutil.ProjectsMCPServerMock
+	mcpServerMock                = testutil.ProjectsMCPServerMock
+	mcpServerMockWithRequestBody = testutil.ProjectsMCPServerMockWithRequestBody
 )

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -314,8 +314,17 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"assignees": helpers.UserGroupsSchema("Assignees for the task.", false),
-					"tag_ids":   helpers.TagIDsAssociateSchema("task"),
+					"assignees": helpers.UserGroupsSchema("Assignees for the task. To remove all "+
+						"assignees, use clear_assignees instead.", false),
+					"clear_assignees": {
+						Description: "If true, removes all assignees from the task, leaving it unassigned. " +
+							"Cannot be combined with a non-empty assignees value.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
+					},
+					"tag_ids": helpers.TagIDsAssociateSchema("task"),
 					"predecessors": {
 						Description: "Task dependencies that must be completed before this task can start.",
 						AnyOf: []*jsonschema.Schema{
@@ -375,6 +384,13 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
+			var clearAssignees bool
+			if err := helpers.ParamGroup(arguments,
+				helpers.OptionalParam(&clearAssignees, "clear_assignees"),
+			); err != nil {
+				return helpers.NewToolResultTextError("invalid clear_assignees: %s", err.Error()), nil
+			}
+
 			if assignees, toolResult := parseUserGroups(
 				arguments,
 				"assignees",
@@ -382,7 +398,28 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 			); toolResult != nil {
 				return toolResult, nil
 			} else if assignees != nil {
+				assigneesEmpty := len(assignees.UserIDs) == 0 &&
+					len(assignees.CompanyIDs) == 0 &&
+					len(assignees.TeamIDs) == 0 &&
+					len(assignees.JobRoleIDs) == 0
+				if clearAssignees && !assigneesEmpty {
+					return helpers.NewToolResultTextError(
+						"clear_assignees cannot be combined with a non-empty assignees value",
+					), nil
+				}
 				taskUpdateRequest.Assignees = assignees
+			}
+
+			if clearAssignees {
+				// Empty arrays unassign every assignee dimension. Job roles are
+				// included because the SDK now sends the "Jobroles-Enabled: true"
+				// header on every request, so the API honours jobRoleIds here.
+				taskUpdateRequest.Assignees = &projects.UserGroups{
+					UserIDs:    []int64{},
+					CompanyIDs: []int64{},
+					TeamIDs:    []int64{},
+					JobRoleIDs: []int64{},
+				}
 			}
 
 			if predecessors, ok := arguments["predecessors"]; ok {

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -1,9 +1,11 @@
 package twprojects_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
 )
@@ -21,9 +23,10 @@ func TestTaskCreate(t *testing.T) {
 		"estimated_minutes": float64(120),
 		"parent_task_id":    float64(456),
 		"assignees": map[string]any{
-			"user_ids":    []float64{1, 2, 3},
-			"team_ids":    []float64{4, 5},
-			"company_ids": []float64{6, 7},
+			"user_ids":     []float64{1, 2, 3},
+			"team_ids":     []float64{4, 5},
+			"company_ids":  []float64{6, 7},
+			"job_role_ids": []float64{8, 9},
 		},
 		"tag_ids": []float64{1, 2, 3},
 		"predecessors": []map[string]any{
@@ -53,9 +56,10 @@ func TestTaskUpdate(t *testing.T) {
 		"estimated_minutes": float64(120),
 		"parent_task_id":    float64(456),
 		"assignees": map[string]any{
-			"user_ids":    []float64{1, 2, 3},
-			"team_ids":    []float64{4, 5},
-			"company_ids": []float64{6, 7},
+			"user_ids":     []float64{1, 2, 3},
+			"team_ids":     []float64{4, 5},
+			"company_ids":  []float64{6, 7},
+			"job_role_ids": []float64{8, 9},
 		},
 		"tag_ids": []float64{1, 2, 3},
 		"predecessors": []map[string]any{
@@ -69,6 +73,83 @@ func TestTaskUpdate(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestTaskUpdateClearAssignees(t *testing.T) {
+	mcpServer, requestBody := mcpServerMockWithRequestBody(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskUpdate.String(), map[string]any{
+		"id":              float64(123),
+		"clear_assignees": true,
+	})
+
+	var payload struct {
+		Task struct {
+			Assignees struct {
+				UserIDs    []int64 `json:"userIds"`
+				CompanyIDs []int64 `json:"companyIds"`
+				TeamIDs    []int64 `json:"teamIds"`
+				JobRoleIDs []int64 `json:"jobRoleIds"`
+			} `json:"assignees"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal(*requestBody, &payload); err != nil {
+		t.Fatalf("failed to decode request body %q: %v", string(*requestBody), err)
+	}
+
+	assignees := payload.Task.Assignees
+	// Empty (non-null) arrays are what the API expects to unassign a task; a
+	// null value would leave the dimension unchanged.
+	if assignees.UserIDs == nil || assignees.CompanyIDs == nil ||
+		assignees.TeamIDs == nil || assignees.JobRoleIDs == nil {
+		t.Fatalf("expected empty (non-null) assignee arrays, got body %q", string(*requestBody))
+	}
+	if len(assignees.UserIDs) != 0 || len(assignees.CompanyIDs) != 0 ||
+		len(assignees.TeamIDs) != 0 || len(assignees.JobRoleIDs) != 0 {
+		t.Errorf("expected all assignee arrays to be empty, got %+v", assignees)
+	}
+}
+
+func TestTaskUpdateAssignJobRoles(t *testing.T) {
+	mcpServer, requestBody := mcpServerMockWithRequestBody(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskUpdate.String(), map[string]any{
+		"id": float64(123),
+		"assignees": map[string]any{
+			"job_role_ids": []float64{8, 9},
+		},
+	})
+
+	var payload struct {
+		Task struct {
+			Assignees struct {
+				JobRoleIDs []int64 `json:"jobRoleIds"`
+			} `json:"assignees"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal(*requestBody, &payload); err != nil {
+		t.Fatalf("failed to decode request body %q: %v", string(*requestBody), err)
+	}
+	if got := payload.Task.Assignees.JobRoleIDs; len(got) != 2 || got[0] != 8 || got[1] != 9 {
+		t.Errorf("expected jobRoleIds [8 9], got %v (body %q)", got, string(*requestBody))
+	}
+}
+
+func TestTaskUpdateClearAssigneesConflictsWithAssignees(t *testing.T) {
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskUpdate.String(), map[string]any{
+		"id":              float64(123),
+		"clear_assignees": true,
+		"assignees": map[string]any{
+			"user_ids": []float64{1, 2, 3},
+		},
+	}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+		toolResult, ok := result.(*mcp.CallToolResult)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", result)
+		}
+		if !toolResult.IsError {
+			t.Errorf("expected an error when combining clear_assignees with a non-empty assignees value")
+		}
+	}))
 }
 
 func TestTaskDelete(t *testing.T) {


### PR DESCRIPTION
## Description

Add a clear_assignees boolean to twprojects-update_task so a task can be fully unassigned (e.g. moving to "Code Review" and dropping yourself). When set, it sends empty userIds/companyIds/teamIds/jobRoleIds arrays — the form the v3 API requires to clear — and is rejected if combined with a non-empty assignees value.

Bump twapi-go-sdk to v1.19.4, which adds the UserGroups.JobRoleIDs field and sends the "Jobroles-Enabled: true" header on every request. With that in place, wire job roles through the shared UserGroupsSchema and both parseUserGroups/parseLegacyUserGroups, so job_role_ids can be set anywhere assignee/notify groups are accepted and clear_assignees also removes them.

Add a request-body-capturing test helper (ProjectsMCPServerMockWithRequestBody) and tests covering the cleared payload, job-role assignment, and the clear_assignees/assignees conflict. Descriptions are kept generic to minimise prompt tokens.

Resolves #372

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors