### PR TITLE
Support for tag colors in the Teamwork API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sonh/qs v0.7.0
 	github.com/teamwork/desksdkgo v1.1.0
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.21.2
+	github.com/teamwork/twapi-go-sdk v1.21.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZe
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
 github.com/teamwork/twapi-go-sdk v1.21.2 h1:SsLaxc15Q+m1v+LO0UHWoxCJ+I4wf6uTftfVMzWGOm0=
 github.com/teamwork/twapi-go-sdk v1.21.2/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
+github.com/teamwork/twapi-go-sdk v1.21.3 h1:xTE2l2Xfw9WQLIlWYUNazQM4y4N6K3Y34CJuUO0xTSM=
+github.com/teamwork/twapi-go-sdk v1.21.3/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/tags.go
+++ b/internal/twprojects/tags.go
@@ -66,6 +66,13 @@ func TagCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:        "string",
 						Description: "The name of the tag. It must have less than 50 characters.",
 					},
+					"color": {
+						Description: "The color of the tag. It must be a valid hex color code.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
+					},
 					"project_id": {
 						Description: "The ID of the project to associate the tag with. This is for project-scoped tags.",
 						AnyOf: []*jsonschema.Schema{
@@ -86,6 +93,7 @@ func TagCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 			}
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredParam(&tagCreateRequest.Name, "name"),
+				helpers.OptionalParam(&tagCreateRequest.Color, "color"),
 				helpers.OptionalNumericPointerParam(&tagCreateRequest.ProjectID, "project_id"),
 			)
 			if err != nil {
@@ -126,6 +134,13 @@ func TagUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"color": {
+						Description: "The color of the tag. It must be a valid hex color code.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string"},
+							{Type: "null"},
+						},
+					},
 					"project_id": {
 						Description: "The ID of the project to associate the tag with. This is for project-scoped tags.",
 						AnyOf: []*jsonschema.Schema{
@@ -147,6 +162,7 @@ func TagUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 			err := helpers.ParamGroup(arguments,
 				helpers.RequiredNumericParam(&tagUpdateRequest.Path.ID, "id"),
 				helpers.OptionalPointerParam(&tagUpdateRequest.Name, "name"),
+				helpers.OptionalPointerParam(&tagUpdateRequest.Color, "color"),
 				helpers.OptionalNumericPointerParam(&tagUpdateRequest.ProjectID, "project_id"),
 			)
 			if err != nil {


### PR DESCRIPTION
## Description

This includes adding a "color" field to the tag creation and update requests, as well as updating the JSON schema to reflect this new field. The color must be a valid hex color code and can be either a string or null.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors