### PR TITLE
Enhancement: Add unassigned and unplanned filters to the list tasks tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.19.5
+	github.com/teamwork/twapi-go-sdk v1.20.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.19.5 h1:Q0Q/ir8ed2ZmxygbOqbvyszna2QQuaLavepF1BgF7Vk=
-github.com/teamwork/twapi-go-sdk v1.19.5/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
+github.com/teamwork/twapi-go-sdk v1.20.1 h1:rnRoumR3F1FfckHyeMv4/zDzqYm1w9QbfR/6GrIov+A=
+github.com/teamwork/twapi-go-sdk v1.20.1/go.mod h1:Z0R6uOeso0BH1tKdHVbT5TOqVGPMwPLuTPsHSyl4G/8=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -755,6 +755,21 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"only_unassigned": {
+						Description: "If true, only return tasks that have no assignee.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
+					},
+					"only_unplanned": {
+						Description: "If true, only return tasks that are unplanned, meaning they are missing an " +
+							"assignee, a due date, or estimated time.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
+					},
 					"page":      helpers.PageSchema(),
 					"page_size": helpers.PageSizeSchema(),
 					"verbose":   helpers.VerboseSchema(),
@@ -789,6 +804,8 @@ func TaskList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalTimePointerParam(&taskListRequest.Filters.CompletedBefore, "completed_before"),
 				helpers.OptionalDatePointerParam(&taskListRequest.Filters.DueAfter, "due_after"),
 				helpers.OptionalDatePointerParam(&taskListRequest.Filters.DueBefore, "due_before"),
+				helpers.OptionalPointerParam(&taskListRequest.Filters.OnlyUnassigned, "only_unassigned"),
+				helpers.OptionalPointerParam(&taskListRequest.Filters.OnlyUnplanned, "only_unplanned"),
 				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {

--- a/internal/twprojects/tasks_test.go
+++ b/internal/twprojects/tasks_test.go
@@ -189,6 +189,8 @@ func TestTaskList(t *testing.T) {
 		"completed_before":    "2023-10-31T23:59:59Z",
 		"due_after":           "2023-10-01",
 		"due_before":          "2023-10-31",
+		"only_unassigned":     true,
+		"only_unplanned":      true,
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})
@@ -211,6 +213,8 @@ func TestTaskListByTasklist(t *testing.T) {
 		"completed_before":    "2023-10-31T23:59:59Z",
 		"due_after":           "2023-10-01",
 		"due_before":          "2023-10-31",
+		"only_unassigned":     true,
+		"only_unplanned":      true,
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})
@@ -233,6 +237,8 @@ func TestTaskListByProject(t *testing.T) {
 		"completed_before":    "2023-10-31T23:59:59Z",
 		"due_after":           "2023-10-01",
 		"due_before":          "2023-10-31",
+		"only_unassigned":     true,
+		"only_unplanned":      true,
 		"page":                float64(1),
 		"page_size":           float64(10),
 	})


### PR DESCRIPTION
## Description
Adds two filters to the `twprojects-list_tasks` tool:

- `only_unassigned` — returns only tasks with no assignee.
- `only_unplanned` — returns only tasks missing an assignee, a due date, or estimated time.

Both are backed by the `OnlyUnassigned` / `OnlyUnplanned` request filters introduced in `twapi-go-sdk` v1.20.1, so the SDK is bumped from v1.19.5 to v1.20.1 as part of this change. They follow the existing optional-filter pattern in `TaskList` (`AnyOf: [boolean, null]` schema, bound via `helpers.OptionalPointerParam`, the same as `match_all_tags`).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Added both params to the three existing `list_tasks` filter tests (`TestTaskList`, `TestTaskListByTasklist`, `TestTaskListByProject`), which enumerate every filter to smoke-test parameter binding.

- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)