### PR TITLE
Fix: Gate Teamwork Spaces delete tools behind allowDelete

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -121,7 +121,7 @@ func newMCPServer(resources config.Resources) (*mcp.Server, error) {
 		return nil, fmt.Errorf("failed to enable desk toolsets: %w", err)
 	}
 
-	spacesGroup := twspaces.DefaultToolsetGroup(false, resources.TeamworkHTTPClient())
+	spacesGroup := twspaces.DefaultToolsetGroup(false, false, resources.TeamworkHTTPClient())
 	if err := spacesGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable spaces toolsets: %w", err)
 	}

--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -124,7 +124,7 @@ func newMCPServer(resources config.Resources) (*mcp.Server, error) {
 		return nil, fmt.Errorf("failed to enable desk toolsets: %w", err)
 	}
 
-	spacesGroup := twspaces.DefaultToolsetGroup(readOnly, resources.TeamworkHTTPClient())
+	spacesGroup := twspaces.DefaultToolsetGroup(readOnly, false, resources.TeamworkHTTPClient())
 	if err := spacesGroup.EnableToolsets(methods.Toolsets()...); err != nil {
 		return nil, fmt.Errorf("failed to enable spaces toolsets: %w", err)
 	}

--- a/cmd/mcp-tokens/main.go
+++ b/cmd/mcp-tokens/main.go
@@ -108,7 +108,7 @@ func allGroups() []*toolsets.ToolsetGroup {
 	return []*toolsets.ToolsetGroup{
 		twprojects.DefaultToolsetGroup(false, true, nil),
 		twdesk.DefaultToolsetGroup(false, httpClient),
-		twspaces.DefaultToolsetGroup(false, httpClient),
+		twspaces.DefaultToolsetGroup(false, true, httpClient),
 	}
 }
 

--- a/internal/testutil/mcp.go
+++ b/internal/testutil/mcp.go
@@ -296,7 +296,7 @@ func SpacesMCPServerMock(t *testing.T, status int, response []byte) (*mcp.Server
 	}
 
 	httpClient := testServer.Client()
-	toolsetGroup := twspaces.DefaultToolsetGroup(false, httpClient)
+	toolsetGroup := twspaces.DefaultToolsetGroup(false, true, httpClient)
 	if err := toolsetGroup.EnableToolsets(toolsets.MethodAll); err != nil {
 		cleanup()
 		t.Fatalf("failed to enable toolsets: %v", err)

--- a/internal/twspaces/tools.go
+++ b/internal/twspaces/tools.go
@@ -30,16 +30,21 @@ func init() {
 }
 
 // DefaultToolsetGroup creates a default ToolsetGroup for Teamwork Spaces.
-func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.ToolsetGroup {
+func DefaultToolsetGroup(readOnly, allowDelete bool, httpClient *http.Client) *toolsets.ToolsetGroup {
 	group := toolsets.NewToolsetGroup(readOnly)
 
 	// --- spaces sub-toolset ---
-	group.AddToolset(toolsets.NewToolset(ToolsetSpaces, spacesDescription).
-		AddWriteTools(
-			SpaceCreate(httpClient),
-			SpaceUpdate(httpClient),
+	spacesWriteTools := []toolsets.ToolWrapper{
+		SpaceCreate(httpClient),
+		SpaceUpdate(httpClient),
+	}
+	if allowDelete {
+		spacesWriteTools = append(spacesWriteTools,
 			SpaceDelete(httpClient),
-		).
+		)
+	}
+	group.AddToolset(toolsets.NewToolset(ToolsetSpaces, spacesDescription).
+		AddWriteTools(spacesWriteTools...).
 		AddReadTools(
 			SpaceGet(httpClient),
 			SpaceList(httpClient),
@@ -47,13 +52,18 @@ func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.Tools
 		))
 
 	// --- pages sub-toolset ---
-	group.AddToolset(toolsets.NewToolset(ToolsetPages, pagesDescription).
-		AddWriteTools(
-			PageCreate(httpClient),
-			PageDuplicate(httpClient),
-			PageUpdate(httpClient),
+	pagesWriteTools := []toolsets.ToolWrapper{
+		PageCreate(httpClient),
+		PageDuplicate(httpClient),
+		PageUpdate(httpClient),
+	}
+	if allowDelete {
+		pagesWriteTools = append(pagesWriteTools,
 			PageDelete(httpClient),
-		).
+		)
+	}
+	group.AddToolset(toolsets.NewToolset(ToolsetPages, pagesDescription).
+		AddWriteTools(pagesWriteTools...).
 		AddReadTools(
 			PageGet(httpClient),
 			PageList(httpClient),
@@ -61,18 +71,23 @@ func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.Tools
 		))
 
 	// --- content sub-toolset ---
-	group.AddToolset(toolsets.NewToolset(ToolsetContent, spacesContentDescription).
-		AddWriteTools(
-			CommentCreate(httpClient),
-			CommentUpdate(httpClient),
+	contentWriteTools := []toolsets.ToolWrapper{
+		CommentCreate(httpClient),
+		CommentUpdate(httpClient),
+		TagCreateBatch(httpClient),
+		TagUpdate(httpClient),
+		CategoryCreate(httpClient),
+		CategoryUpdate(httpClient),
+	}
+	if allowDelete {
+		contentWriteTools = append(contentWriteTools,
 			CommentDelete(httpClient),
-			TagCreateBatch(httpClient),
-			TagUpdate(httpClient),
 			TagDelete(httpClient),
-			CategoryCreate(httpClient),
-			CategoryUpdate(httpClient),
 			CategoryDelete(httpClient),
-		).
+		)
+	}
+	group.AddToolset(toolsets.NewToolset(ToolsetContent, spacesContentDescription).
+		AddWriteTools(contentWriteTools...).
 		AddReadTools(
 			CommentGet(httpClient),
 			CommentList(httpClient),


### PR DESCRIPTION
## Description

Spaces registered its delete tools (space, page, comment, tag, category) as plain write tools, so they were exposed on the HTTP connector even though Projects deliberately gates deletes behind allowDelete=false.

Add an allowDelete parameter to twspaces.DefaultToolsetGroup mirroring twprojects, and pass false from the HTTP and STDIO servers so deletes are no longer exposed there. mcp-tokens and testutil pass true so token counting and tests still enumerate every tool.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors