### PR TITLE
Fix: Search - stop hardcoding sideloads and truncate returned content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/teamwork/desksdkgo v1.0.1
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.20.8
+	github.com/teamwork/twapi-go-sdk v1.20.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.0.1 h1:Mi5D1pnGfL5JwD7s7g7OyHml7Y9jsak5MNJaotJt
 github.com/teamwork/desksdkgo v1.0.1/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.20.8 h1:qFt8kSnfY7Qy0Hh2L/7xceOQV8wwqKSHSb9to0x9dMo=
-github.com/teamwork/twapi-go-sdk v1.20.8/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
+github.com/teamwork/twapi-go-sdk v1.20.9 h1:tj8VvYnuRDwkNK4rsAP4E/QfhQBfF6pEDvVErfzm3JM=
+github.com/teamwork/twapi-go-sdk v1.20.9/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/comments.go
+++ b/internal/twprojects/comments.go
@@ -58,18 +58,6 @@ var commentListFields = slices.DeleteFunc(
 	},
 )
 
-// commentBodyLimit is how many characters of a comment body list_comments
-// returns before truncating it.
-//
-// Comment bodies are not short in practice: bots post build summaries and
-// agents post long reports, so a list of a few hundred routinely ran to
-// hundreds of thousands of tokens. The distribution is what makes a cap work —
-// across one real account the median body was 484 characters while the top 5%
-// of records held 52.8% of all body text. A 500-character cap therefore leaves
-// roughly three quarters of comments untouched and still removes ~90% of the
-// payload. Full text stays one get_comment away.
-const commentBodyLimit = 500
-
 func init() {
 	var err error
 
@@ -420,7 +408,7 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 		Tool: &mcp.Tool{
 			Name: string(MethodCommentList),
 			Description: "List comments. Scope by one of task_id, milestone_id, notebook_id, link_id, or file_version_id; " +
-				"omit all for site-wide. Comment bodies are truncated at " + strconv.Itoa(commentBodyLimit) +
+				"omit all for site-wide. Comment bodies are truncated at " + strconv.Itoa(contentTruncationLimit) +
 				" characters and marked where they are cut; use " + string(MethodCommentGet) + " for the full text.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "List Comments",
@@ -552,23 +540,10 @@ func CommentList(engine *twapi.Engine) toolsets.ToolWrapper {
 	}
 }
 
-// truncateCommentBodies caps the body of every comment in a raw list_comments
-// response at commentBodyLimit characters, appending a marker naming how much
-// was cut and how to get the rest.
-//
-// The marker is not decoration. Silent truncation is worse than none: a caller
-// handed half a comment with no sign of it reasons over the half confidently.
-// It goes inline at the point the text stops rather than into a sibling field
-// so it is read as part of the content, survives any later reshaping of the
-// record, and needs no change to the published schema — body is still a string.
-//
-// It applies whether or not the caller named `fields`: an explicit selection of
-// body across a few hundred records is exactly the payload this exists to
-// bound, and get_comment is the way to full text either way.
-//
-// Anything unexpected leaves the payload untouched, matching how WebLinker
-// treats a body it cannot parse: returning the response whole is always
-// preferable to failing a read the API already answered.
+// truncateCommentBodies caps every comment body in a raw list_comments
+// response, even when the caller named body in `fields`. Anything unexpected
+// leaves the payload untouched: returning the response whole beats failing a
+// read the API already answered.
 func truncateCommentBodies(data []byte) []byte {
 	var decoded map[string]any
 	if err := json.Unmarshal(data, &decoded); err != nil {
@@ -589,7 +564,7 @@ func truncateCommentBodies(data []byte) []byte {
 		if !ok {
 			continue
 		}
-		short, ok := truncateCommentBody(body, comment["id"])
+		short, ok := truncateContent(body, MethodCommentGet, comment["id"])
 		if !ok {
 			continue
 		}
@@ -605,66 +580,6 @@ func truncateCommentBodies(data []byte) []byte {
 		return data
 	}
 	return encoded
-}
-
-// truncateCommentBody shortens a single body, reporting whether it had to. The
-// marker carries all three things a caller needs at the point of the cut: that
-// the text stops early, how much text there is in total, and the call that
-// returns the rest. A bare "truncated" would not distinguish 520 characters
-// missing from 128,927, which are very different decisions.
-func truncateCommentBody(body string, id any) (string, bool) {
-	// Byte length is never below rune count, so this rejects the common case
-	// without allocating.
-	if len(body) <= commentBodyLimit {
-		return body, false
-	}
-	runes := []rune(body)
-	if len(runes) <= commentBodyLimit {
-		return body, false
-	}
-
-	var marker strings.Builder
-	fmt.Fprintf(&marker, "...[truncated — %s chars total", formatThousands(len(runes)))
-	if commentID := formatCommentID(id); commentID != "" {
-		fmt.Fprintf(&marker, ", %s(id=%s) for full text", MethodCommentGet, commentID)
-	}
-	marker.WriteString("]")
-
-	return string(runes[:commentBodyLimit]) + marker.String(), true
-}
-
-// formatCommentID renders the id of a decoded comment for the truncation
-// marker, or an empty string when there is nothing addressable to point at. A
-// caller can exclude id from `fields`, but the handler appends it to any
-// selection, so in practice this only gives up on a malformed record.
-func formatCommentID(id any) string {
-	switch value := id.(type) {
-	case float64:
-		if math.Trunc(value) == value {
-			return strconv.FormatInt(int64(value), 10)
-		}
-	case string:
-		return value
-	}
-	return ""
-}
-
-// formatThousands renders a non-negative count with thousands separators, so
-// the scale of what is missing reads at a glance rather than by counting
-// digits.
-func formatThousands(n int) string {
-	digits := strconv.Itoa(n)
-	if len(digits) <= 3 {
-		return digits
-	}
-	var formatted strings.Builder
-	for i, digit := range digits {
-		if i > 0 && (len(digits)-i)%3 == 0 {
-			formatted.WriteRune(',')
-		}
-		formatted.WriteRune(digit)
-	}
-	return formatted.String()
 }
 
 func commentPathBuilder(object map[string]any) string {

--- a/internal/twprojects/search.go
+++ b/internal/twprojects/search.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -21,6 +24,61 @@ const (
 	MethodSearch toolsets.Method = "twprojects-search"
 )
 
+// searchSideloads is every sideload the SDK models, and the default when the
+// caller does not narrow `include`. The API also accepts files and
+// fileversions, but the SDK does not model those sideloads yet.
+var searchSideloads = []projects.SearchRequestSideload{
+	projects.SearchRequestSideloadComments,
+	projects.SearchRequestSideloadCompanies,
+	projects.SearchRequestSideloadLinks,
+	projects.SearchRequestSideloadMessages,
+	projects.SearchRequestSideloadMilestones,
+	projects.SearchRequestSideloadNotebooks,
+	projects.SearchRequestSideloadProjects,
+	projects.SearchRequestSideloadTasklists,
+	projects.SearchRequestSideloadTasks,
+	projects.SearchRequestSideloadTeams,
+	projects.SearchRequestSideloadTimelogs,
+	projects.SearchRequestSideloadUsers,
+}
+
+// searchTruncatedFields maps each sideload section to its free-form content
+// fields and the tool that returns the full record. Note the comment sideload
+// serializes the comment's content under "title".
+var searchTruncatedFields = map[string]struct {
+	fields []string
+	method toolsets.Method
+}{
+	"comments":   {fields: []string{"title"}, method: MethodCommentGet},
+	"links":      {fields: []string{"description"}, method: MethodLinkGet},
+	"messages":   {fields: []string{"body"}, method: MethodMessageGet},
+	"milestones": {fields: []string{"description"}, method: MethodMilestoneGet},
+	"notebooks":  {fields: []string{"description", "contents"}, method: MethodNotebookGet},
+	"projects":   {fields: []string{"description"}, method: MethodProjectGet},
+	"tasklists":  {fields: []string{"description"}, method: MethodTasklistGet},
+	"tasks":      {fields: []string{"description"}, method: MethodTaskGet},
+	"teams":      {fields: []string{"description"}, method: MethodTeamGet},
+	"timelogs":   {fields: []string{"description"}, method: MethodTimelogGet},
+}
+
+// searchMinimalFields is what each sideloaded record carries when
+// verbose=false: id plus its identifying label. A comment's content doubles as
+// its label ("title") and is capped by truncation like any other field.
+var searchMinimalFields = projects.SearchFields{
+	Comments:   []projects.CommentSideloadField{projects.CommentSideloadFieldID, projects.CommentSideloadFieldBody},
+	Companies:  []projects.CompanyField{projects.CompanyFieldID, projects.CompanyFieldName},
+	Links:      []projects.LinkField{projects.LinkFieldID, projects.LinkFieldTitle},
+	Messages:   []projects.MessageField{projects.MessageFieldID, projects.MessageFieldTitle},
+	Milestones: []projects.MilestoneField{projects.MilestoneFieldID, projects.MilestoneFieldName},
+	Notebooks:  []projects.NotebookField{projects.NotebookFieldID, projects.NotebookFieldName},
+	Projects:   []projects.ProjectField{projects.ProjectFieldID, projects.ProjectFieldName},
+	Tasklists:  []projects.TasklistField{projects.TasklistFieldID, projects.TasklistFieldName},
+	Tasks:      []projects.TaskField{projects.TaskFieldID, projects.TaskFieldName},
+	Teams:      []projects.TeamField{projects.TeamFieldID, projects.TeamFieldName},
+	Timelogs:   []projects.TimelogField{projects.TimelogFieldID, projects.TimelogFieldDescription},
+	Users:      []projects.UserField{projects.UserFieldID, projects.UserFieldFirstName, projects.UserFieldLastName},
+}
+
 var (
 	searchOutputSchema *jsonschema.Schema
 )
@@ -37,10 +95,18 @@ func init() {
 
 // Search lists searches in Teamwork.com.
 func Search(engine *twapi.Engine) toolsets.ToolWrapper {
+	searchIncludeEnum := make([]any, len(searchSideloads))
+	for i, sideload := range searchSideloads {
+		searchIncludeEnum[i] = string(sideload)
+	}
+
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodSearch),
-			Description: "Cross-entity keyword search across projects, tasks, files, messages, and more.",
+			Name: string(MethodSearch),
+			Description: "Cross-entity keyword search across projects, tasks, files, messages, and more. " +
+				"Long content fields in the sideloaded records are truncated at " +
+				strconv.Itoa(contentTruncationLimit) + " characters and marked where they are cut; " +
+				"the marker names the tool that returns the full record.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Search",
 				ReadOnlyHint:    true,
@@ -79,6 +145,20 @@ func Search(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"include": {
+						Description: "Entity types to return as full records in the response sideloads. " +
+							"Defaults to all supported types; narrow it to the types of interest to keep the response small.",
+						AnyOf: []*jsonschema.Schema{
+							{
+								Type: "array",
+								Items: &jsonschema.Schema{
+									Type: "string",
+									Enum: searchIncludeEnum,
+								},
+							},
+							{Type: "null"},
+						},
+					},
 					"cursor": {
 						Description: "Cursor for pagination of results.",
 						AnyOf: []*jsonschema.Schema{
@@ -93,62 +173,123 @@ func Search(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"verbose": helpers.VerboseSchema(),
 				},
 				Required: []string{"search_term"},
 			},
-			OutputSchema: searchOutputSchema,
+			OutputSchema: helpers.WithOptionalFields(searchOutputSchema),
 		},
 		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var searchRequest projects.SearchRequest
-			searchRequest.Filters.Include = []projects.SearchRequestSideload{
-				projects.SearchRequestSideloadComments,
-				projects.SearchRequestSideloadCompanies,
-				projects.SearchRequestSideloadLinks,
-				projects.SearchRequestSideloadMessages,
-				projects.SearchRequestSideloadMilestones,
-				projects.SearchRequestSideloadNotebooks,
-				projects.SearchRequestSideloadProjects,
-				projects.SearchRequestSideloadTasklists,
-				projects.SearchRequestSideloadTasks,
-				projects.SearchRequestSideloadTeams,
-				projects.SearchRequestSideloadTimelogs,
-				projects.SearchRequestSideloadUsers,
-			}
+			searchRequest.Filters.Include = searchSideloads
 
 			var arguments map[string]any
 			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
 				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
 			}
+			verbose := true
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredParam(&searchRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericParam(&searchRequest.Filters.ProjectID, "project_id"),
 				helpers.OptionalPointerParam(&searchRequest.Filters.IncludeCompletedItems, "include_completed_items"),
 				helpers.OptionalTimeParam(&searchRequest.Filters.UpdatedAfter, "updated_after"),
 				helpers.OptionalPointerParam(&searchRequest.Filters.ExtendedSearch, "extended_search"),
+				helpers.OptionalListParam(&searchRequest.Filters.Include, "include",
+					helpers.RestrictValues(searchSideloads...)),
 				helpers.OptionalParam(&searchRequest.Filters.Cursor, "cursor"),
 				helpers.OptionalNumericParam(&searchRequest.Filters.Limit, "limit"),
+				helpers.OptionalParam(&verbose, "verbose"),
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
 			}
 
-			search, err := projects.Search(ctx, engine, searchRequest)
-			if err != nil {
-				return helpers.HandleAPIError(err, "failed to list searches")
+			if !verbose {
+				searchRequest.Filters.Fields = searchMinimalFields
 			}
 
-			encoded, err := json.Marshal(search)
+			resp, err := twapi.ExecuteRaw(ctx, engine, searchRequest)
 			if err != nil {
-				return nil, err
+				return helpers.HandleAPIError(err, "failed to search")
 			}
-			return &mcp.CallToolResult{
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode != http.StatusOK {
+				return helpers.HandleAPIError(twapi.NewHTTPError(resp, "failed to search"), "failed to search")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			truncated := truncateSearchSideloads(body)
+			result := &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: string(encoded),
-					},
+					&mcp.TextContent{Text: string(truncated)},
 				},
-				StructuredContent: search,
-			}, nil
+			}
+			var structured any
+			if err := json.Unmarshal(truncated, &structured); err != nil {
+				return nil, fmt.Errorf("failed to decode response: %w", err)
+			}
+			result.StructuredContent = structured
+			return result, nil
 		},
 	}
+}
+
+// truncateSearchSideloads caps the content fields named in
+// searchTruncatedFields across a raw search response. Anything unexpected
+// leaves the payload untouched: returning the response whole beats failing a
+// read the API already answered.
+func truncateSearchSideloads(data []byte) []byte {
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return data
+	}
+	included, ok := decoded["included"].(map[string]any)
+	if !ok {
+		return data
+	}
+
+	var truncated bool
+	for section, truncation := range searchTruncatedFields {
+		records, ok := included[section].(map[string]any)
+		if !ok {
+			continue
+		}
+		for key, item := range records {
+			record, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			id := record["id"]
+			if id == nil {
+				// sideload sections are keyed by the record's ID
+				id = key
+			}
+			for _, field := range truncation.fields {
+				content, ok := record[field].(string)
+				if !ok {
+					continue
+				}
+				short, ok := truncateContent(content, truncation.method, id)
+				if !ok {
+					continue
+				}
+				record[field] = short
+				truncated = true
+			}
+		}
+	}
+	if !truncated {
+		return data
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return data
+	}
+	return encoded
 }

--- a/internal/twprojects/search_test.go
+++ b/internal/twprojects/search_test.go
@@ -1,9 +1,12 @@
 package twprojects_test
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/testutil"
 	"github.com/teamwork/mcp/internal/twprojects"
 )
@@ -16,7 +19,207 @@ func TestSearch(t *testing.T) {
 		"include_completed_items": true,
 		"updated_after":           "2023-01-01T00:00:00Z",
 		"extended_search":         true,
+		"include":                 []any{"tasks", "projects"},
 		"cursor":                  "c858b04ba8b066bcb4f83727c23de6e9238de642",
 		"limit":                   float64(10),
 	})
+}
+
+// TestSearchDefaultSideloads pins that an unnarrowed search asks for every
+// sideload the SDK models.
+func TestSearchDefaultSideloads(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+	})
+
+	want := "comments,companies,links,messages,milestones,notebooks,projects,tasklists,tasks,teams,timelogs,users"
+	if got := lastURL.Query().Get("include"); got != want {
+		t.Errorf("expected include=%q but got %q", want, got)
+	}
+}
+
+// TestSearchIncludeNarrowsSideloads guards that `include` replaces the
+// default sideload list rather than adding to it.
+func TestSearchIncludeNarrowsSideloads(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+		"include":     []any{"tasks", "projects"},
+	})
+
+	if got := lastURL.Query().Get("include"); got != "tasks,projects" {
+		t.Errorf("expected include=%q but got %q", "tasks,projects", got)
+	}
+}
+
+// TestSearchVerboseDefaultSendsNoSparseFields pins that the default keeps the
+// API's full records, leaving size control to truncation.
+func TestSearchVerboseDefaultSendsNoSparseFields(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+	})
+
+	for key := range lastURL.Query() {
+		if strings.HasPrefix(key, "fields[") {
+			t.Errorf("unexpected sparse-fields parameter %q on a verbose search", key)
+		}
+	}
+}
+
+// TestSearchVerboseFalseRequestsMinimalFields guards that verbose=false asks
+// the API for id + label per sideloaded entity instead of full records.
+func TestSearchVerboseFalseRequestsMinimalFields(t *testing.T) {
+	mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+		"verbose":     false,
+	})
+
+	query := lastURL.Query()
+	for key, want := range map[string]string{
+		"fields[comments]": "id,title",
+		"fields[tasks]":    "id,name",
+		"fields[users]":    "id,firstName,lastName",
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("expected %s=%q but got %q", key, want, got)
+		}
+	}
+}
+
+// TestSearchIncludeRejectsUnknownType guards that a misspelled entity type
+// fails loudly instead of being silently ignored.
+func TestSearchIncludeRejectsUnknownType(t *testing.T) {
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+		"include":     []any{"task"},
+	}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+		toolResult, ok := result.(*mcp.CallToolResult)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", result)
+		}
+		if !toolResult.IsError {
+			t.Errorf("expected an error for an unknown include value")
+		}
+	}))
+}
+
+// TestSearchTruncatesSideloadContent covers the content cap per sideload
+// section (each keeps content under a different attribute) and the marker
+// naming the per-entity get tool.
+func TestSearchTruncatesSideloadContent(t *testing.T) {
+	long := strings.Repeat("a", 1234)
+
+	response := `{
+		"search": [{"id": 1, "type": "tasks"}],
+		"included": {
+			"comments": {"11": {"id": 11, "title": "` + long + `"}},
+			"messages": {"22": {"id": 22, "title": "subject", "body": "` + long + `"}},
+			"tasks": {"33": {"id": 33, "name": "a task", "description": "` + long + `"}}
+		}
+	}`
+
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(response))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+	}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+		t.Helper()
+		testutil.CheckMessage(t, result)
+
+		included := searchIncludedFromToolResult(t, result)
+		for _, entry := range []struct {
+			section string
+			id      string
+			field   string
+			method  string
+		}{
+			{"comments", "11", "title", twprojects.MethodCommentGet.String()},
+			{"messages", "22", "body", twprojects.MethodMessageGet.String()},
+			{"tasks", "33", "description", twprojects.MethodTaskGet.String()},
+		} {
+			got, ok := included[entry.section][entry.id][entry.field].(string)
+			if !ok {
+				t.Fatalf("expected a string at included.%s.%s.%s", entry.section, entry.id, entry.field)
+			}
+			if !strings.HasPrefix(got, strings.Repeat("a", 500)) {
+				t.Errorf("expected the first 500 characters of %s.%s to survive, got %q",
+					entry.section, entry.field, got)
+			}
+			if strings.Contains(got, strings.Repeat("a", 501)) {
+				t.Errorf("expected %s.%s to stop at 500 characters, got %q",
+					entry.section, entry.field, got)
+			}
+			for _, want := range []string{"truncated", "1,234 chars total", "id=" + entry.id, entry.method} {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected the %s.%s marker to carry %q but got %q",
+						entry.section, entry.field, want, got)
+				}
+			}
+		}
+
+		// A message's title is its subject line, not its content, so it stays.
+		if got := included["messages"]["22"]["title"]; got != "subject" {
+			t.Errorf("expected the message title untouched but got %q", got)
+		}
+	}))
+}
+
+// TestSearchLeavesShortContentAlone is the control: content within the limit
+// comes back untouched.
+func TestSearchLeavesShortContentAlone(t *testing.T) {
+	// 500 emoji are 2000 bytes: guards that the cap counts runes, not bytes.
+	emoji := strings.Repeat("🙂", 500)
+	encodedEmoji, err := json.Marshal(emoji)
+	if err != nil {
+		t.Fatalf("failed to encode body: %v", err)
+	}
+
+	response := `{
+		"search": [{"id": 1, "type": "tasks"}],
+		"included": {
+			"comments": {"11": {"id": 11, "title": "short comment"}},
+			"tasks": {"33": {"id": 33, "description": ` + string(encodedEmoji) + `}}
+		}
+	}`
+
+	mcpServer := mcpServerMock(t, http.StatusOK, []byte(response))
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodSearch.String(), map[string]any{
+		"search_term": "test",
+	}, testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+		t.Helper()
+		testutil.CheckMessage(t, result)
+
+		included := searchIncludedFromToolResult(t, result)
+		if got := included["comments"]["11"]["title"]; got != "short comment" {
+			t.Errorf("expected the comment content untouched but got %q", got)
+		}
+		if got := included["tasks"]["33"]["description"]; got != emoji {
+			t.Errorf("expected the task description untouched but got %q", got)
+		}
+	}))
+}
+
+// searchIncludedFromToolResult decodes the sideload sections out of a search
+// tool result.
+func searchIncludedFromToolResult(t *testing.T, result mcp.Result) map[string]map[string]map[string]any {
+	t.Helper()
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", result)
+	}
+	text, ok := toolResult.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type: %T", toolResult.Content[0])
+	}
+	var payload struct {
+		Included map[string]map[string]map[string]any `json:"included"`
+	}
+	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
+		t.Fatalf("failed to decode tool output: %v", err)
+	}
+	return payload.Included
 }

--- a/internal/twprojects/truncate.go
+++ b/internal/twprojects/truncate.go
@@ -1,0 +1,69 @@
+package twprojects
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/teamwork/mcp/internal/toolsets"
+)
+
+// contentTruncationLimit caps content-bearing fields in list-shaped responses.
+// Most records fit under it while the long tail (bot reports, agent summaries)
+// no longer dominates the payload; full text stays one get call away.
+const contentTruncationLimit = 500
+
+// truncateContent shortens a content field, reporting whether it had to. The
+// marker is inline so the cut cannot be missed, and names the total size and
+// the call that returns the full text.
+func truncateContent(content string, method toolsets.Method, id any) (string, bool) {
+	// Byte length is never below rune count, so this rejects the common case
+	// without allocating.
+	if len(content) <= contentTruncationLimit {
+		return content, false
+	}
+	runes := []rune(content)
+	if len(runes) <= contentTruncationLimit {
+		return content, false
+	}
+
+	var marker strings.Builder
+	fmt.Fprintf(&marker, "...[truncated — %s chars total", formatThousands(len(runes)))
+	if entityID := formatEntityID(id); entityID != "" {
+		fmt.Fprintf(&marker, ", %s(id=%s) for full text", method, entityID)
+	}
+	marker.WriteString("]")
+
+	return string(runes[:contentTruncationLimit]) + marker.String(), true
+}
+
+// formatEntityID renders a decoded record's id for the truncation marker, or
+// an empty string when there is nothing addressable to point at.
+func formatEntityID(id any) string {
+	switch value := id.(type) {
+	case float64:
+		if math.Trunc(value) == value {
+			return strconv.FormatInt(int64(value), 10)
+		}
+	case string:
+		return value
+	}
+	return ""
+}
+
+// formatThousands renders a non-negative count with thousands separators.
+func formatThousands(n int) string {
+	digits := strconv.Itoa(n)
+	if len(digits) <= 3 {
+		return digits
+	}
+	var formatted strings.Builder
+	for i, digit := range digits {
+		if i > 0 && (len(digits)-i)%3 == 0 {
+			formatted.WriteRune(',')
+		}
+		formatted.WriteRune(digit)
+	}
+	return formatted.String()
+}


### PR DESCRIPTION
## Description

Search responses ran to hundreds of thousands of tokens on content-heavy accounts. Long fields in sideloaded records are now truncated at 500 chars with an inline marker naming the get tool that returns the full record (same approach as `list_comments`).

New `include` parameter narrows which entity types are sideloaded, and `verbose=false` requests id + label per entity via sparse fieldsets.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors