### PR TITLE
List comments improvements

### DIFF
--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,6 +57,18 @@ var commentListFields = slices.DeleteFunc(
 		return field == projects.CommentFieldHTMLBody
 	},
 )
+
+// commentBodyLimit is how many characters of a comment body list_comments
+// returns before truncating it.
+//
+// Comment bodies are not short in practice: bots post build summaries and
+// agents post long reports, so a list of a few hundred routinely ran to
+// hundreds of thousands of tokens. The distribution is what makes a cap work —
+// across one real account the median body was 484 characters while the top 5%
+// of records held 52.8% of all body text. A 500-character cap therefore leaves
+// roughly three quarters of comments untouched and still removes ~90% of the
+// payload. Full text stays one get_comment away.
+const commentBodyLimit = 500
 
 func init() {
 	var err error
@@ -483,7 +496,8 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Tool: &mcp.Tool{
 			Name: string(MethodCommentList),
 			Description: "List comments. Scope by one of task_id, milestone_id, notebook_id, link_id, or file_version_id; " +
-				"omit all for site-wide.",
+				"omit all for site-wide. Comment bodies are truncated at " + strconv.Itoa(commentBodyLimit) +
+				" characters and marked where they are cut; use " + string(MethodCommentGet) + " for the full text.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "List Comments",
 				ReadOnlyHint:    true,
@@ -598,7 +612,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				return nil, fmt.Errorf("failed to read response body: %w", err)
 			}
 
-			linked := helpers.WebLinker(ctx, body, commentPathBuilder)
+			linked := helpers.WebLinker(ctx, truncateCommentBodies(body), commentPathBuilder)
 			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
 					&mcp.TextContent{Text: string(linked)},
@@ -612,6 +626,121 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 			return result, nil
 		},
 	}
+}
+
+// truncateCommentBodies caps the body of every comment in a raw list_comments
+// response at commentBodyLimit characters, appending a marker naming how much
+// was cut and how to get the rest.
+//
+// The marker is not decoration. Silent truncation is worse than none: a caller
+// handed half a comment with no sign of it reasons over the half confidently.
+// It goes inline at the point the text stops rather than into a sibling field
+// so it is read as part of the content, survives any later reshaping of the
+// record, and needs no change to the published schema — body is still a string.
+//
+// It applies whether or not the caller named `fields`: an explicit selection of
+// body across a few hundred records is exactly the payload this exists to
+// bound, and get_comment is the way to full text either way.
+//
+// Anything unexpected leaves the payload untouched, matching how WebLinker
+// treats a body it cannot parse: returning the response whole is always
+// preferable to failing a read the API already answered.
+func truncateCommentBodies(data []byte) []byte {
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return data
+	}
+	comments, ok := decoded["comments"].([]any)
+	if !ok {
+		return data
+	}
+
+	var truncated bool
+	for _, item := range comments {
+		comment, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		body, ok := comment["body"].(string)
+		if !ok {
+			continue
+		}
+		short, ok := truncateCommentBody(body, comment["id"])
+		if !ok {
+			continue
+		}
+		comment["body"] = short
+		truncated = true
+	}
+	if !truncated {
+		return data
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return data
+	}
+	return encoded
+}
+
+// truncateCommentBody shortens a single body, reporting whether it had to. The
+// marker carries all three things a caller needs at the point of the cut: that
+// the text stops early, how much text there is in total, and the call that
+// returns the rest. A bare "truncated" would not distinguish 520 characters
+// missing from 128,927, which are very different decisions.
+func truncateCommentBody(body string, id any) (string, bool) {
+	// Byte length is never below rune count, so this rejects the common case
+	// without allocating.
+	if len(body) <= commentBodyLimit {
+		return body, false
+	}
+	runes := []rune(body)
+	if len(runes) <= commentBodyLimit {
+		return body, false
+	}
+
+	var marker strings.Builder
+	fmt.Fprintf(&marker, "...[truncated — %s chars total", formatThousands(len(runes)))
+	if commentID := formatCommentID(id); commentID != "" {
+		fmt.Fprintf(&marker, ", %s(id=%s) for full text", MethodCommentGet, commentID)
+	}
+	marker.WriteString("]")
+
+	return string(runes[:commentBodyLimit]) + marker.String(), true
+}
+
+// formatCommentID renders the id of a decoded comment for the truncation
+// marker, or an empty string when there is nothing addressable to point at. A
+// caller can exclude id from `fields`, but the handler appends it to any
+// selection, so in practice this only gives up on a malformed record.
+func formatCommentID(id any) string {
+	switch value := id.(type) {
+	case float64:
+		if math.Trunc(value) == value {
+			return strconv.FormatInt(int64(value), 10)
+		}
+	case string:
+		return value
+	}
+	return ""
+}
+
+// formatThousands renders a non-negative count with thousands separators, so
+// the scale of what is missing reads at a glance rather than by counting
+// digits.
+func formatThousands(n int) string {
+	digits := strconv.Itoa(n)
+	if len(digits) <= 3 {
+		return digits
+	}
+	var formatted strings.Builder
+	for i, digit := range digits {
+		if i > 0 && (len(digits)-i)%3 == 0 {
+			formatted.WriteRune(',')
+		}
+		formatted.WriteRune(digit)
+	}
+	return formatted.String()
 }
 
 func commentPathBuilder(object map[string]any) string {

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -34,6 +35,26 @@ const (
 var (
 	commentGetOutputSchema  *jsonschema.Schema
 	commentListOutputSchema *jsonschema.Schema
+)
+
+// commentListFields is the attribute set list_comments asks for when the caller
+// names none: every attribute the SDK models except htmlBody.
+//
+// htmlBody is the same content as body a second time, and the larger of the
+// two — measured across one real account it came to 130% of the body payload —
+// so a list response carried the text twice for no extra meaning. Selecting the
+// rest server-side rather than stripping htmlBody from the response means we do
+// not pay to transfer it either. get_comment still returns it, and a caller that
+// wants it back in a list can name it in `fields`.
+//
+// Derived from the entity struct rather than restated as constants so an SDK
+// upgrade that adds an attribute picks it up here instead of quietly excluding
+// it.
+var commentListFields = slices.DeleteFunc(
+	helpers.SparseFieldNames[projects.CommentField, projects.Comment](),
+	func(field projects.CommentField) bool {
+		return field == projects.CommentFieldHTMLBody
+	},
 )
 
 func init() {
@@ -551,10 +572,15 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				commentListRequest.Filters.UpdatedAfter = time.Now().AddDate(0, -3, 0)
 			}
 
-			if !verbose && len(commentListRequest.Filters.Fields.Comments) == 0 {
+			switch {
+			case len(commentListRequest.Filters.Fields.Comments) > 0:
+				// an explicit selection wins over both defaults below
+			case !verbose:
 				commentListRequest.Filters.Fields.Comments = []projects.CommentField{
 					projects.CommentFieldID,
 				}
+			default:
+				commentListRequest.Filters.Fields.Comments = commentListFields
 			}
 
 			resp, err := twapi.ExecuteRaw(ctx, engine, commentListRequest)

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -2,10 +2,14 @@ package twprojects_test
 
 import (
 	"net/http"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
+	"github.com/teamwork/twapi-go-sdk/projects"
 )
 
 func TestCommentCreate(t *testing.T) {
@@ -59,6 +63,55 @@ func TestCommentList(t *testing.T) {
 		"page":          float64(1),
 		"page_size":     float64(10),
 	})
+}
+
+// TestCommentListDropsHTMLBody pins htmlBody out of the default list selection.
+// It is the same content as body a second time and the larger of the two, so a
+// list response that carries both spends most of its payload on a duplicate.
+// The endpoint implements sparse fieldsets, so this is asserted on the outgoing
+// query: the mock replies with the same canned body whatever is asked for, and
+// a selection that never reaches the API means the response quietly carries
+// htmlBody anyway.
+func TestCommentListDropsHTMLBody(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{})
+
+	selections := sparseFieldsParams(lastURL.Query())
+	if len(selections) != 1 {
+		t.Fatalf("expected exactly one fields[...] selection but got %v (raw query: %s)",
+			selections, lastURL.RawQuery)
+	}
+	for entity, got := range selections {
+		selected := strings.Split(got, ",")
+		if slices.Contains(selected, string(projects.CommentFieldHTMLBody)) {
+			t.Errorf("expected htmlBody out of fields[%s] but got %q", entity, got)
+		}
+		// Everything else the SDK models stays in, so the cut is the duplicate
+		// body rather than a narrowing of the record.
+		for _, attribute := range helpers.SparseFieldNames[projects.CommentField, projects.Comment]() {
+			if attribute == projects.CommentFieldHTMLBody {
+				continue
+			}
+			if !slices.Contains(selected, string(attribute)) {
+				t.Errorf("expected %s in fields[%s] but got %q", attribute, entity, got)
+			}
+		}
+	}
+}
+
+// TestCommentListHTMLBodyRemainsSelectable guards the escape hatch: dropping
+// htmlBody is a default, not a removal, so a caller that names it still gets it.
+func TestCommentListHTMLBodyRemainsSelectable(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
+		"fields": []any{string(projects.CommentFieldHTMLBody)},
+	})
+
+	for entity, got := range sparseFieldsParams(lastURL.Query()) {
+		if !slices.Contains(strings.Split(got, ","), string(projects.CommentFieldHTMLBody)) {
+			t.Errorf("expected htmlBody in fields[%s] but got %q", entity, got)
+		}
+	}
 }
 
 func TestCommentListByFileVersion(t *testing.T) {

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -1,11 +1,13 @@
 package twprojects_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
@@ -112,6 +114,131 @@ func TestCommentListHTMLBodyRemainsSelectable(t *testing.T) {
 			t.Errorf("expected htmlBody in fields[%s] but got %q", entity, got)
 		}
 	}
+}
+
+// TestCommentListTruncatesBody covers the cap on comment bodies and, just as
+// importantly, the marker that admits to it. A caller handed half a comment
+// with no sign of it reasons over the half confidently, so the assertions below
+// pin all three things the marker has to carry: that the text stops early, how
+// much text there is in total, and the call that returns the rest.
+func TestCommentListTruncatesBody(t *testing.T) {
+	const total = 1234
+	body := strings.Repeat("a", total)
+
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{"comments":[{"id":13674684,"body":"`+body+`"}]}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{},
+		testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+			t.Helper()
+			testutil.CheckMessage(t, result)
+
+			got := commentBodiesFromToolResult(t, result)
+			if len(got) != 1 {
+				t.Fatalf("expected one comment but got %d", len(got))
+			}
+			if !strings.HasPrefix(got[0], strings.Repeat("a", 500)) {
+				t.Errorf("expected the first 500 characters to survive, got %q", got[0])
+			}
+			if strings.Contains(got[0], strings.Repeat("a", 501)) {
+				t.Errorf("expected the body to stop at 500 characters, got %q", got[0])
+			}
+			for _, want := range []string{"truncated", "1,234 chars total", "id=13674684"} {
+				if !strings.Contains(got[0], want) {
+					t.Errorf("expected the marker to carry %q but got %q", want, got[0])
+				}
+			}
+			if !strings.Contains(got[0], twprojects.MethodCommentGet.String()) {
+				t.Errorf("expected the marker to name %s but got %q", twprojects.MethodCommentGet, got[0])
+			}
+		}))
+}
+
+// TestCommentListLeavesShortBodyAlone is the control on the cap. The median
+// comment is under it, so a truncation that fired on every record would be
+// paying the marker's cost on the majority of a response for nothing.
+func TestCommentListLeavesShortBodyAlone(t *testing.T) {
+	// Multi-byte characters make this a rune count rather than a byte count:
+	// 500 emoji are 2000 bytes, and cutting by bytes would both truncate a body
+	// that is within the cap and split a character while doing it.
+	for name, body := range map[string]string{
+		"short":    "Looks good to me",
+		"at limit": strings.Repeat("a", 500),
+		"emoji":    strings.Repeat("🙂", 500),
+	} {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("failed to encode body: %v", err)
+			}
+
+			mcpServer := mcpServerMock(t, http.StatusOK,
+				[]byte(`{"comments":[{"id":1,"body":`+string(encoded)+`}]}`))
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{},
+				testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+					t.Helper()
+					testutil.CheckMessage(t, result)
+
+					got := commentBodiesFromToolResult(t, result)
+					if len(got) != 1 {
+						t.Fatalf("expected one comment but got %d", len(got))
+					}
+					if got[0] != body {
+						t.Errorf("expected the body untouched but got %q", got[0])
+					}
+				}))
+		})
+	}
+}
+
+// TestCommentListTruncatesSelectedBody guards that naming body in `fields` does
+// not opt out of the cap: an explicit selection of body across a few hundred
+// records is exactly the payload the cap exists to bound, and get_comment
+// returns full text either way.
+func TestCommentListTruncatesSelectedBody(t *testing.T) {
+	body := strings.Repeat("a", 1234)
+
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{"comments":[{"id":7,"body":"`+body+`"}]}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
+		"fields": []any{string(projects.CommentFieldBody)},
+	}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+		t.Helper()
+		testutil.CheckMessage(t, result)
+
+		got := commentBodiesFromToolResult(t, result)
+		if len(got) != 1 {
+			t.Fatalf("expected one comment but got %d", len(got))
+		}
+		if !strings.Contains(got[0], "truncated") {
+			t.Errorf("expected a selected body to be truncated too, got %q", got[0])
+		}
+	}))
+}
+
+// commentBodiesFromToolResult decodes the comment bodies out of a list_comments
+// tool result.
+func commentBodiesFromToolResult(t *testing.T, result mcp.Result) []string {
+	t.Helper()
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", result)
+	}
+	text, ok := toolResult.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type: %T", toolResult.Content[0])
+	}
+	var payload struct {
+		Comments []struct {
+			Body string `json:"body"`
+		} `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
+		t.Fatalf("failed to decode tool output: %v", err)
+	}
+	bodies := make([]string, len(payload.Comments))
+	for i, comment := range payload.Comments {
+		bodies[i] = comment.Body
+	}
+	return bodies
 }
 
 func TestCommentListByFileVersion(t *testing.T) {


### PR DESCRIPTION
## Description

`twprojects-list_comments` returns full comment bodies, twice, with no length limit. Comment bodies in practice are not short — many are bot-posted PR summaries or long agent-generated reports — so list responses routinely run into the hundreds of thousands of tokens.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors