### PR TITLE
Enhancement: Add due date filters to the list tasks tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.19.4
+	github.com/teamwork/twapi-go-sdk v1.19.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.19.4 h1:s7+gzMWrwprOxamv/I/mJug02sdPioSq7RWUM6QLoKk=
-github.com/teamwork/twapi-go-sdk v1.19.4/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
+github.com/teamwork/twapi-go-sdk v1.19.5 h1:Q0Q/ir8ed2ZmxygbOqbvyszna2QQuaLavepF1BgF7Vk=
+github.com/teamwork/twapi-go-sdk v1.19.5/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -739,6 +739,22 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"due_after": {
+						Description: "Filter tasks due after.",
+						Examples:    []any{"2023-01-01"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Format: "date"},
+							{Type: "null"},
+						},
+					},
+					"due_before": {
+						Description: "Filter tasks due before.",
+						Examples:    []any{"2023-12-31"},
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Format: "date"},
+							{Type: "null"},
+						},
+					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
 					"verbose":   helpers.VerboseSchema(),
@@ -771,6 +787,8 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.UpdatedBefore, "updated_before"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedAfter, "completed_after"),
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedBefore, "completed_before"),
+				helpers.OptionalDatePointerParam(&taskListRequest.Filters.DueAfter, "due_after"),
+				helpers.OptionalDatePointerParam(&taskListRequest.Filters.DueBefore, "due_before"),
 				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -187,6 +187,8 @@ func TestTaskList(t *testing.T) {
 		"updated_before":      "2023-10-31T23:59:59Z",
 		"completed_after":     "2023-10-01T00:00:00Z",
 		"completed_before":    "2023-10-31T23:59:59Z",
+		"due_after":           "2023-10-01",
+		"due_before":          "2023-10-31",
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})
@@ -207,6 +209,8 @@ func TestTaskListByTasklist(t *testing.T) {
 		"updated_before":      "2023-10-31T23:59:59Z",
 		"completed_after":     "2023-10-01T00:00:00Z",
 		"completed_before":    "2023-10-31T23:59:59Z",
+		"due_after":           "2023-10-01",
+		"due_before":          "2023-10-31",
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})
@@ -227,6 +231,8 @@ func TestTaskListByProject(t *testing.T) {
 		"updated_before":      "2023-10-31T23:59:59Z",
 		"completed_after":     "2023-10-01T00:00:00Z",
 		"completed_before":    "2023-10-31T23:59:59Z",
+		"due_after":           "2023-10-01",
+		"due_before":          "2023-10-31",
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})


### PR DESCRIPTION
## Description

Add due_after and due_before filters to twprojects-list_tasks, backed by twapi-go-sdk v1.19.5, which exposes the DueAfter/DueBefore task filter fields.

Related to:
https://github.com/Teamwork/twapi-go-sdk/pull/98

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors