### PR TITLE
Fix: Filter comments by user IDs

### DIFF
--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -459,6 +459,13 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"user_ids": {
+						Description: "A list of user IDs to filter comments by",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+							{Type: "null"},
+						},
+					},
 					"file_version_id": {
 						Description: "The ID of the file version to retrieve comments for. Each file can have multiple versions, " +
 							"and comments can be associated with specific versions.",
@@ -500,6 +507,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 				helpers.OptionalParam(&verbose, "verbose"),
 				helpers.OptionalFieldsParam[projects.Comment](&commentListRequest.Filters.Fields.Comments, "fields"),
+				helpers.OptionalNumericListParam(&commentListRequest.Filters.UserIDs, "user_ids"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -501,13 +501,13 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericParam(&commentListRequest.Path.NotebookID, "notebook_id"),
 				helpers.OptionalNumericParam(&commentListRequest.Path.LinkID, "link_id"),
 				helpers.OptionalNumericParam(&commentListRequest.Path.FileVersionID, "file_version_id"),
+				helpers.OptionalNumericListParam(&commentListRequest.Filters.UserIDs, "user_ids"),
 				helpers.OptionalParam(&commentListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalTimeParam(&commentListRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&commentListRequest.Filters.PageSize, "page_size"),
 				helpers.OptionalParam(&verbose, "verbose"),
 				helpers.OptionalFieldsParam[projects.Comment](&commentListRequest.Filters.Fields.Comments, "fields"),
-				helpers.OptionalNumericListParam(&commentListRequest.Filters.UserIDs, "user_ids"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil

--- a/internal/twprojects/comments_test.go
+++ b/internal/twprojects/comments_test.go
@@ -337,3 +337,17 @@ func TestCommentListByLink(t *testing.T) {
 		"page_size":     float64(10),
 	})
 }
+
+func TestCommentListByUsers(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodCommentList.String(), map[string]any{
+		"user_ids":      []any{float64(123), float64(456)},
+		"updated_after": "2025-01-01T00:00:00Z",
+		"page":          float64(1),
+		"page_size":     float64(10),
+	})
+
+	if got := lastURL.Query().Get("userIds"); got != "123,456" {
+		t.Errorf("expected userIds=123,456 in the outgoing query but got %q", got)
+	}
+}


### PR DESCRIPTION
## Description

This allows users to retrieve comments made by specific users, enhancing the ability to analyze and manage feedback within the project.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors