### PR TITLE
Serve the OpenAI apps origin verification token

### DIFF
--- a/cmd/mcp-http/README.md
+++ b/cmd/mcp-http/README.md
@@ -82,6 +82,8 @@ Besides the MCP endpoints, the HTTP server provides the following extended API e
 | `/` | POST | MCP HTTP transport (JSON-RPC over HTTP) |
 | `/sse` | GET | MCP SSE transport (Server-Sent Events for streaming) |
 | `/api/health` | GET | Health check endpoint |
+| `/.well-known/oauth-protected-resource` | GET | OAuth 2.0 protected resource metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)) |
+| `/.well-known/openai-apps-challenge` | GET | Origin verification token for the ChatGPT app listing (plain text) |
 
 ## ⚙️ Configuration
 

--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -41,6 +41,12 @@ var (
 // Limit request body size (e.g., 10MB)
 const maxBodySize = 10 * 1024 * 1024 // 10 MB
 
+// openAIAppsChallengeToken proves to OpenAI that we control this origin, so the
+// MCP server can be listed as a ChatGPT app. It is a public verification value,
+// not a credential, and OpenAI expects it served verbatim as plain text from
+// the origin root. Replace it if OpenAI issues a new token.
+const openAIAppsChallengeToken = "qi_6vPrb4b2ob0EAizJTh0ziBCIjObAdxGkDegPy50Y"
+
 func main() {
 	defer handleExit()
 
@@ -179,6 +185,24 @@ func newRouter(resources config.Resources) *http.ServeMux {
   "resource_documentation": "https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
   "scopes_supported": [ "projects", "desk", "spaces", "chat" ]
 }`))
+	})
+	mux.HandleFunc("/.well-known/openai-apps-challenge", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodOptions {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == http.MethodOptions {
+			return
+		}
+
+		_, _ = w.Write([]byte(openAIAppsChallengeToken))
 	})
 	return mux
 }


### PR DESCRIPTION
## Description

ChatGPT app submission requires proving we control mcp.ai.teamwork.com by serving an OpenAI-issued token from the origin root. `GET /.well-known/openai-apps-challenge` returns it verbatim as `text/plain`, alongside the existing `oauth-protected-resource` handler.

The token is a public verification value, not a credential, so it lives as a const rather than an env var — it must be stable across deployments and identical on every replica. No auth change was needed: authMiddleware already exempts the whole `/.well-known` prefix for `GET`/`OPTIONS`, and `tracerMiddleware` already skips it.

Also documents both `/.well-known` endpoints in the README endpoint table; `oauth-protected-resource` was missing from it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors