### PR TITLE
Enhancement: Use the tasklist project hint in the skills and roles prompt

### DIFF
--- a/internal/helpers/relationship.go
+++ b/internal/helpers/relationship.go
@@ -1,0 +1,54 @@
+package helpers
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// RelationshipMetaID reads a numeric ID out of a relationship's meta bag.
+//
+// The v3 API attaches hints to a relationship under "meta" — a task's tasklist
+// relationship, for instance, carries the "projectId" the tasklist belongs to,
+// which saves loading the tasklist just to resolve its project. The bag is
+// decoded as map[string]any, so a JSON number arrives as float64; the other
+// cases are covered for callers that decode with json.Number or receive the
+// value as a string.
+//
+// It reports false when the key is absent, holds a non-numeric value, or is not
+// a positive ID, so callers can fall back to whatever they did before the hint
+// existed.
+func RelationshipMetaID(meta map[string]any, key string) (int64, bool) {
+	value, ok := meta[key]
+	if !ok {
+		return 0, false
+	}
+
+	var id int64
+	switch v := value.(type) {
+	case float64:
+		id = int64(v)
+	case int64:
+		id = v
+	case int:
+		id = int64(v)
+	case json.Number:
+		parsed, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		id = parsed
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		id = parsed
+	default:
+		return 0, false
+	}
+
+	if id <= 0 {
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/helpers/relationship_test.go
+++ b/internal/helpers/relationship_test.go
@@ -1,0 +1,83 @@
+package helpers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/teamwork/mcp/internal/helpers"
+)
+
+func TestRelationshipMetaID(t *testing.T) {
+	tests := []struct {
+		name  string
+		meta  map[string]any
+		key   string
+		want  int64
+		wantR bool
+	}{{
+		name:  "json number decoded as float64",
+		meta:  map[string]any{"projectId": float64(5)},
+		key:   "projectId",
+		want:  5,
+		wantR: true,
+	}, {
+		name:  "int64",
+		meta:  map[string]any{"projectId": int64(5)},
+		key:   "projectId",
+		want:  5,
+		wantR: true,
+	}, {
+		name:  "int",
+		meta:  map[string]any{"projectId": 5},
+		key:   "projectId",
+		want:  5,
+		wantR: true,
+	}, {
+		name:  "json.Number",
+		meta:  map[string]any{"projectId": json.Number("5")},
+		key:   "projectId",
+		want:  5,
+		wantR: true,
+	}, {
+		name:  "string",
+		meta:  map[string]any{"projectId": "5"},
+		key:   "projectId",
+		want:  5,
+		wantR: true,
+	}, {
+		name: "missing key",
+		meta: map[string]any{"other": float64(5)},
+		key:  "projectId",
+	}, {
+		name: "nil meta",
+		key:  "projectId",
+	}, {
+		name: "zero is not an ID",
+		meta: map[string]any{"projectId": float64(0)},
+		key:  "projectId",
+	}, {
+		name: "negative is not an ID",
+		meta: map[string]any{"projectId": float64(-1)},
+		key:  "projectId",
+	}, {
+		name: "unparsable string",
+		meta: map[string]any{"projectId": "abc"},
+		key:  "projectId",
+	}, {
+		name: "unexpected type",
+		meta: map[string]any{"projectId": []any{float64(5)}},
+		key:  "projectId",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := helpers.RelationshipMetaID(tt.meta, tt.key)
+			if ok != tt.wantR {
+				t.Errorf("expected ok %t, got %t", tt.wantR, ok)
+			}
+			if got != tt.want {
+				t.Errorf("expected id %d, got %d", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/twprojects/tasks_prompts.go
+++ b/internal/twprojects/tasks_prompts.go
@@ -2,11 +2,14 @@ package twprojects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/teamwork/mcp/internal/helpers"
 	"github.com/teamwork/mcp/internal/toolsets"
 	"github.com/teamwork/twapi-go-sdk"
 	"github.com/teamwork/twapi-go-sdk/projects"
@@ -50,16 +53,49 @@ func TaskSkillsAndRolesPrompt(engine *twapi.Engine) toolsets.ServerPrompt {
 				return nil, fmt.Errorf("failed to get task: %w", err)
 			}
 
-			tasklistResponse, err := projects.TasklistGet(ctx, engine,
-				projects.NewTasklistGetRequest(taskResponse.Task.Tasklist.ID))
-			if err != nil {
-				return nil, fmt.Errorf("failed to get tasklist: %w", err)
+			var (
+				tasklistResponse *projects.TasklistGetResponse
+				projectResponse  *projects.ProjectGetResponse
+			)
+
+			tasklistID := taskResponse.Task.Tasklist.ID
+			loadTasklist := func() error {
+				var err error
+				tasklistResponse, err = projects.TasklistGet(ctx, engine, projects.NewTasklistGetRequest(tasklistID))
+				if err != nil {
+					return fmt.Errorf("failed to get tasklist: %w", err)
+				}
+				return nil
+			}
+			loadProject := func(projectID int64) error {
+				var err error
+				projectResponse, err = projects.ProjectGet(ctx, engine, projects.NewProjectGetRequest(projectID))
+				if err != nil {
+					return fmt.Errorf("failed to get project: %w", err)
+				}
+				return nil
 			}
 
-			projectResponse, err := projects.ProjectGet(ctx, engine,
-				projects.NewProjectGetRequest(tasklistResponse.Tasklist.Project.ID))
-			if err != nil {
-				return nil, fmt.Errorf("failed to get project: %w", err)
+			// The task's tasklist relationship hints which project it belongs to, so
+			// the tasklist — still loaded for its name — and the project no longer
+			// have to be fetched one after the other.
+			if projectID, ok := helpers.RelationshipMetaID(taskResponse.Task.Tasklist.Meta, "projectId"); ok {
+				var wg sync.WaitGroup
+				var tasklistErr, projectErr error
+				wg.Go(func() { tasklistErr = loadTasklist() })
+				wg.Go(func() { projectErr = loadProject(projectID) })
+				wg.Wait()
+				if err := errors.Join(tasklistErr, projectErr); err != nil {
+					return nil, err
+				}
+			} else {
+				// Sites on an API without the hint still pay the chained round trip.
+				if err := loadTasklist(); err != nil {
+					return nil, err
+				}
+				if err := loadProject(tasklistResponse.Tasklist.Project.ID); err != nil {
+					return nil, err
+				}
 			}
 
 			skillsNext, err := twapi.Iterate[projects.SkillListRequest, *projects.SkillListResponse](

--- a/internal/twprojects/tasks_prompts_test.go
+++ b/internal/twprojects/tasks_prompts_test.go
@@ -1,0 +1,130 @@
+package twprojects_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/teamwork/mcp/internal/testutil"
+	"github.com/teamwork/mcp/internal/twprojects"
+	"github.com/teamwork/twapi-go-sdk"
+)
+
+// taskSkillsAndRolesEngine serves the endpoints the task skills and roles prompt
+// walks, recording every path it requests. The tasklist reports a different
+// project than the task's tasklist relationship hints at, so the recorded
+// project path tells which of the two the prompt trusted.
+func taskSkillsAndRolesEngine(t *testing.T, tasklistMeta string) (*twapi.Engine, *[]string) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var paths []string
+
+	bodies := map[string]string{
+		"/v3/tasks/": fmt.Sprintf(`{"task":{"id":1,"name":"Ship it","tasklist":{"id":12,"type":"tasklists"%s}}}`,
+			tasklistMeta),
+		"/v3/tasklists/": `{"tasklist":{"id":12,"name":"Sprint 1","project":{"id":999,"type":"projects"}}}`,
+		"/v3/projects/":  `{"project":{"id":5,"name":"Apollo"}}`,
+		"/v3/skills":     `{"skills":[{"id":1,"name":"Go"}],"meta":{"page":{"hasMore":false}}}`,
+		"/v3/jobroles":   `{"jobRoles":[{"id":2,"name":"Engineer"}],"meta":{"page":{"hasMore":false}}}`,
+	}
+
+	engine := twapi.NewEngine(testutil.ProjectsSessionMock{}, twapi.WithMiddleware(func(twapi.HTTPClient) twapi.HTTPClient {
+		return twapi.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+			mu.Lock()
+			paths = append(paths, req.URL.Path)
+			mu.Unlock()
+
+			body := "{}"
+			for match, candidate := range bodies {
+				if strings.Contains(req.URL.Path, match) {
+					body = candidate
+					break
+				}
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     http.StatusText(http.StatusOK),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		})
+	}))
+
+	return engine, &paths
+}
+
+func runTaskSkillsAndRolesPrompt(t *testing.T, engine *twapi.Engine) *mcp.GetPromptResult {
+	t.Helper()
+
+	prompt := twprojects.TaskSkillsAndRolesPrompt(engine)
+	result, err := prompt.Handler(context.Background(), &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{
+			Name:      "twprojects_task_skills_and_roles",
+			Arguments: map[string]string{"task_id": "1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prompt handler failed: %v", err)
+	}
+	return result
+}
+
+func TestTaskSkillsAndRolesPromptUsesTasklistProjectHint(t *testing.T) {
+	engine, paths := taskSkillsAndRolesEngine(t, `,"meta":{"projectId":5}`)
+	result := runTaskSkillsAndRolesPrompt(t, engine)
+
+	// The hint says project 5; the tasklist says 999. Trusting the hint means the
+	// project fetch no longer waits on the tasklist response.
+	if !containsPath(*paths, "/projects/api/v3/projects/5.json") {
+		t.Errorf("expected the project to be loaded from the tasklist hint, got paths %v", *paths)
+	}
+	if containsPath(*paths, "/projects/api/v3/projects/999.json") {
+		t.Errorf("expected the tasklist project not to be used, got paths %v", *paths)
+	}
+	assertPromptMentions(t, result, "Project Name: Apollo", "Tasklist Name: Sprint 1")
+}
+
+func TestTaskSkillsAndRolesPromptFallsBackWithoutHint(t *testing.T) {
+	engine, paths := taskSkillsAndRolesEngine(t, "")
+	result := runTaskSkillsAndRolesPrompt(t, engine)
+
+	// Without the hint the prompt has to resolve the project through the tasklist.
+	if !containsPath(*paths, "/projects/api/v3/projects/999.json") {
+		t.Errorf("expected the project to be resolved through the tasklist, got paths %v", *paths)
+	}
+	assertPromptMentions(t, result, "Tasklist Name: Sprint 1")
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPromptMentions(t *testing.T, result *mcp.GetPromptResult, wants ...string) {
+	t.Helper()
+
+	var text strings.Builder
+	for _, message := range result.Messages {
+		if content, ok := message.Content.(*mcp.TextContent); ok {
+			text.WriteString(content.Text)
+		}
+	}
+	for _, want := range wants {
+		if !strings.Contains(text.String(), want) {
+			t.Errorf("expected the prompt to contain %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The task's tasklist relationship now carries `meta.projectId`, so the project no longer has to be resolved through the tasklist. The tasklist is still loaded for its name, but both fetches now run in parallel instead of chained.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors