### PR TITLE
Fix Desk/Chat tool annotations and modernize helpers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.11
 
   test:
     runs-on: ubuntu-latest

--- a/cmd/docs-gen/main.go
+++ b/cmd/docs-gen/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -170,7 +171,7 @@ func sortedMethods(g *toolsets.ToolsetGroup) []toolsets.Method {
 	for m := range g.Toolsets {
 		methods = append(methods, m)
 	}
-	sort.Slice(methods, func(i, j int) bool { return methods[i] < methods[j] })
+	slices.Sort(methods)
 	return methods
 }
 
@@ -235,8 +236,8 @@ func writeToolset(b *strings.Builder, ts *toolsets.Toolset) {
 // stripPrefix removes the "tw<product>-" namespace prefix from a tool or method
 // name, returning the action/toolset slug.
 func stripPrefix(name string) string {
-	if i := strings.IndexByte(name, '-'); i >= 0 {
-		return name[i+1:]
+	if _, after, ok := strings.Cut(name, "-"); ok {
+		return after
 	}
 	return name
 }

--- a/internal/twchat/chat.go
+++ b/internal/twchat/chat.go
@@ -371,8 +371,7 @@ func DMGetOrCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 		Tool: &mcp.Tool{
 			Name: string(MethodDMGetOrCreate),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        "Get or Create Direct Message",
-				ReadOnlyHint: true,
+				Title: "Get or Create Direct Message",
 			},
 			Description: "Get the 1:1 direct-message conversation with a person, creating it if it does not " +
 				"exist yet. Returns the conversation (use its id with send_message). Use list_people to find user_id.",

--- a/internal/twchat/tools.go
+++ b/internal/twchat/tools.go
@@ -43,7 +43,9 @@ func init() {
 }
 
 // DefaultToolsetGroup creates a default ToolsetGroup for Teamwork Chat. Write
-// tools (send_message) are skipped automatically when readOnly is true.
+// tools (send_message, send_dm, get_or_create_dm) are skipped automatically when
+// readOnly is true. get_or_create_dm is a write tool because it creates the 1:1
+// conversation when one does not already exist.
 func DefaultToolsetGroup(readOnly bool, engine *twapi.Engine) *toolsets.ToolsetGroup {
 	group := toolsets.NewToolsetGroup(readOnly)
 
@@ -51,6 +53,7 @@ func DefaultToolsetGroup(readOnly bool, engine *twapi.Engine) *toolsets.ToolsetG
 		AddWriteTools(
 			MessageSend(engine),
 			SendDM(engine),
+			DMGetOrCreate(engine),
 		).
 		AddReadTools(
 			CurrentUserGet(engine),
@@ -58,7 +61,6 @@ func DefaultToolsetGroup(readOnly bool, engine *twapi.Engine) *toolsets.ToolsetG
 			ConversationGet(engine),
 			MessageList(engine),
 			PeopleList(engine),
-			DMGetOrCreate(engine),
 		))
 
 	return group

--- a/internal/twdesk/customers.go
+++ b/internal/twdesk/customers.go
@@ -280,7 +280,7 @@ func CustomerCreate(httpClient *http.Client) toolsets.ToolWrapper {
 					Phone:         strPtr(arguments.GetString("phone", "")),
 					Mobile:        strPtr(arguments.GetString("mobile", "")),
 					Address:       strPtr(arguments.GetString("address", "")),
-					Trusted:       boolPtr(trusted),
+					Trusted:       new(trusted),
 				},
 			})
 			if err != nil {
@@ -429,7 +429,7 @@ func CustomerUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 					Phone:         strPtr(arguments.GetString("phone", "")),
 					Mobile:        strPtr(arguments.GetString("mobile", "")),
 					Address:       strPtr(arguments.GetString("address", "")),
-					Trusted:       boolPtr(trusted),
+					Trusted:       new(trusted),
 				},
 			})
 			if err != nil {

--- a/internal/twdesk/helpdocs.go
+++ b/internal/twdesk/helpdocs.go
@@ -154,6 +154,9 @@ func HelpDocArticleCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Name: string(MethodHelpDocArticleCreate),
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Help Doc Article",
+				// A published, non-private article is visible on the public knowledge
+				// base, so this can change publicly-visible internet state.
+				OpenWorldHint: new(true),
 			},
 			Description: "Create a new help doc article.",
 			InputSchema: &jsonschema.Schema{
@@ -248,6 +251,9 @@ func HelpDocArticleUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 			Name: string(MethodHelpDocArticleUpdate),
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Update Help Doc Article",
+				// Changing status to published or toggling isPrivate alters
+				// publicly-visible knowledge-base content.
+				OpenWorldHint: new(true),
 			},
 			Description: "Update an existing help doc article.",
 			InputSchema: &jsonschema.Schema{

--- a/internal/twdesk/messages.go
+++ b/internal/twdesk/messages.go
@@ -27,6 +27,11 @@ func MessageCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Name: string(MethodMessageCreate),
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Reply to Ticket",
+				// A customer-facing reply (threadType=message, the default) emails the
+				// external customer and cannot be unsent, so it both reaches an open
+				// world of external recipients and is irreversible.
+				DestructiveHint: new(true),
+				OpenWorldHint:   new(true),
 			},
 			Description: "Reply to a ticket. Use threadType=note for internal agent notes.",
 			InputSchema: &jsonschema.Schema{

--- a/internal/twdesk/meta.go
+++ b/internal/twdesk/meta.go
@@ -25,11 +25,6 @@ func intPtr(i int) *int {
 	return &i
 }
 
-// boolPtr returns a pointer to b.
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 // falseSchema returns a schema that serialises to JSON boolean false.
 // Used as AdditionalProperties: falseSchema() to satisfy OpenAI strict mode.
 func falseSchema() *jsonschema.Schema {

--- a/internal/twdesk/schema_validation_test.go
+++ b/internal/twdesk/schema_validation_test.go
@@ -3,6 +3,7 @@ package twdesk_test
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -84,12 +85,7 @@ func isArrayType(s *jsonschema.Schema) bool {
 	if s.Type == "array" {
 		return true
 	}
-	for _, t := range s.Types {
-		if t == "array" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Types, "array")
 }
 
 // TestToolInputSchemasOpenAIStrictMode verifies that all twdesk tools satisfy

--- a/internal/twdesk/tickets.go
+++ b/internal/twdesk/tickets.go
@@ -211,6 +211,11 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			Name: string(MethodTicketCreate),
 			Annotations: &mcp.ToolAnnotations{
 				Title: "Create Ticket",
+				// A ticket created with notifyCustomer (or cc/bcc) emails the external
+				// customer a copy that cannot be unsent, so it can reach an open world
+				// of external recipients and is irreversible.
+				DestructiveHint: new(true),
+				OpenWorldHint:   new(true),
 			},
 			Description: "Create ticket.",
 			InputSchema: &jsonschema.Schema{
@@ -396,7 +401,7 @@ func TicketCreate(httpClient *http.Client) toolsets.ToolWrapper {
 			}
 
 			if arguments.GetBool("notifyCustomer", false) {
-				data.NotifyCustomer = boolPtr(true)
+				data.NotifyCustomer = new(true)
 			}
 
 			if len(arguments.GetIntSlice("files", []int{})) > 0 {

--- a/internal/twdesk/types.go
+++ b/internal/twdesk/types.go
@@ -179,7 +179,7 @@ func TypeCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				TicketType: deskmodels.TicketType{
 					Name:                    &name,
 					DisplayOrder:            intPtr(arguments.GetInt("displayOrder", 0)),
-					EnabledForFutureInboxes: boolPtr(enabledForFutureInboxes),
+					EnabledForFutureInboxes: new(enabledForFutureInboxes),
 				},
 			})
 			if err != nil {
@@ -244,7 +244,7 @@ func TypeUpdate(httpClient *http.Client) toolsets.ToolWrapper {
 				TicketType: deskmodels.TicketType{
 					Name:                    strPtr(arguments.GetString("name", "")),
 					DisplayOrder:            intPtr(arguments.GetInt("displayOrder", 0)),
-					EnabledForFutureInboxes: boolPtr(enabledForFutureInboxes),
+					EnabledForFutureInboxes: new(enabledForFutureInboxes),
 				},
 			})
 			if err != nil {

--- a/internal/twprojects/custom_field_values.go
+++ b/internal/twprojects/custom_field_values.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -633,10 +634,8 @@ func containsNumber(raw any) bool {
 	case float64, float32, int, int32, int64, json.Number:
 		return true
 	case []any:
-		for _, e := range v {
-			if containsNumber(e) {
-				return true
-			}
+		if slices.ContainsFunc(v, containsNumber) {
+			return true
 		}
 	}
 	return false

--- a/internal/twprojects/tools_test.go
+++ b/internal/twprojects/tools_test.go
@@ -2,6 +2,7 @@ package twprojects_test
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -76,10 +77,5 @@ func isArrayType(s *jsonschema.Schema) bool {
 	if s.Type == "array" {
 		return true
 	}
-	for _, t := range s.Types {
-		if t == "array" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Types, "array")
 }


### PR DESCRIPTION
## Description

- `twchat-get_or_create_dm`: drop incorrect `ReadOnlyHint` and move to write tools (it creates the DM when missing).
- `twdesk reply_ticket/create_ticket`: mark `Destructive` + `OpenWorld` (can email external customers); `helpdoc create/update`: `OpenWorld` (can publish to the public knowledge base).
- Replace `boolPtr` with the Go 1.26 `new(x)` builtin and use slices/strings helpers in place of hand-rolled loops.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors