### PR TITLE
Fix: Coerce stringified scalar arguments before schema validation

### DIFF
--- a/internal/helpers/tool_parser.go
+++ b/internal/helpers/tool_parser.go
@@ -102,17 +102,17 @@ func param[T any](
 	}
 	v, ok := value.(T)
 	if !ok {
-		// attempt to convert from string if the type is only an alias of string and
-		// the value is a string
+		// Some MCP clients serialize scalar arguments as strings (e.g. "false"
+		// instead of false). Recover the intended value when the target type can
+		// accept it, keying off the target type (never the source, which is
+		// always string here).
 		var fallback bool
 		if vStr, okStr := value.(string); okStr {
-			vv := reflect.ValueOf(value)
-			if vv.Kind() == reflect.Pointer {
-				vv = vv.Elem()
-			}
-			if vv.Kind() == reflect.String {
-				v = reflect.ValueOf(vStr).Convert(reflect.TypeOf(v)).Interface().(T)
-				fallback = true
+			if targetType := reflect.TypeOf(v); targetType != nil {
+				if converted, did := coerceStringValue(vStr, targetType); did {
+					v = converted.Interface().(T)
+					fallback = true
+				}
 			}
 		}
 		if !fallback {
@@ -127,6 +127,36 @@ func param[T any](
 	}
 	*target = v
 	return nil
+}
+
+// coerceStringValue converts a string into a value of type t when t is a string
+// (or a named string alias), a bool, or a pointer to a supported type. It
+// reports ok=false when t is an unsupported kind or the string does not parse
+// (e.g. a non-boolean string for a bool target), leaving the caller to surface a
+// type error. reflect.Convert panics on an illegal pair (string is not
+// convertible to bool), so each kind is handled explicitly rather than via a
+// blanket Convert.
+func coerceStringValue(s string, t reflect.Type) (reflect.Value, bool) {
+	switch t.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(s).Convert(t), true
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return reflect.Value{}, false
+		}
+		return reflect.ValueOf(b).Convert(t), true
+	case reflect.Pointer:
+		elem, ok := coerceStringValue(s, t.Elem())
+		if !ok {
+			return reflect.Value{}, false
+		}
+		ptr := reflect.New(t.Elem())
+		ptr.Elem().Set(elem)
+		return ptr, true
+	default:
+		return reflect.Value{}, false
+	}
 }
 
 // RequiredNumericParam retrieves a required numeric parameter from a map,

--- a/internal/helpers/tool_parser_test.go
+++ b/internal/helpers/tool_parser_test.go
@@ -157,3 +157,74 @@ func TestParamsAcceptDefinedTypes(t *testing.T) {
 	})
 
 }
+
+// TestParamCoercesStringBool verifies that a boolean parameter supplied as a
+// string (as some MCP clients serialize scalars) is parsed rather than causing a
+// panic. reflect.Convert(string -> bool) is illegal, so the parser must handle
+// bool targets explicitly. Invalid strings must return an error, not panic.
+func TestParamCoercesStringBool(t *testing.T) {
+	cases := map[string]bool{"true": true, "false": false, "1": true, "0": false}
+	for in, want := range cases {
+		t.Run("valid "+in, func(t *testing.T) {
+			var b bool
+			if err := helpers.ParamGroup(map[string]any{"k": in}, helpers.OptionalParam(&b, "k")); err != nil {
+				t.Fatalf("expected nil error for %q, got: %v", in, err)
+			}
+			if b != want {
+				t.Errorf("for %q expected %v, got %v", in, want, b)
+			}
+		})
+	}
+
+	t.Run("native bool still works", func(t *testing.T) {
+		var b bool
+		if err := helpers.ParamGroup(map[string]any{"k": true}, helpers.OptionalParam(&b, "k")); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if !b {
+			t.Errorf("expected true, got false")
+		}
+	})
+
+	t.Run("non-boolean string returns error without panic", func(t *testing.T) {
+		var b bool
+		err := helpers.ParamGroup(map[string]any{"k": "maybe"}, helpers.OptionalParam(&b, "k"))
+		if err == nil {
+			t.Fatalf("expected error for non-boolean string, got nil")
+		}
+	})
+}
+
+// TestParamCoercesStringToPointer verifies that a string value is coerced when
+// the target is a pointer to a supported type. No current caller uses param with
+// a pointer target (pointer optionals go through OptionalPointerParam), but the
+// generic parser must handle it safely rather than erroring or panicking.
+func TestParamCoercesStringToPointer(t *testing.T) {
+	t.Run("string to *string", func(t *testing.T) {
+		var sp *string
+		if err := helpers.ParamGroup(map[string]any{"k": "hi"}, helpers.OptionalParam(&sp, "k")); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if sp == nil || *sp != "hi" {
+			t.Errorf("expected pointer to %q, got %v", "hi", sp)
+		}
+	})
+
+	t.Run("string to *bool", func(t *testing.T) {
+		var bp *bool
+		if err := helpers.ParamGroup(map[string]any{"k": "true"}, helpers.OptionalParam(&bp, "k")); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if bp == nil || !*bp {
+			t.Errorf("expected pointer to true, got %v", bp)
+		}
+	})
+
+	t.Run("invalid bool string to *bool returns error", func(t *testing.T) {
+		var bp *bool
+		err := helpers.ParamGroup(map[string]any{"k": "maybe"}, helpers.OptionalParam(&bp, "k"))
+		if err == nil {
+			t.Fatalf("expected error for non-boolean string to *bool, got nil")
+		}
+	})
+}

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -298,11 +299,171 @@ func withInputValidation(tool *mcp.Tool, handler mcp.ToolHandler) mcp.ToolHandle
 				return newInputValidationError("invalid arguments JSON: %s", err.Error()), nil
 			}
 		}
+		// Repair arguments from clients that serialize scalars as strings before
+		// validating (see coerceStringScalars). When anything changes, re-marshal
+		// so the handler receives the coerced values too.
+		if coerceStringScalars(schema, args) {
+			raw, err := json.Marshal(args)
+			if err != nil {
+				return newInputValidationError("invalid arguments: %s", err.Error()), nil
+			}
+			req.Params.Arguments = raw
+		}
 		if err := resolved.Validate(args); err != nil {
 			return newInputValidationError("invalid arguments: %s", err.Error()), nil
 		}
 		return handler(ctx, req)
 	}
+}
+
+// coerceStringScalars repairs arguments from MCP clients that serialize scalar
+// values as strings (e.g. "911218" instead of 911218, "false" instead of false)
+// before they are validated against the tool's InputSchema. Some clients coerce
+// arguments to the declared JSON type but do not look inside anyOf/oneOf
+// branches, so nullable/optional parameters — which we express as
+// anyOf: [{type: <scalar>}, {type: "null"}] to satisfy OpenAI strict mode —
+// arrive as strings and fail validation before the handler ever runs (issue
+// #383). Coercion is schema-directed and conservative: a string is converted
+// only when the schema accepts the target scalar type but not string, so
+// genuine string parameters (e.g. search_term) are left untouched. It returns
+// true if any value was changed. The value map is mutated in place.
+func coerceStringScalars(schema *jsonschema.Schema, value any) bool {
+	if schema == nil {
+		return false
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		obj := objectBranch(schema)
+		if obj == nil {
+			return false
+		}
+		var changed bool
+		for key, sub := range v {
+			propSchema, ok := obj.Properties[key]
+			if !ok {
+				continue
+			}
+			if s, isStr := sub.(string); isStr {
+				if coerced, did := coerceScalarString(propSchema, s); did {
+					v[key] = coerced
+					changed = true
+					continue
+				}
+			}
+			if coerceStringScalars(propSchema, sub) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		items := arrayItems(schema)
+		if items == nil {
+			return false
+		}
+		var changed bool
+		for i, sub := range v {
+			if s, isStr := sub.(string); isStr {
+				if coerced, did := coerceScalarString(items, s); did {
+					v[i] = coerced
+					changed = true
+					continue
+				}
+			}
+			if coerceStringScalars(items, sub) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
+}
+
+// coerceScalarString converts a string to the scalar type declared by schema,
+// returning the converted value and true when a conversion was applied. It
+// leaves the string unchanged (returning false) when the schema accepts string,
+// declares no compatible scalar type, or the string does not parse as the
+// target type — in which case validation surfaces the appropriate error.
+func coerceScalarString(schema *jsonschema.Schema, s string) (any, bool) {
+	types := make(map[string]bool)
+	collectTypes(schema, types)
+	if types["string"] {
+		return s, false
+	}
+	switch {
+	case types["integer"] || types["number"]:
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f, true
+		}
+	case types["boolean"]:
+		if b, err := strconv.ParseBool(s); err == nil {
+			return b, true
+		}
+	}
+	return s, false
+}
+
+// collectTypes gathers the set of JSON types accepted by schema, descending
+// into anyOf/oneOf/allOf branches (the shape used for nullable parameters).
+func collectTypes(schema *jsonschema.Schema, out map[string]bool) {
+	if schema == nil {
+		return
+	}
+	if schema.Type != "" {
+		out[schema.Type] = true
+	}
+	for _, t := range schema.Types {
+		out[t] = true
+	}
+	for _, branch := range schema.AnyOf {
+		collectTypes(branch, out)
+	}
+	for _, branch := range schema.OneOf {
+		collectTypes(branch, out)
+	}
+	for _, branch := range schema.AllOf {
+		collectTypes(branch, out)
+	}
+}
+
+// objectBranch returns the object sub-schema of schema (schema itself when it is
+// an object, otherwise the first object branch of an anyOf/oneOf/allOf), or nil
+// when schema describes no object.
+func objectBranch(schema *jsonschema.Schema) *jsonschema.Schema {
+	if schema == nil {
+		return nil
+	}
+	if len(schema.Properties) > 0 {
+		return schema
+	}
+	for _, branches := range [][]*jsonschema.Schema{schema.AnyOf, schema.OneOf, schema.AllOf} {
+		for _, branch := range branches {
+			if obj := objectBranch(branch); obj != nil {
+				return obj
+			}
+		}
+	}
+	return nil
+}
+
+// arrayItems returns the item schema for the array described by schema (schema
+// itself when it is an array, otherwise the first array branch of an
+// anyOf/oneOf/allOf), or nil when schema describes no array.
+func arrayItems(schema *jsonschema.Schema) *jsonschema.Schema {
+	if schema == nil {
+		return nil
+	}
+	if schema.Items != nil {
+		return schema.Items
+	}
+	for _, branches := range [][]*jsonschema.Schema{schema.AnyOf, schema.OneOf, schema.AllOf} {
+		for _, branch := range branches {
+			if items := arrayItems(branch); items != nil {
+				return items
+			}
+		}
+	}
+	return nil
 }
 
 func newInputValidationError(format string, args ...any) *mcp.CallToolResult {

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -1,0 +1,178 @@
+package toolsets
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// nullableInteger mirrors the anyOf: [{integer}, {null}] shape used across the
+// tool schemas for optional numeric parameters.
+func nullableInteger() *jsonschema.Schema {
+	return &jsonschema.Schema{AnyOf: []*jsonschema.Schema{{Type: "integer"}, {Type: "null"}}}
+}
+
+func nullableBoolean() *jsonschema.Schema {
+	return &jsonschema.Schema{AnyOf: []*jsonschema.Schema{{Type: "boolean"}, {Type: "null"}}}
+}
+
+func nullableString() *jsonschema.Schema {
+	return &jsonschema.Schema{AnyOf: []*jsonschema.Schema{{Type: "string"}, {Type: "null"}}}
+}
+
+func TestCoerceStringScalars(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"project_id":  nullableInteger(),
+			"page":        nullableInteger(),
+			"verbose":     nullableBoolean(),
+			"search_term": nullableString(),
+			"tag_ids": {
+				AnyOf: []*jsonschema.Schema{
+					{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+					{Type: "null"},
+				},
+			},
+			"groups": {
+				AnyOf: []*jsonschema.Schema{
+					{
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"user_ids": {Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+						},
+					},
+					{Type: "null"},
+				},
+			},
+		},
+	}
+
+	args := map[string]any{
+		"project_id":  "911218",
+		"page":        "2",
+		"verbose":     "false",
+		"search_term": "911218",        // must stay a string
+		"tag_ids":     []any{"1", "2"}, // stringified array elements
+		"groups":      map[string]any{"user_ids": []any{"7"}},
+	}
+
+	if !coerceStringScalars(schema, args) {
+		t.Fatalf("expected coerceStringScalars to report a change")
+	}
+
+	if got := args["project_id"]; got != float64(911218) {
+		t.Errorf("project_id = %#v, want float64(911218)", got)
+	}
+	if got := args["page"]; got != float64(2) {
+		t.Errorf("page = %#v, want float64(2)", got)
+	}
+	if got := args["verbose"]; got != false {
+		t.Errorf("verbose = %#v, want false", got)
+	}
+	if got := args["search_term"]; got != "911218" {
+		t.Errorf("search_term = %#v, want untouched string \"911218\"", got)
+	}
+	tagIDs, ok := args["tag_ids"].([]any)
+	if !ok || len(tagIDs) != 2 || tagIDs[0] != float64(1) || tagIDs[1] != float64(2) {
+		t.Errorf("tag_ids = %#v, want [1 2] as numbers", args["tag_ids"])
+	}
+	groups, ok := args["groups"].(map[string]any)
+	if !ok {
+		t.Fatalf("groups = %#v, want map", args["groups"])
+	}
+	userIDs, ok := groups["user_ids"].([]any)
+	if !ok || len(userIDs) != 1 || userIDs[0] != float64(7) {
+		t.Errorf("groups.user_ids = %#v, want [7] as number", groups["user_ids"])
+	}
+}
+
+func TestCoerceStringScalarsNoChange(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"project_id":  nullableInteger(),
+			"search_term": nullableString(),
+		},
+	}
+	// Well-behaved client: native types already correct.
+	args := map[string]any{"project_id": float64(911218), "search_term": "Inbox"}
+	if coerceStringScalars(schema, args) {
+		t.Errorf("expected no change for already-typed arguments")
+	}
+}
+
+// TestWithInputValidationCoercesStringifiedScalars is the regression test for
+// issue #383: a client that sends project_id as the string "911218" against an
+// anyOf: [{integer}, {null}] schema must pass validation, and the handler must
+// receive it as a number.
+func TestWithInputValidationCoercesStringifiedScalars(t *testing.T) {
+	tool := &mcp.Tool{
+		Name: "twprojects-list_tasklists",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"project_id": nullableInteger(),
+				"verbose":    nullableBoolean(),
+			},
+		},
+	}
+
+	var received map[string]any
+	handler := func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		received = map[string]any{}
+		if err := json.Unmarshal(req.Params.Arguments, &received); err != nil {
+			t.Fatalf("handler could not decode arguments: %v", err)
+		}
+		return &mcp.CallToolResult{}, nil
+	}
+
+	wrapped := withInputValidation(tool, handler)
+
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Arguments: json.RawMessage(`{"project_id":"911218","verbose":"false"}`),
+	}}
+	res, err := wrapped(context.Background(), req)
+	if err != nil {
+		t.Fatalf("wrapped handler returned error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected validation to pass, got error result: %+v", res.Content)
+	}
+	if received["project_id"] != float64(911218) {
+		t.Errorf("handler received project_id = %#v, want float64(911218)", received["project_id"])
+	}
+	if received["verbose"] != false {
+		t.Errorf("handler received verbose = %#v, want false", received["verbose"])
+	}
+}
+
+// TestWithInputValidationRejectsInvalidInput ensures the coercion does not
+// swallow genuinely invalid input: a non-numeric string for an integer field
+// still fails validation.
+func TestWithInputValidationRejectsInvalidInput(t *testing.T) {
+	tool := &mcp.Tool{
+		Name: "twprojects-list_tasklists",
+		InputSchema: &jsonschema.Schema{
+			Type:       "object",
+			Properties: map[string]*jsonschema.Schema{"project_id": nullableInteger()},
+		},
+	}
+	wrapped := withInputValidation(tool, func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		t.Fatalf("handler must not be called for invalid input")
+		return nil, nil
+	})
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Arguments: json.RawMessage(`{"project_id":"not-a-number"}`),
+	}}
+	res, err := wrapped(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected validation error for non-numeric string")
+	}
+}


### PR DESCRIPTION
## Description

Some MCP clients (e.g. the Claude/Cowork tool-calling layer) do schema-aware argument coercion that reads a property's declared `type` but does not look inside `anyOf`/`oneOf` branches. Because optional parameters are expressed as `anyOf: [{type: <scalar>}, {type: "null"}]` to satisfy OpenAI strict mode, such clients serialize them as strings ("911218", "false") instead of native JSON scalars. The server's withInputValidation gate then rejects them ("invalid arguments: ... has type string, want integer") before the handler runs, breaking project_id filtering, pagination, and verbose across list_* and search tools. Plain required scalars (e.g. get_project's id) were unaffected, which is why it only surfaced on nullable params. Fixes #383.

Fixed in two layers:

- withInputValidation now repairs arguments at the boundary: it walks the incoming values alongside the tool's InputSchema and converts a string only when the schema accepts the target scalar but not string, so genuine string params (search_term) are left untouched. It recurses into objects and array elements, re-marshals when anything changes, and rewrites the request so the handler receives coerced types. Published schemas are unchanged, keeping the strict-mode design intact.

- helpers.param no longer panics on string input. Its string fallback keyed off the source value's kind and called reflect.Convert to the target, which panics for illegal pairs (string -> bool). It now keys off the target type via a recursive coerceStringValue helper that handles string, bool, and pointers to either, returning a clean type error for unsupported kinds or unparseable strings.

Adds regression tests in both packages.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors