### PR TITLE
Fix: Accept plain user-ID arrays and boolean true in notify tool parameters

### DIFF
--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -206,6 +207,50 @@ func UserGroupsSchema(description string, required bool) *jsonschema.Schema {
 		Description: description,
 		AnyOf: []*jsonschema.Schema{
 			obj,
+			{Type: "null"},
+		},
+	}
+}
+
+// NotifySchema returns the schema for a "notify" parameter. Every shape must
+// be advertised here: the MCP SDK validates arguments against the schema
+// before the handler runs, so parseNotify (twprojects) can only coerce what
+// the schema allows. false = notify nobody. true = followers and the default
+// when withFollowers (comments), otherwise an alias for "all", the default.
+func NotifySchema(description string, withFollowers bool) *jsonschema.Schema {
+	defaultValue := json.RawMessage(`"all"`)
+	boolDescription := `true is the same as "all": notify all project members. false notifies nobody.`
+	boolPhrase := `, the boolean true as an alias for "all"`
+	if withFollowers {
+		defaultValue = json.RawMessage(`true`)
+		boolDescription = "true notifies all followers of the entity this comment is related to. " +
+			"false notifies nobody."
+		boolPhrase = ", the boolean true to notify all followers of the related entity"
+	}
+	description += ` Accepts the string "all" to notify all project members` + boolPhrase +
+		`, the boolean false to notify nobody, a plain array of user IDs (e.g. [123, 456]), ` +
+		`or an object selecting user_ids, company_ids, team_ids and/or job_role_ids ` +
+		`(e.g. {"user_ids": [123, 456]}).`
+	return &jsonschema.Schema{
+		Description: description,
+		Default:     defaultValue,
+		AnyOf: []*jsonschema.Schema{
+			{
+				Type:        "string",
+				Description: "Notify all project members.",
+				Enum:        []any{"all"},
+			},
+			{
+				Type:        "boolean",
+				Description: boolDescription,
+			},
+			{
+				Type:        "array",
+				Description: `The IDs of the users to notify; shorthand for {"user_ids": [...]}.`,
+				Items:       &jsonschema.Schema{Type: "integer"},
+				MinItems:    new(1),
+			},
+			UserGroupsSchema("", true),
 			{Type: "null"},
 		},
 	}

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -106,28 +106,7 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the new comment.",
-						Default:     json.RawMessage(`true`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									{
-										Type:        "boolean",
-										Description: "Notify all followers of the entity this comment is related to.",
-										Enum:        []any{true},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the new comment.", true),
 				},
 				Required: []string{"object", "body"},
 			},
@@ -148,35 +127,18 @@ func CommentCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case bool:
-					if !value {
-						return helpers.NewToolResultTextError("invalid parameters: notify must be true when using boolean"), nil
-					}
-					commentCreateRequest.Notify = projects.NewCommentNotifyFollowers()
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						commentCreateRequest.Notify = projects.NewCommentNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						commentCreateRequest.Notify = projects.NewCommentNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either boolean true, " +
-						"string ('all'), or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, true)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceAll:
+				commentCreateRequest.Notify = projects.NewCommentNotifyAll()
+			case notifyChoiceGroup:
+				commentCreateRequest.Notify = projects.NewCommentNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				commentCreateRequest.Notify = projects.NewCommentNotifyFollowers()
 			}
 
@@ -260,28 +222,7 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the comment change.",
-						Default:     json.RawMessage(`true`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									{
-										Type:        "boolean",
-										Description: "Notify all followers of the entity this comment is related to.",
-										Enum:        []any{true},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the comment change.", true),
 				},
 				Required: []string{"id", "body"},
 			},
@@ -303,35 +244,18 @@ func CommentUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case bool:
-					if !value {
-						return helpers.NewToolResultTextError("invalid parameters: notify must be true when using boolean"), nil
-					}
-					commentUpdateRequest.Notify = projects.NewCommentNotifyFollowers()
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						commentUpdateRequest.Notify = projects.NewCommentNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						commentUpdateRequest.Notify = projects.NewCommentNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either boolean true, " +
-						"string ('all'), or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, true)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceAll:
+				commentUpdateRequest.Notify = projects.NewCommentNotifyAll()
+			case notifyChoiceGroup:
+				commentUpdateRequest.Notify = projects.NewCommentNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				commentUpdateRequest.Notify = projects.NewCommentNotifyFollowers()
 			}
 

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -1,6 +1,7 @@
 package twprojects_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -24,6 +25,48 @@ func TestCommentCreate(t *testing.T) {
 			"company_ids": []any{float64(4)},
 		},
 	})
+}
+
+// Comment-specific notify contract: true (and the default) mean followers;
+// the shared shapes behave as in the other notify-carrying tools.
+func TestCommentCreateNotifyShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		notify     any
+		wantNotify string // raw JSON as serialized for the API; empty means omitted
+	}{
+		{name: "boolean true notifies followers", notify: true, wantNotify: `true`},
+		{name: "boolean false notifies nobody", notify: false, wantNotify: ""},
+		{name: "explicit null falls back to followers", notify: nil, wantNotify: `true`},
+		{name: "string all notifies project members", notify: "all", wantNotify: `"ALL"`},
+		{name: "array of user IDs", notify: []any{float64(1), float64(2)}, wantNotify: `"1,2"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, requestBody := mcpServerMockWithRequestBody(t, http.StatusCreated, []byte(`{"id":"123"}`))
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentCreate.String(), map[string]any{
+				"object": map[string]any{
+					"type": "tasks",
+					"id":   float64(123),
+				},
+				"body":   "Example",
+				"notify": tt.notify,
+			})
+
+			var payload struct {
+				Comment struct {
+					Notify json.RawMessage `json:"notify"`
+				} `json:"comment"`
+			}
+			if err := json.Unmarshal(*requestBody, &payload); err != nil {
+				t.Fatalf("failed to decode request body %q: %v", string(*requestBody), err)
+			}
+			if string(payload.Comment.Notify) != tt.wantNotify {
+				t.Errorf("expected notify %s, got %s (body %q)",
+					tt.wantNotify, payload.Comment.Notify, string(*requestBody))
+			}
+		})
+	}
 }
 
 func TestCommentUpdate(t *testing.T) {

--- a/internal/twprojects/helpers.go
+++ b/internal/twprojects/helpers.go
@@ -1,6 +1,8 @@
 package twprojects
 
 import (
+	"strings"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/twapi-go-sdk/projects"
@@ -33,6 +35,69 @@ func parseUserGroups(
 		return nil, helpers.NewToolResultTextError("invalid %s: %s", label, err)
 	}
 	return &userGroups, nil
+}
+
+// notifyChoice is the parsed form of a "notify" argument.
+type notifyChoice int
+
+const (
+	// notifyChoiceDefault: notify was absent or null; caller applies its default.
+	notifyChoiceDefault notifyChoice = iota
+	notifyChoiceAll
+	notifyChoiceFollowers
+	notifyChoiceGroup
+	// notifyChoiceNone: caller leaves Notify unset; the API then notifies nobody.
+	notifyChoiceNone
+)
+
+// parseNotify binds the "notify" argument shared by the message, message
+// reply, link and comment tools, coercing near-misses: an array of IDs
+// becomes {"user_ids": [...]}, true means followers (withFollowers) or
+// "all", false means nobody. The error lists every accepted shape.
+func parseNotify(
+	arguments map[string]any,
+	withFollowers bool,
+) (notifyChoice, *projects.LegacyUserGroups, *mcp.CallToolResult) {
+	value, ok := arguments["notify"]
+	if !ok || value == nil {
+		return notifyChoiceDefault, nil, nil
+	}
+	switch typed := value.(type) {
+	case string:
+		if strings.EqualFold(typed, "all") {
+			return notifyChoiceAll, nil, nil
+		}
+	case bool:
+		if !typed {
+			return notifyChoiceNone, nil, nil
+		}
+		if withFollowers {
+			return notifyChoiceFollowers, nil, nil
+		}
+		return notifyChoiceAll, nil, nil
+	case []any:
+		groups, toolResult := parseLegacyUserGroups(
+			map[string]any{"notify": map[string]any{"user_ids": typed}},
+			"notify",
+			"notifiers",
+		)
+		if toolResult == nil && groups != nil && len(groups.UserIDs) > 0 {
+			return notifyChoiceGroup, groups, nil
+		}
+	case map[string]any:
+		groups, toolResult := parseLegacyUserGroups(arguments, "notify", "notifiers")
+		if toolResult != nil {
+			return notifyChoiceDefault, nil, toolResult
+		}
+		if groups == nil {
+			return notifyChoiceDefault, nil, nil
+		}
+		return notifyChoiceGroup, groups, nil
+	}
+	return notifyChoiceDefault, nil, helpers.NewToolResultTextError(
+		`invalid parameters: notify must be the string "all", a boolean (false notifies nobody), ` +
+			"an array of user IDs (e.g. [123, 456]), or an object with user_ids, company_ids, " +
+			`team_ids and/or job_role_ids (e.g. {"user_ids": [123, 456]})`)
 }
 
 func parseLegacyUserGroups(

--- a/internal/twprojects/links.go
+++ b/internal/twprojects/links.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -108,23 +107,7 @@ func LinkCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the new link.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the new link.", false),
 				},
 				Required: []string{"project_id", "code"},
 			},
@@ -148,30 +131,16 @@ func LinkCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						linkCreateRequest.Notify = projects.NewLinkNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						linkCreateRequest.Notify = projects.NewLinkNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				linkCreateRequest.Notify = projects.NewLinkNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				linkCreateRequest.Notify = projects.NewLinkNotifyAll()
 			}
 
@@ -231,23 +200,7 @@ func LinkUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the link update.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the link update.", false),
 				},
 				Required: []string{"id"},
 			},
@@ -271,30 +224,16 @@ func LinkUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						linkUpdateRequest.Notify = projects.NewLinkNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						linkUpdateRequest.Notify = projects.NewLinkNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				linkUpdateRequest.Notify = projects.NewLinkNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				linkUpdateRequest.Notify = projects.NewLinkNotifyAll()
 			}
 

--- a/internal/twprojects/message_replies.go
+++ b/internal/twprojects/message_replies.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -78,23 +77,7 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the new reply.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the new reply.", false),
 				},
 				Required: []string{"message_id", "body"},
 			},
@@ -115,30 +98,16 @@ func MessageReplyCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						messageReplyCreateRequest.Notify = projects.NewMessageNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						messageReplyCreateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				messageReplyCreateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				messageReplyCreateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
@@ -183,23 +152,7 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the reply update.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the reply update.", false),
 				},
 				Required: []string{"id"},
 			},
@@ -220,30 +173,16 @@ func MessageReplyUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						messageReplyUpdateRequest.Notify = projects.NewMessageNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						messageReplyUpdateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				messageReplyUpdateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				messageReplyUpdateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 

--- a/internal/twprojects/message_replies_test.go
+++ b/internal/twprojects/message_replies_test.go
@@ -1,9 +1,11 @@
 package twprojects_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
 )
@@ -20,6 +22,75 @@ func TestMessageReplyCreate(t *testing.T) {
 			"team_ids":    []float64{6, 7},
 		},
 	})
+}
+
+// Covers every accepted notify shape, including coerced near-misses, by
+// asserting the notifier actually serialized for the API.
+func TestMessageReplyCreateNotifyShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		notify     any
+		wantNotify string // raw JSON as serialized for the API; empty means omitted
+	}{
+		{name: "string all", notify: "all", wantNotify: `"ALL"`},
+		{name: "array of user IDs", notify: []any{float64(1), float64(2)}, wantNotify: `"1,2"`},
+		{name: "boolean true coerces to all", notify: true, wantNotify: `"ALL"`},
+		{name: "boolean false notifies nobody", notify: false, wantNotify: ""},
+		{name: "explicit null falls back to the default", notify: nil, wantNotify: `"ALL"`},
+		{
+			name: "object of user groups",
+			notify: map[string]any{
+				"user_ids": []any{float64(1), float64(2)},
+				"team_ids": []any{float64(6)},
+			},
+			wantNotify: `"1,2,t6"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, requestBody := mcpServerMockWithRequestBody(t, http.StatusCreated, []byte(`{"postId":"123"}`))
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMessageReplyCreate.String(), map[string]any{
+				"message_id": float64(123),
+				"body":       "Example message reply body",
+				"notify":     tt.notify,
+			})
+
+			var payload struct {
+				MessageReply struct {
+					Notify json.RawMessage `json:"notify"`
+				} `json:"messagereply"`
+			}
+			if err := json.Unmarshal(*requestBody, &payload); err != nil {
+				t.Fatalf("failed to decode request body %q: %v", string(*requestBody), err)
+			}
+			if string(payload.MessageReply.Notify) != tt.wantNotify {
+				t.Errorf("expected notify %s, got %s (body %q)",
+					tt.wantNotify, payload.MessageReply.Notify, string(*requestBody))
+			}
+		})
+	}
+}
+
+// Shapes outside the contract are rejected by SDK schema validation before
+// reaching the API; the handler's fallback error is pinned in notify_test.go.
+func TestMessageReplyCreateNotifyRejectsUnknownShapes(t *testing.T) {
+	for _, notify := range []any{"everyone", float64(7), []any{"bob"}, []any{}} {
+		mcpServer := mcpServerMock(t, http.StatusCreated, []byte(`{"postId":"123"}`))
+		testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMessageReplyCreate.String(), map[string]any{
+			"message_id": float64(123),
+			"body":       "Example message reply body",
+			"notify":     notify,
+		}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+			t.Helper()
+			toolResult, ok := result.(*mcp.CallToolResult)
+			if !ok {
+				t.Fatalf("unexpected result type: %T", result)
+			}
+			if !toolResult.IsError {
+				t.Fatalf("expected notify %#v to be rejected", notify)
+			}
+		}))
+	}
 }
 
 func TestMessageReplyUpdate(t *testing.T) {

--- a/internal/twprojects/messages.go
+++ b/internal/twprojects/messages.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -82,23 +81,7 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the new message.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the new message.", false),
 				},
 				Required: []string{"title", "project_id", "body"},
 			},
@@ -120,30 +103,16 @@ func MessageCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						messageCreateRequest.Notify = projects.NewMessageNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						messageCreateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				messageCreateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				messageCreateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 
@@ -202,23 +171,7 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"notify": {
-						Description: "Who to notify of the message update.",
-						Default:     json.RawMessage(`"all"`),
-						AnyOf: []*jsonschema.Schema{
-							{
-								AnyOf: []*jsonschema.Schema{
-									{
-										Type:        "string",
-										Description: "Notify all project members.",
-										Enum:        []any{"all"},
-									},
-									helpers.UserGroupsSchema("", true),
-								},
-							},
-							{Type: "null"},
-						},
-					},
+					"notify": helpers.NotifySchema("Who to notify of the message update.", false),
 				},
 				Required: []string{"id"},
 			},
@@ -240,30 +193,16 @@ func MessageUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			if notify, ok := arguments["notify"]; ok {
-				switch value := notify.(type) {
-				case string:
-					switch strings.ToLower(value) {
-					case "all":
-						messageUpdateRequest.Notify = projects.NewMessageNotifyAll()
-					default:
-						return helpers.NewToolResultTextError("invalid parameters: notify must be 'all'"), nil
-					}
-				case map[string]any:
-					if notifiers, toolResult := parseLegacyUserGroups(
-						arguments,
-						"notify",
-						"notifiers",
-					); toolResult != nil {
-						return toolResult, nil
-					} else if notifiers != nil {
-						messageUpdateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
-					}
-				default:
-					return helpers.NewToolResultTextError("invalid parameters: notify must be either string ('all'), " +
-						"or an object"), nil
-				}
-			} else {
+			notifyChosen, notifiers, toolResult := parseNotify(arguments, false)
+			if toolResult != nil {
+				return toolResult, nil
+			}
+			switch notifyChosen {
+			case notifyChoiceGroup:
+				messageUpdateRequest.Notify = projects.NewMessageNotifyGroup(*notifiers)
+			case notifyChoiceNone:
+				// leave Notify unset: the API sends no notifications
+			default:
 				messageUpdateRequest.Notify = projects.NewMessageNotifyAll()
 			}
 

--- a/internal/twprojects/notify_test.go
+++ b/internal/twprojects/notify_test.go
@@ -1,0 +1,114 @@
+package twprojects
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// White-box: SDK schema validation normally runs first, but the binder still
+// guards transports that skip it (case-insensitive "all", fallback error).
+func TestParseNotify(t *testing.T) {
+	tests := []struct {
+		name          string
+		arguments     map[string]any
+		withFollowers bool
+		wantChoice    notifyChoice
+		wantUserIDs   []int64
+	}{
+		{
+			name:       "absent means default",
+			arguments:  map[string]any{},
+			wantChoice: notifyChoiceDefault,
+		},
+		{
+			name:       "explicit null means default",
+			arguments:  map[string]any{"notify": nil},
+			wantChoice: notifyChoiceDefault,
+		},
+		{
+			name:       "string all is case-insensitive",
+			arguments:  map[string]any{"notify": "ALL"},
+			wantChoice: notifyChoiceAll,
+		},
+		{
+			name:       "boolean true coerces to all",
+			arguments:  map[string]any{"notify": true},
+			wantChoice: notifyChoiceAll,
+		},
+		{
+			name:          "boolean true means followers when supported",
+			arguments:     map[string]any{"notify": true},
+			withFollowers: true,
+			wantChoice:    notifyChoiceFollowers,
+		},
+		{
+			name:       "boolean false means nobody",
+			arguments:  map[string]any{"notify": false},
+			wantChoice: notifyChoiceNone,
+		},
+		{
+			name:          "boolean false means nobody with followers too",
+			arguments:     map[string]any{"notify": false},
+			withFollowers: true,
+			wantChoice:    notifyChoiceNone,
+		},
+		{
+			name:        "array of user IDs coerces to a group",
+			arguments:   map[string]any{"notify": []any{float64(1), float64(2)}},
+			wantChoice:  notifyChoiceGroup,
+			wantUserIDs: []int64{1, 2},
+		},
+		{
+			name:        "object of user groups",
+			arguments:   map[string]any{"notify": map[string]any{"user_ids": []any{float64(7)}}},
+			wantChoice:  notifyChoiceGroup,
+			wantUserIDs: []int64{7},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			choice, groups, toolResult := parseNotify(tt.arguments, tt.withFollowers)
+			if toolResult != nil {
+				t.Fatalf("unexpected error result: %v", toolResult.Content)
+			}
+			if choice != tt.wantChoice {
+				t.Errorf("expected choice %v, got %v", tt.wantChoice, choice)
+			}
+			if tt.wantUserIDs == nil {
+				return
+			}
+			if groups == nil {
+				t.Fatal("expected user groups, got nil")
+			}
+			if len(groups.UserIDs) != len(tt.wantUserIDs) {
+				t.Fatalf("expected user IDs %v, got %v", tt.wantUserIDs, groups.UserIDs)
+			}
+			for i, id := range tt.wantUserIDs {
+				if groups.UserIDs[i] != id {
+					t.Errorf("expected user IDs %v, got %v", tt.wantUserIDs, groups.UserIDs)
+				}
+			}
+		})
+	}
+}
+
+// The fallback error must list every accepted shape.
+func TestParseNotifyRejectsUnknownShapes(t *testing.T) {
+	for _, notify := range []any{"everyone", float64(7), []any{"bob"}, []any{}} {
+		_, _, toolResult := parseNotify(map[string]any{"notify": notify}, false)
+		if toolResult == nil {
+			t.Fatalf("expected notify %#v to be rejected", notify)
+		}
+		text, ok := toolResult.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("unexpected content type: %T", toolResult.Content[0])
+		}
+		if !strings.Contains(text.Text, `notify must be the string "all"`) ||
+			!strings.Contains(text.Text, "array of user IDs") ||
+			!strings.Contains(text.Text, "user_ids, company_ids, team_ids and/or job_role_ids") {
+			t.Errorf("error should list the accepted shapes, got %q", text.Text)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The notify shapes lived only in handler type switches, so models guessed and failed. Centralise schema (`helpers.NotifySchema`) and binding (`parseNotify`) for messages, replies, links and comments; treat explicit `null` as the default; list accepted shapes in the error.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors