### PR TITLE
Fix: Coerce stringified array/object arguments before schema validation

### DIFF
--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -299,10 +299,10 @@ func withInputValidation(tool *mcp.Tool, handler mcp.ToolHandler) mcp.ToolHandle
 				return newInputValidationError("invalid arguments JSON: %s", err.Error()), nil
 			}
 		}
-		// Repair arguments from clients that serialize scalars as strings before
-		// validating (see coerceStringScalars). When anything changes, re-marshal
+		// Repair arguments from clients that serialize values as strings before
+		// validating (see coerceStringValues). When anything changes, re-marshal
 		// so the handler receives the coerced values too.
-		if coerceStringScalars(schema, args) {
+		if coerceStringValues(schema, args) {
 			raw, err := json.Marshal(args)
 			if err != nil {
 				return newInputValidationError("invalid arguments: %s", err.Error()), nil
@@ -316,18 +316,20 @@ func withInputValidation(tool *mcp.Tool, handler mcp.ToolHandler) mcp.ToolHandle
 	}
 }
 
-// coerceStringScalars repairs arguments from MCP clients that serialize scalar
-// values as strings (e.g. "911218" instead of 911218, "false" instead of false)
-// before they are validated against the tool's InputSchema. Some clients coerce
+// coerceStringValues repairs arguments from MCP clients that serialize values
+// as strings (e.g. "911218" instead of 911218, "false" instead of false, or
+// "[1,2,3]" / "{\"user_ids\":[1]}" instead of a native array/object) before
+// they are validated against the tool's InputSchema. Some clients coerce
 // arguments to the declared JSON type but do not look inside anyOf/oneOf
 // branches, so nullable/optional parameters — which we express as
-// anyOf: [{type: <scalar>}, {type: "null"}] to satisfy OpenAI strict mode —
-// arrive as strings and fail validation before the handler ever runs (issue
-// #383). Coercion is schema-directed and conservative: a string is converted
-// only when the schema accepts the target scalar type but not string, so
-// genuine string parameters (e.g. search_term) are left untouched. It returns
-// true if any value was changed. The value map is mutated in place.
-func coerceStringScalars(schema *jsonschema.Schema, value any) bool {
+// anyOf: [{type: <type>}, {type: "null"}] to satisfy OpenAI strict mode —
+// arrive as strings and fail validation before the handler ever runs (issues
+// #383 for scalars, #402 for arrays/objects). Coercion is schema-directed and
+// conservative: a string is converted only when the schema accepts the target
+// type but not string, so genuine string parameters (e.g. search_term) are left
+// untouched. It returns true if any value was changed. The value map is mutated
+// in place.
+func coerceStringValues(schema *jsonschema.Schema, value any) bool {
 	if schema == nil {
 		return false
 	}
@@ -344,13 +346,15 @@ func coerceStringScalars(schema *jsonschema.Schema, value any) bool {
 				continue
 			}
 			if s, isStr := sub.(string); isStr {
-				if coerced, did := coerceScalarString(propSchema, s); did {
+				if coerced, did := coerceStringValue(propSchema, s); did {
 					v[key] = coerced
 					changed = true
+					// Recurse into a decoded array/object to repair nested values.
+					coerceStringValues(propSchema, coerced)
 					continue
 				}
 			}
-			if coerceStringScalars(propSchema, sub) {
+			if coerceStringValues(propSchema, sub) {
 				changed = true
 			}
 		}
@@ -363,13 +367,14 @@ func coerceStringScalars(schema *jsonschema.Schema, value any) bool {
 		var changed bool
 		for i, sub := range v {
 			if s, isStr := sub.(string); isStr {
-				if coerced, did := coerceScalarString(items, s); did {
+				if coerced, did := coerceStringValue(items, s); did {
 					v[i] = coerced
 					changed = true
+					coerceStringValues(items, coerced)
 					continue
 				}
 			}
-			if coerceStringScalars(items, sub) {
+			if coerceStringValues(items, sub) {
 				changed = true
 			}
 		}
@@ -379,12 +384,13 @@ func coerceStringScalars(schema *jsonschema.Schema, value any) bool {
 	}
 }
 
-// coerceScalarString converts a string to the scalar type declared by schema,
-// returning the converted value and true when a conversion was applied. It
+// coerceStringValue converts a string to the type declared by schema, returning
+// the converted value and true when a conversion was applied. Scalars are
+// parsed (integer/number/boolean); arrays and objects are JSON-decoded. It
 // leaves the string unchanged (returning false) when the schema accepts string,
-// declares no compatible scalar type, or the string does not parse as the
-// target type — in which case validation surfaces the appropriate error.
-func coerceScalarString(schema *jsonschema.Schema, s string) (any, bool) {
+// declares no compatible type, or the string does not parse as the target type
+// — in which case validation surfaces the appropriate error.
+func coerceStringValue(schema *jsonschema.Schema, s string) (any, bool) {
 	types := make(map[string]bool)
 	collectTypes(schema, types)
 	if types["string"] {
@@ -398,6 +404,20 @@ func coerceScalarString(schema *jsonschema.Schema, s string) (any, bool) {
 	case types["boolean"]:
 		if b, err := strconv.ParseBool(s); err == nil {
 			return b, true
+		}
+	case types["array"] || types["object"]:
+		var decoded any
+		if err := json.Unmarshal([]byte(s), &decoded); err == nil {
+			switch decoded.(type) {
+			case []any:
+				if types["array"] {
+					return decoded, true
+				}
+			case map[string]any:
+				if types["object"] {
+					return decoded, true
+				}
+			}
 		}
 	}
 	return s, false

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -23,7 +23,7 @@ func nullableString() *jsonschema.Schema {
 	return &jsonschema.Schema{AnyOf: []*jsonschema.Schema{{Type: "string"}, {Type: "null"}}}
 }
 
-func TestCoerceStringScalars(t *testing.T) {
+func TestCoerceStringValues(t *testing.T) {
 	schema := &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
@@ -60,8 +60,8 @@ func TestCoerceStringScalars(t *testing.T) {
 		"groups":      map[string]any{"user_ids": []any{"7"}},
 	}
 
-	if !coerceStringScalars(schema, args) {
-		t.Fatalf("expected coerceStringScalars to report a change")
+	if !coerceStringValues(schema, args) {
+		t.Fatalf("expected coerceStringValues to report a change")
 	}
 
 	if got := args["project_id"]; got != float64(911218) {
@@ -90,7 +90,7 @@ func TestCoerceStringScalars(t *testing.T) {
 	}
 }
 
-func TestCoerceStringScalarsNoChange(t *testing.T) {
+func TestCoerceStringValuesNoChange(t *testing.T) {
 	schema := &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
@@ -100,8 +100,58 @@ func TestCoerceStringScalarsNoChange(t *testing.T) {
 	}
 	// Well-behaved client: native types already correct.
 	args := map[string]any{"project_id": float64(911218), "search_term": "Inbox"}
-	if coerceStringScalars(schema, args) {
+	if coerceStringValues(schema, args) {
 		t.Errorf("expected no change for already-typed arguments")
+	}
+}
+
+// TestCoerceStringValuesComplex is the regression test for issue #402: a client
+// that JSON-encodes a whole array or object parameter as a string (against an
+// anyOf: [{array|object}, {null}] schema) must have it decoded to the native
+// type so validation passes and the handler receives the real value.
+func TestCoerceStringValuesComplex(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"tag_ids": {
+				AnyOf: []*jsonschema.Schema{
+					{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+					{Type: "null"},
+				},
+			},
+			"assignees": {
+				AnyOf: []*jsonschema.Schema{
+					{
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"user_ids": {Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+						},
+					},
+					{Type: "null"},
+				},
+			},
+		},
+	}
+
+	args := map[string]any{
+		"tag_ids":   `[1,2,3]`,              // whole array stringified
+		"assignees": `{"user_ids":[1,2,3]}`, // whole object stringified
+	}
+
+	if !coerceStringValues(schema, args) {
+		t.Fatalf("expected coerceStringValues to report a change")
+	}
+
+	tagIDs, ok := args["tag_ids"].([]any)
+	if !ok || len(tagIDs) != 3 || tagIDs[0] != float64(1) {
+		t.Errorf("tag_ids = %#v, want [1 2 3] as numbers", args["tag_ids"])
+	}
+	assignees, ok := args["assignees"].(map[string]any)
+	if !ok {
+		t.Fatalf("assignees = %#v, want map", args["assignees"])
+	}
+	if userIDs, ok := assignees["user_ids"].([]any); !ok || len(userIDs) != 3 {
+		t.Errorf("assignees.user_ids = %#v, want [1 2 3]", assignees["user_ids"])
 	}
 }
 


### PR DESCRIPTION
## Description

Some MCP clients JSON-encode complex arguments as strings — sending `"[1,2,3]"` or `"{\"user_ids\":[1]}"` instead of a native array/object — so optional parameters expressed as `anyOf: [{array|object}, {null}]` arrived as strings and failed validation with `has type "string"` before the handler ran. This blocked setting `assignees` or `tag_ids` on `create_task` / `update_task` (issue #402).

Extend the existing string-coercion shim (which already handled scalars for #383) to also JSON-decode array and object parameters. Coercion stays schema-directed and conservative: a string is decoded only when the schema accepts array/object but not string, so genuine string parameters are untouched, and decoded containers are recursed into to repair nested values. Rename coerceStringScalars/coerceScalarString to coerceStringValues/coerceStringValue to reflect the broader scope.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors