### PR TITLE
Fix: list_project_budgets status enum to match the Projects API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.20.6
+	github.com/teamwork/twapi-go-sdk v1.20.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.20.6 h1:Go6SO6d4Nv/YBwaSeAdQzCUN+YXePO4m+nl8P3YcmwI=
-github.com/teamwork/twapi-go-sdk v1.20.6/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
+github.com/teamwork/twapi-go-sdk v1.20.7 h1:ftwQirD8zI2z/icv/UKvHUKMt6zSU6SPgxEDRkjnP6M=
+github.com/teamwork/twapi-go-sdk v1.20.7/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/budgets.go
+++ b/internal/twprojects/budgets.go
@@ -92,7 +92,13 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 					"status": {
 						Description: "Filter budgets by status.",
 						AnyOf: []*jsonschema.Schema{
-							{Type: "string", Enum: []any{"upcoming", "active", "complete"}},
+							// The endpoint 400s on anything outside its own vocabulary, so these
+							// come from the SDK constants rather than being spelled out here.
+							{Type: "string", Enum: []any{
+								string(projects.ProjectBudgetStatusUpcoming),
+								string(projects.ProjectBudgetStatusActive),
+								string(projects.ProjectBudgetStatusCompleted),
+							}},
 							{Type: "null"},
 						},
 					},
@@ -131,15 +137,9 @@ func ProjectBudgetList(engine *twapi.Engine) toolsets.ToolWrapper {
 			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericListParam(&projectBudgetListRequest.Filters.ProjectIDs, "project_ids"),
-				helpers.OptionalParam(
-					&projectBudgetListRequest.Filters.Status,
-					"status",
-					helpers.RestrictValues(
-						projects.ProjectBudgetStatusUpcoming,
-						projects.ProjectBudgetStatusActive,
-						projects.ProjectBudgetStatusComplete,
-					),
-				),
+				// No RestrictValues on status: withInputValidation already rejects
+				// anything outside the schema enum before the handler runs.
+				helpers.OptionalParam(&projectBudgetListRequest.Filters.Status, "status"),
 				helpers.OptionalNumericParam(&projectBudgetListRequest.Filters.Limit, "limit"),
 				helpers.OptionalNumericParam(&projectBudgetListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&projectBudgetListRequest.Filters.PageSize, "page_size"),

--- a/internal/twprojects/budgets_test.go
+++ b/internal/twprojects/budgets_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
@@ -27,7 +29,7 @@ func TestProjectBudgetList(t *testing.T) {
 	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{"meta":{"page":{"hasMore":false}},"budgets":[{"id":13579,"projectId":2468}]}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodProjectBudgetList.String(), map[string]any{
 		"project_ids": []float64{2468, 9753},
-		"status":      "active",
+		"status":      "ACTIVE",
 		"limit":       float64(5),
 		"page_size":   float64(2),
 		"cursor":      "next-cursor-token",
@@ -54,6 +56,75 @@ func TestProjectBudgetListPagination(t *testing.T) {
 	if got := query.Get("pageSize"); got != "250" {
 		t.Errorf("expected pageSize=250 in request query but got %q (raw query: %s)", got, lastURL.RawQuery)
 	}
+}
+
+// TestProjectBudgetListStatusFilter pins the status filter onto the outgoing
+// query. The tool used to advertise "complete", which the budgets endpoint
+// rejects with 400 "unknown project budget status".
+func TestProjectBudgetListStatusFilter(t *testing.T) {
+	for _, status := range []string{"UPCOMING", "ACTIVE", "COMPLETED"} {
+		t.Run(status, func(t *testing.T) {
+			mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK,
+				[]byte(`{"meta":{"page":{"hasMore":false}},"budgets":[]}`))
+
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodProjectBudgetList.String(), map[string]any{
+				"status": status,
+			})
+
+			if got := lastURL.Query().Get("status"); got != status {
+				t.Errorf("expected status=%q in request query but got %q (raw query: %s)",
+					status, got, lastURL.RawQuery)
+			}
+		})
+	}
+}
+
+// TestProjectBudgetListStatusEnumMatchesAPI pins the published enum to the
+// upstream vocabulary. The values are spelled out rather than read back from
+// projectBudgetStatuses, so widening that list to something the API rejects
+// fails here instead of at call time.
+func TestProjectBudgetListStatusEnumMatchesAPI(t *testing.T) {
+	// Accepted by GET /projects/api/v3/projects/budgets.json. Its enum also has
+	// ALL, ARCHIVED, DELETED and INVALID, which this tool doesn't expose.
+	want := []any{"UPCOMING", "ACTIVE", "COMPLETED"}
+
+	schema := projectBudgetListInputSchema(t)
+	property, ok := schema.Properties["status"]
+	if !ok {
+		t.Fatal("status property missing from input schema")
+	}
+
+	var got []any
+	for _, branch := range property.AnyOf {
+		if branch.Enum != nil {
+			got = branch.Enum
+		}
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("status enum is %v, want %v", got, want)
+	}
+}
+
+// projectBudgetListInputSchema returns the input schema
+// twprojects-list_project_budgets publishes.
+func projectBudgetListInputSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+
+	group := twprojects.DefaultToolsetGroup(false, true, testutil.ProjectsEngineMock(http.StatusOK, nil))
+	for _, toolset := range group.Toolsets {
+		for _, tool := range toolset.GetAvailableTools() {
+			if tool.Tool.Name != twprojects.MethodProjectBudgetList.String() {
+				continue
+			}
+			schema, ok := tool.Tool.InputSchema.(*jsonschema.Schema)
+			if !ok {
+				t.Fatalf("InputSchema is not *jsonschema.Schema (got %T)", tool.Tool.InputSchema)
+			}
+			return schema
+		}
+	}
+	t.Fatalf("tool %s not found", twprojects.MethodProjectBudgetList)
+	return nil
 }
 
 // sparseFieldsParams returns the fields[...] selections on a request query,


### PR DESCRIPTION
## Description

The tool advertised a status of "complete", which the budgets endpoint rejects with 400 "unknown project budget status" — the accepted value is COMPLETED.

The schema enum and the handler's RestrictValues gate now derive from the SDK constants, so they can't drift from each other or from the API. Needs SDK v1.20.7, which corrects the constant this came from.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors