### PR TITLE
Fix: MCP Apps metadata and handshake on the timelog app

### DIFF
--- a/internal/twprojects/apps/timelog_create.html
+++ b/internal/twprojects/apps/timelog_create.html
@@ -816,9 +816,18 @@
         }
       });
 
+      // Spec requires appCapabilities, listing every display mode we support;
+      // this form is only laid out for inline.
+      var appInfo = { name: "twprojects-create_timelog", version: "1.0.0" };
+      var appCapabilities = { availableDisplayModes: ["inline"] };
+
       async function initialize() {
         var initResult = await request("ui/initialize", {
           protocolVersion: "2026-01-26",
+          appInfo: appInfo,
+          appCapabilities: appCapabilities,
+          // the spec's own example uses these older names instead.
+          clientInfo: appInfo,
           capabilities: {}
         }, 5000);
 

--- a/internal/twprojects/timelog_app.go
+++ b/internal/twprojects/timelog_app.go
@@ -15,6 +15,7 @@ const (
 	timelogCreateAppDescription   = "Interactive form for creating Teamwork timelogs."
 )
 
+// Standard _meta.ui.csp surface. Empty: the app is self-contained.
 var timelogCreateWidgetCSP = map[string]any{
 	"connectDomains":  []string{},
 	"resourceDomains": []string{},
@@ -22,22 +23,23 @@ var timelogCreateWidgetCSP = map[string]any{
 	"baseUriDomains":  []string{},
 }
 
-var timelogCreateWidgetPermissions = map[string]any{
-	"camera":         map[string]any{},
-	"microphone":     map[string]any{},
-	"geolocation":    map[string]any{},
-	"clipboardWrite": map[string]any{},
+// Same lists for ChatGPT's legacy openai/widgetCSP key, which only recognises
+// snake_case names. camelCase here fails OpenAI's tool scan.
+var timelogCreateOpenAIWidgetCSP = map[string]any{
+	"connect_domains":  []string{},
+	"resource_domains": []string{},
+	"frame_domains":    []string{},
+	"redirect_domains": []string{},
 }
 
 var timelogCreateResourceMeta = mcp.Meta{
 	"ui": map[string]any{
 		"csp":           timelogCreateWidgetCSP,
-		"permissions":   timelogCreateWidgetPermissions,
 		"prefersBorder": true,
 	},
 	"openai/widgetDescription":   timelogCreateAppDescription,
 	"openai/widgetPrefersBorder": true,
-	"openai/widgetCSP":           timelogCreateWidgetCSP,
+	"openai/widgetCSP":           timelogCreateOpenAIWidgetCSP,
 }
 
 //go:embed apps/timelog_create.html

--- a/internal/twprojects/timelog_app_test.go
+++ b/internal/twprojects/timelog_app_test.go
@@ -100,6 +100,12 @@ func TestTimelogCreateResourceRead(t *testing.T) {
 	if !strings.Contains(content.Text, "Create Timelog") {
 		t.Fatalf("expected embedded HTML to contain heading, got: %q", content.Text)
 	}
+	// no JS harness, so guard the required ui/initialize fields at source level.
+	for _, fragment := range []string{"appInfo:", "appCapabilities:", `availableDisplayModes: ["inline"]`} {
+		if !strings.Contains(content.Text, fragment) {
+			t.Errorf("expected embedded HTML ui/initialize handshake to declare %s", fragment)
+		}
+	}
 
 	uiMetaRaw, ok := content.Meta["ui"]
 	if !ok {
@@ -109,13 +115,27 @@ func TestTimelogCreateResourceRead(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected _meta.ui to be map[string]any, got %T", uiMetaRaw)
 	}
-	if _, ok := uiMeta["csp"].(map[string]any); !ok {
+	csp, ok := uiMeta["csp"].(map[string]any)
+	if !ok {
 		t.Fatalf("expected _meta.ui.csp to be map[string]any, got %T", uiMeta["csp"])
+	}
+	// the standard MCP Apps surface uses camelCase field names.
+	for _, field := range []string{"connectDomains", "resourceDomains", "frameDomains", "baseUriDomains"} {
+		if _, ok := csp[field]; !ok {
+			t.Errorf("expected _meta.ui.csp to declare %q, got %#v", field, csp)
+		}
 	}
 	if _, ok := content.Meta["openai/widgetDescription"].(string); !ok {
 		t.Fatalf("expected _meta.openai/widgetDescription to be present, got %#v", content.Meta["openai/widgetDescription"])
 	}
-	if _, ok := content.Meta["openai/widgetCSP"].(map[string]any); !ok {
+	openAICSP, ok := content.Meta["openai/widgetCSP"].(map[string]any)
+	if !ok {
 		t.Fatalf("expected _meta.openai/widgetCSP to be map[string]any, got %T", content.Meta["openai/widgetCSP"])
+	}
+	// the legacy ChatGPT key only recognises snake_case names.
+	for _, field := range []string{"connect_domains", "resource_domains", "frame_domains", "redirect_domains"} {
+		if _, ok := openAICSP[field]; !ok {
+			t.Errorf("expected _meta.openai/widgetCSP to declare %q, got %#v", field, openAICSP)
+		}
 	}
 }


### PR DESCRIPTION
## Description

- `openai/widgetCSP` needs snake_case field names (`connect_domains`, etc); reusing the camelCase `_meta.ui.csp` map made OpenAI's tool scan see no domain lists and reject the submission. The two surfaces are now declared separately; `_meta.ui.csp` is unchanged.
- Drop `_meta.ui.permissions`, which requested `camera`, `microphone`, `geolocation` and `clipboardWrite` — an empty object value is a capability request, and the app uses none of them.
- `ui/initialize` now sends `appInfo`/`appCapabilities`, which the spec requires ("MUST include its capabilities in the appCapabilities field"), and declares `availableDisplayModes: ["inline"]`, the only mode the form is laid out for. `protocolVersion` and `capabilities` are kept as-is so ChatGPT sees no change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors