### PR TITLE
Add get/list helpdoc sites endpoint

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -109,11 +109,12 @@ Companies, customers, and user management in Teamwork Desk.
 
 ### Helpdocs — `twdesk-helpdocs`
 
-Help doc articles in Teamwork Desk.
+Help doc articles and sites in Teamwork Desk.
 
 | Resource | Create | Get | List | Update |
 |---|---|---|---|---|
 | Helpdoc Article | ✓ | ✓ | — | ✓ |
+| Helpdoc Site | — | ✓ | ✓ | — |
 
 **Other actions:** `search_helpdoc_articles`
 

--- a/internal/twdesk/helpdocs.go
+++ b/internal/twdesk/helpdocs.go
@@ -95,7 +95,7 @@ func HelpDocArticleSearch(httpClient *http.Client) toolsets.ToolWrapper {
 						},
 					},
 					"siteID": {
-						Description: "Filter by help doc site ID.",
+						Description: "Filter by help doc site ID. Use twdesk-list_helpdoc_sites to discover.",
 						AnyOf: []*jsonschema.Schema{
 							{Type: "integer"},
 							{Type: "null"},
@@ -169,8 +169,9 @@ func HelpDocArticleCreate(httpClient *http.Client) toolsets.ToolWrapper {
 				AdditionalProperties: falseSchema(),
 				Properties: map[string]*jsonschema.Schema{
 					"siteID": {
-						Type:        "integer",
-						Description: "The ID of the help doc site to create the article in.",
+						Type: "integer",
+						Description: "The ID of the help doc site to create the article in. " +
+							"Use twdesk-list_helpdoc_sites to discover.",
 					},
 					"title": {
 						Type:        "string",

--- a/internal/twdesk/helpdocsites.go
+++ b/internal/twdesk/helpdocsites.go
@@ -1,0 +1,135 @@
+package twdesk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	deskclient "github.com/teamwork/desksdkgo/client"
+	"github.com/teamwork/mcp/internal/helpers"
+	"github.com/teamwork/mcp/internal/toolsets"
+)
+
+// List of methods available in the Teamwork.com MCP service.
+//
+// The naming convention for methods follows a pattern described here:
+// https://github.com/github/github-mcp-server/issues/333
+const (
+	MethodHelpDocSiteGet  toolsets.Method = "twdesk-get_helpdoc_site"
+	MethodHelpDocSiteList toolsets.Method = "twdesk-list_helpdoc_sites"
+)
+
+// HelpDocSiteGet retrieves a single help doc site by ID.
+func HelpDocSiteGet(httpClient *http.Client) toolsets.ToolWrapper {
+	return toolsets.ToolWrapper{
+		Tool: &mcp.Tool{
+			Name: string(MethodHelpDocSiteGet),
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Get Help Doc Site",
+				ReadOnlyHint:    true,
+				DestructiveHint: new(false),
+				OpenWorldHint:   new(false),
+			},
+			Description: "Get a help doc site (knowledge base) by ID, including its subdomain, branding and article counts.",
+			InputSchema: &jsonschema.Schema{
+				Type:                 "object",
+				AdditionalProperties: falseSchema(),
+				Properties: map[string]*jsonschema.Schema{
+					"id": {
+						Type:        "integer",
+						Description: "The ID of the help doc site to retrieve.",
+					},
+					"fields": sparseFieldsSchema(),
+				},
+				Required: []string{"id", "fields"},
+			},
+		},
+		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			client := ClientFromContext(ctx, httpClient)
+			arguments, err := helpers.NewToolArguments(request)
+			if err != nil {
+				return helpers.NewToolResultTextError("%v", err), nil
+			}
+
+			site, err := client.HelpDocSites.Get(ctx, arguments.GetInt("id", 0), getParams(arguments))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get help doc site: %w", err)
+			}
+			return helpers.NewToolResultJSON(site)
+		},
+	}
+}
+
+// HelpDocSiteList returns a list of help doc sites that apply to the filters in
+// Teamwork Desk.
+func HelpDocSiteList(httpClient *http.Client) toolsets.ToolWrapper {
+	properties := map[string]*jsonschema.Schema{
+		"name": {
+			Description: "The name of the help doc site to filter by.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
+			},
+		},
+		"subdomain": {
+			Description: "The subdomain of the help doc site to filter by.",
+			AnyOf: []*jsonschema.Schema{
+				{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+				{Type: "null"},
+			},
+		},
+	}
+	properties = paginationOptions(properties)
+
+	return toolsets.ToolWrapper{
+		Tool: &mcp.Tool{
+			Name: string(MethodHelpDocSiteList),
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "List Help Doc Sites",
+				ReadOnlyHint:    true,
+				DestructiveHint: new(false),
+				OpenWorldHint:   new(false),
+			},
+			Description: "List help doc sites (knowledge bases). Filter by name or subdomain. " +
+				"Use this to discover the site ID required by the help doc article tools.",
+			InputSchema: &jsonschema.Schema{
+				Type:                 "object",
+				AdditionalProperties: falseSchema(),
+				Properties:           properties,
+				Required:             append(paginationRequiredKeys(), "name", "subdomain"),
+			},
+		},
+		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			client := ClientFromContext(ctx, httpClient)
+			arguments, err := helpers.NewToolArguments(request)
+			if err != nil {
+				return helpers.NewToolResultTextError("%v", err), nil
+			}
+
+			// Apply filters to the help doc site list
+			name := arguments.GetStringSlice("name", []string{})
+			subdomain := arguments.GetStringSlice("subdomain", []string{})
+
+			filter := deskclient.NewFilter()
+			if len(name) > 0 {
+				filter = filter.In("name", helpers.SliceToAny(name))
+			}
+			if len(subdomain) > 0 {
+				filter = filter.In("subdomain", helpers.SliceToAny(subdomain))
+			}
+
+			params := url.Values{}
+			params.Set("filter", filter.Build())
+			setPagination(&params, arguments)
+
+			sites, err := client.HelpDocSites.List(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list help doc sites: %w", err)
+			}
+			return helpers.NewToolResultJSON(sites)
+		},
+	}
+}

--- a/internal/twdesk/helpdocsites_test.go
+++ b/internal/twdesk/helpdocsites_test.go
@@ -1,0 +1,50 @@
+//nolint:lll
+package twdesk_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/teamwork/mcp/internal/testutil"
+	"github.com/teamwork/mcp/internal/twdesk"
+)
+
+func TestHelpDocSiteGet(t *testing.T) {
+	mcpServer, cleanup := mcpServerMock(t, http.StatusOK, []byte(`{"helpdocssite":{"id":7,"name":"Support Centre","subdomain":"support"}}`))
+	defer cleanup()
+
+	testutil.ExecuteToolRequest(t, mcpServer, twdesk.MethodHelpDocSiteGet.String(), map[string]any{
+		"id":     float64(7),
+		"fields": nil,
+	})
+}
+
+func TestHelpDocSiteList(t *testing.T) {
+	mcpServer, cleanup := mcpServerMock(t, http.StatusOK, []byte(`{"helpdocssites":[{"id":7,"name":"Support Centre","subdomain":"support"}]}`))
+	defer cleanup()
+
+	testutil.ExecuteToolRequest(t, mcpServer, twdesk.MethodHelpDocSiteList.String(), map[string]any{
+		"name":           []any{"Support Centre"},
+		"subdomain":      []any{"support"},
+		"page":           float64(1),
+		"pageSize":       float64(10),
+		"orderBy":        "name",
+		"orderDirection": "asc",
+		"fields":         []any{"id", "name", "subdomain"},
+	})
+}
+
+func TestHelpDocSiteListMinimal(t *testing.T) {
+	mcpServer, cleanup := mcpServerMock(t, http.StatusOK, []byte(`{"helpdocssites":[]}`))
+	defer cleanup()
+
+	testutil.ExecuteToolRequest(t, mcpServer, twdesk.MethodHelpDocSiteList.String(), map[string]any{
+		"name":           nil,
+		"subdomain":      nil,
+		"page":           nil,
+		"pageSize":       nil,
+		"orderBy":        nil,
+		"orderDirection": nil,
+		"fields":         nil,
+	})
+}

--- a/internal/twdesk/tools.go
+++ b/internal/twdesk/tools.go
@@ -10,7 +10,7 @@ const (
 	deskTicketsDescription   = "Tickets, messages, files, and inboxes in Teamwork Desk."
 	deskCustomersDescription = "Companies, customers, and user management in Teamwork Desk."
 	deskAdminDescription     = "Inbox configuration: priorities, statuses, types, and tags in Teamwork Desk."
-	deskHelpDocsDescription  = "Help doc articles in Teamwork Desk."
+	deskHelpDocsDescription  = "Help doc articles and sites in Teamwork Desk."
 )
 
 // Sub-toolset keys for twdesk. These are the valid values for the
@@ -22,7 +22,7 @@ const (
 	ToolsetCustomers toolsets.Method = "twdesk-customers"
 	// ToolsetAdmin covers priorities, statuses, types, and tags.
 	ToolsetAdmin toolsets.Method = "twdesk-admin"
-	// ToolsetHelpDocs covers help doc articles.
+	// ToolsetHelpDocs covers help doc articles and sites.
 	ToolsetHelpDocs toolsets.Method = "twdesk-helpdocs"
 )
 
@@ -101,6 +101,8 @@ func DefaultToolsetGroup(readOnly bool, httpClient *http.Client) *toolsets.Tools
 		AddReadTools(
 			HelpDocArticleGet(httpClient),
 			HelpDocArticleSearch(httpClient),
+			HelpDocSiteGet(httpClient),
+			HelpDocSiteList(httpClient),
 		))
 
 	return group


### PR DESCRIPTION
## Description

Previously you could list all helpdocs, but there was no way to get a list of helpdoc sites. This adds a new endpoint to get a list of helpdoc sites so it would need to make a ton of requests to get all the helpdocs and then extract the sites from that list.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors