### PR TITLE
Feature: Share the HTTP server plumbing via pkg/mcphttp

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -1,26 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
-	"regexp"
-	"slices"
 	"strings"
 	"syscall"
 	"time"
 
-	ddhttp "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/getsentry/sentry-go"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/teamwork/mcp/internal/cli"
 	"github.com/teamwork/mcp/internal/twchat"
@@ -29,20 +20,14 @@ import (
 	"github.com/teamwork/mcp/internal/twspaces"
 	"github.com/teamwork/mcp/pkg/auth"
 	"github.com/teamwork/mcp/pkg/config"
-	"github.com/teamwork/mcp/pkg/logsafe"
-	"github.com/teamwork/mcp/pkg/request"
+	"github.com/teamwork/mcp/pkg/mcphttp"
 	"github.com/teamwork/mcp/pkg/toolsets"
-	"github.com/teamwork/mcp/pkg/twctx"
-	"github.com/teamwork/twapi-go-sdk/session"
 )
 
-var (
-	reBearerToken = regexp.MustCompile(`^Bearer (.+)$`)
-	methods       = cli.NewMethods(toolsets.MethodAll)
-)
+var methods = cli.NewMethods(toolsets.MethodAll)
 
 // Limit request body size (e.g., 10MB)
-const maxBodySize = 10 * 1024 * 1024 // 10 MB
+const maxBodySize = mcphttp.DefaultMaxBodySize
 
 // openAIAppsChallengeToken proves to OpenAI that we control this origin, so the
 // MCP server can be listed as a ChatGPT app. It is a public verification value,
@@ -84,8 +69,8 @@ func main() {
 		return mcpServer
 	}, &mcp.SSEOptions{})
 
-	mux := newRouter(resources, toolsets.Scopes(groups))
-	mux.Handle("/sse", sseLogMiddleware(resources.Logger(), mcpSSEServer))
+	mux := newRouter(resources, groups)
+	mux.Handle("/sse", mcphttp.SSELog(resources.Logger(), mcpSSEServer))
 	mux.Handle("/", mcpHTTPServer)
 
 	httpServer := &http.Server{
@@ -157,54 +142,11 @@ func newToolsetGroups(resources config.Resources) ([]*toolsets.ToolsetGroup, err
 	}, nil
 }
 
-func newRouter(resources config.Resources, scopes []string) *http.ServeMux {
-	// Advertised verbatim from what the registered groups declare, so the scopes
-	// a client may ask for always have a group behind them.
-	scopesSupported, err := json.Marshal(scopes)
-	if err != nil {
-		// Marshalling a []string cannot fail, but advertising no scope beats
-		// serving malformed metadata if it ever does.
-		resources.Logger().Error("failed to encode supported scopes",
-			slog.String("error", err.Error()),
-		)
-		scopesSupported = []byte("[]")
-	}
-
+func newRouter(resources config.Resources, groups []*toolsets.ToolsetGroup) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/favicon.ico", http.RedirectHandler("https://teamwork.com/favicon.ico", http.StatusPermanentRedirect))
-	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet && r.Method != http.MethodOptions {
-			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK")) //nolint:errcheck
-	})
-	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet && r.Method != http.MethodOptions {
-			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "*")
-		w.WriteHeader(http.StatusOK)
-
-		if r.Method == http.MethodOptions {
-			return
-		}
-
-		// https://datatracker.ietf.org/doc/html/rfc9728/#section-2
-		_, _ = w.Write([]byte(`{
-  "resource": "` + resources.Info.MCPURL + `",
-  "authorization_servers": ["` + resources.Info.APIURL + `"],
-  "bearer_methods_supported": ["header"],
-  "resource_documentation": "https://apidocs.teamwork.com/guides/teamwork/app-login-flow",
-  "scopes_supported": ` + string(scopesSupported) + `
-}`))
-	})
+	mcphttp.Health(mux, "/api/health")
+	mcphttp.ProtectedResource(mux, resources, groups)
 	mux.HandleFunc("/.well-known/openai-apps-challenge", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodOptions {
 			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
@@ -226,48 +168,32 @@ func newRouter(resources config.Resources, scopes []string) *http.ServeMux {
 	return mux
 }
 
+// quietPaths are the endpoints not worth a log line or a trace: health checks
+// fire constantly, browsers probe the favicon, and /sse is logged by
+// mcphttp.SSELog instead, which handles its long-lived stream.
+var quietPaths = map[string]struct{}{
+	"/favicon.ico": {},
+	"/api/health":  {},
+	"/sse":         {},
+}
+
 func addRouterMiddlewares(resources config.Resources, mux *http.ServeMux) http.Handler {
-	return chainMiddlewares(mux,
-		func(h http.Handler) http.Handler { return stripProfile(resources.Info.MCPProfiles, h) },
+	validator := auth.NewValidator(resources.TeamworkHTTPClient(), resources.Info.APIURL, resources.Logger())
+
+	return mcphttp.Chain(mux,
+		func(h http.Handler) http.Handler { return mcphttp.StripProfile(resources.Info.MCPProfiles, h) },
 		htmlIndexMiddleware,
-		limitBodyMiddleware,
-		requestInfoMiddleware,
-		func(h http.Handler) http.Handler { return logMiddleware(resources.Logger(), h) },
-		func(h http.Handler) http.Handler { return sentryMiddleware(resources, h) },
-		func(h http.Handler) http.Handler { return tracerMiddleware(resources, h) },
-		func(h http.Handler) http.Handler { return authMiddleware(resources, h) },
+		func(h http.Handler) http.Handler { return mcphttp.LimitBody(maxBodySize, h) },
+		mcphttp.RequestInfo,
+		func(h http.Handler) http.Handler { return mcphttp.Log(resources.Logger(), quietPaths, h) },
+		func(h http.Handler) http.Handler { return mcphttp.Sentry(resources, h) },
+		func(h http.Handler) http.Handler { return mcphttp.Tracer(resources, quietPaths, h) },
+		func(h http.Handler) http.Handler { return mcphttp.Auth(resources, validator, h) },
 	)
 }
 
-// chainMiddlewares applies middlewares so the first argument is the outermost
-// wrapper (runs first on the request, last on the response).
-func chainMiddlewares(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
-	for i := len(mws) - 1; i >= 0; i-- {
-		h = mws[i](h)
-	}
-	return h
-}
-
-// stripProfile is a middleware that checks if the request path starts with a
-// known profile name, and if so, it strips the profile from the path and sets
-// an "TW-MCP-Profile" header with the profile name. This allows clients to use
-// URLs like "/project-manager/endpoint" to access the same endpoints as
-// "/endpoint" but with a profile context.
-func stripProfile(profiles []string, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// If the path starts with a known profile, strip it and set a header
-		r.Header.Set("TW-MCP-Profile", "")
-		for _, profile := range profiles {
-			if strings.HasPrefix(r.URL.Path, "/"+profile+"/") {
-				r.URL.Path = strings.TrimPrefix(r.URL.Path, "/"+profile)
-				r.Header.Add("TW-MCP-Profile", profile)
-				break
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
+// htmlIndexMiddleware redirects a browser hitting the root to the MCP homepage.
+// Specific to this server: a premium or internal deployment has no such page.
 func htmlIndexMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// If the request is for the root path and accepts HTML, redirect to the MCP
@@ -283,309 +209,6 @@ func htmlIndexMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		next.ServeHTTP(w, r)
-	})
-}
-
-func limitBodyMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
-		next.ServeHTTP(w, r)
-	})
-}
-
-func requestInfoMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(w, r.WithContext(request.WithInfo(r.Context(), request.NewInfo(r))))
-	})
-}
-
-func logMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
-	skipPaths := map[string]struct{}{
-		"/favicon.ico": {}, // avoid logging browser favicon requests
-		"/api/health":  {}, // health checks can be very noisy
-		"/sse":         {}, // special log middleware
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, skip := skipPaths[r.URL.Path]; skip {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		var reqBody []byte
-		if r.Body != nil {
-			var err error
-			reqBody, err = io.ReadAll(r.Body)
-			if err != nil {
-				logger.Error("failed to read request body", slog.String("error", err.Error()))
-			}
-			r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-		}
-
-		start := time.Now()
-		rw := request.NewResponseWriter(w)
-		next.ServeHTTP(rw, r)
-
-		headers := r.Header.Clone()
-		if auth := headers.Get("Authorization"); auth != "" {
-			if authParts := strings.SplitN(auth, " ", 2); len(authParts) == 2 {
-				headers.Set("Authorization", authParts[0]+" REDACTED")
-			} else {
-				headers.Set("Authorization", "REDACTED")
-			}
-		}
-
-		info, _ := request.InfoFromContext(r.Context())
-		logger.Info("request",
-			slog.String("trace_id", info.TraceID()),
-			slog.String("request_url", r.URL.String()),
-			slog.String("request_method", r.Method),
-			slog.Any("request_headers", headers),
-			slog.String("request_body", logsafe.String(string(reqBody))),
-			slog.Int("response_status", rw.StatusCode()),
-			slog.Any("response_headers", rw.Header()),
-			slog.String("response_body", string(rw.Body())),
-			slog.Duration("duration", time.Since(start)),
-			slog.Int64("installation.id", info.InstallationID()),
-			slog.String("installation.url", info.InstallationURL()),
-			slog.Int64("user.id", info.UserID()),
-		)
-	})
-}
-
-func sseLogMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		headers := r.Header.Clone()
-		if auth := headers.Get("Authorization"); auth != "" {
-			if authParts := strings.SplitN(auth, " ", 2); len(authParts) == 2 {
-				headers.Set("Authorization", authParts[0]+" REDACTED")
-			} else {
-				headers.Set("Authorization", "REDACTED")
-			}
-		}
-
-		info, _ := request.InfoFromContext(r.Context())
-
-		if r.Method == http.MethodGet {
-			// long-lived SSE stream connection
-			logger.Info("SSE stream opened",
-				slog.String("trace_id", info.TraceID()),
-				slog.String("request_url", r.URL.String()),
-				slog.String("request_method", r.Method),
-				slog.Any("request_headers", headers),
-				slog.String("path", r.URL.String()),
-			)
-			start := time.Now()
-			next.ServeHTTP(w, r)
-			logger.Info("SSE stream closed",
-				slog.String("trace_id", info.TraceID()),
-				slog.Duration("duration", time.Since(start)),
-			)
-			return
-		}
-
-		// short-lived message deliveries to a session
-
-		sessionID := r.URL.Query().Get("sessionid")
-
-		var reqBody []byte
-		if r.Body != nil {
-			var err error
-			reqBody, err = io.ReadAll(r.Body)
-			if err != nil {
-				logger.Error("failed to read SSE message body", slog.String("error", err.Error()))
-			}
-			r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-		}
-
-		start := time.Now()
-		rw := request.NewResponseWriter(w)
-		next.ServeHTTP(rw, r)
-
-		logger.Info("SSE message",
-			slog.String("trace_id", info.TraceID()),
-			slog.String("session_id", sessionID),
-			slog.String("request_url", r.URL.String()),
-			slog.String("request_method", r.Method),
-			slog.Any("request_headers", headers),
-			slog.String("request_body", logsafe.String(string(reqBody))),
-			slog.Int("response_status", rw.StatusCode()),
-			slog.Any("response_headers", rw.Header()),
-			slog.String("response_body", string(rw.Body())),
-			slog.Duration("duration", time.Since(start)),
-			slog.Int64("installation.id", info.InstallationID()),
-			slog.String("installation.url", info.InstallationURL()),
-			slog.Int64("user.id", info.UserID()),
-		)
-	})
-}
-
-func sentryMiddleware(resources config.Resources, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if resources.Info.Log.SentryDSN != "" {
-			hub := sentry.CurrentHub().Clone()
-			hub.Scope().SetRequest(r)
-			ctx := sentry.SetHubOnContext(r.Context(), hub)
-			r = r.WithContext(ctx)
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func tracerMiddleware(resources config.Resources, next http.Handler) http.Handler {
-	if !resources.Info.DatadogAPM.Enabled {
-		return next
-	}
-	skipPaths := map[string]struct{}{
-		"/favicon.ico": {}, // avoid logging browser favicon requests
-		"/api/health":  {}, // health checks can be very noisy
-		"/sse":         {}, // long-lived connections don't work well with tracing
-	}
-	return ddhttp.WrapHandler(next, resources.Info.DatadogAPM.Service, "http.request",
-		ddhttp.WithResourceNamer(func(req *http.Request) string {
-			return fmt.Sprintf("%s_%s", req.Method, req.URL.Path)
-		}),
-		ddhttp.WithIgnoreRequest(func(req *http.Request) bool {
-			if _, skip := skipPaths[req.URL.Path]; skip {
-				return true
-			}
-			if strings.HasPrefix(req.URL.Path, "/.well-known") {
-				return true
-			}
-			return false
-		}),
-	)
-}
-
-func authMiddleware(resources config.Resources, next http.Handler) http.Handler {
-	whitelistEndpoints := map[string][]string{
-		// health checks don't require authentication
-		"/api/health": {http.MethodGet, http.MethodOptions},
-		// browser may request favicons without authentication
-		"/favicon.ico": {http.MethodGet, http.MethodOptions},
-	}
-
-	whitelistPrefixEndpoints := map[string][]string{
-		// OAuth2 endpoints cannot require authentication
-		"/.well-known": {"GET", "OPTIONS"},
-	}
-
-	validator := auth.NewValidator(resources.TeamworkHTTPClient(), resources.Info.APIURL, resources.Logger())
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestLogger := resources.Logger().With(
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path),
-			slog.String("query", r.URL.RawQuery),
-		)
-
-		if r.Header.Get("Authorization") == "" {
-			// some endpoints don't require auth
-
-			if methods, ok := whitelistEndpoints[r.URL.Path]; ok && slices.Contains(methods, r.Method) {
-				next.ServeHTTP(w, r)
-				return
-			}
-			for prefix, methods := range whitelistPrefixEndpoints {
-				if strings.HasPrefix(r.URL.Path, prefix) && slices.Contains(methods, r.Method) {
-					next.ServeHTTP(w, r)
-					return
-				}
-			}
-
-			content, err := io.ReadAll(r.Body)
-			if err != nil {
-				requestLogger.ErrorContext(r.Context(), "failed to read request body",
-					slog.String("error", err.Error()),
-				)
-				http.Error(w, "Failed to read request body", http.StatusInternalServerError)
-				return
-			}
-
-			bypass, err := auth.Bypass(content)
-			switch {
-			case err != nil, !bypass:
-				// https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response
-				w.Header().Set("WWW-Authenticate",
-					`Bearer resource_metadata="`+resources.Info.MCPURL+`/.well-known/oauth-protected-resource"`)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			default:
-				r.Body = io.NopCloser(bytes.NewBuffer(content))
-				next.ServeHTTP(w, r)
-			}
-			return
-		}
-
-		matches := reBearerToken.FindStringSubmatch(r.Header.Get("Authorization"))
-		if len(matches) < 2 {
-			// https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response
-			w.Header().Set("WWW-Authenticate",
-				`Bearer resource_metadata="`+resources.Info.MCPURL+`/.well-known/oauth-protected-resource"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		bearerToken := matches[1]
-
-		info, err := validator.GetBearerInfo(r.Context(), bearerToken)
-		switch {
-		case errors.Is(err, auth.ErrBearerInfoUnauthorized):
-			// The token was positively rejected, so challenge the client to
-			// re-authorise.
-			// https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response
-			w.Header().Set("WWW-Authenticate",
-				`Bearer resource_metadata="`+resources.Info.MCPURL+`/.well-known/oauth-protected-resource"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-
-		case errors.Is(err, auth.ErrBearerInfoCanceled):
-			// The client hung up while we were validating. Nobody is left to
-			// read a response and nothing failed on our side, so this is debug
-			// noise rather than an error.
-			requestLogger.DebugContext(r.Context(), "bearer info validation canceled by client",
-				slog.String("error", err.Error()),
-			)
-			return
-
-		case errors.Is(err, auth.ErrBearerInfoUnavailable):
-			// We could not determine whether the token is valid. Never send a
-			// re-authorisation challenge here: the token is probably fine, and
-			// telling the client to discard it puts the user through the whole
-			// OAuth flow (and MFA) over what may be a momentary blip.
-			requestLogger.ErrorContext(r.Context(), "failed to validate bearer info",
-				slog.String("error", err.Error()),
-			)
-			http.Error(w, "Failed to validate bearer token", http.StatusServiceUnavailable)
-			return
-
-		case err != nil:
-			requestLogger.ErrorContext(r.Context(), "failed to get bearer info",
-				slog.String("error", err.Error()),
-			)
-			http.Error(w, "Failed to get bearer info", http.StatusInternalServerError)
-			return
-		}
-
-		if span, ok := tracer.SpanFromContext(r.Context()); ok {
-			span.SetTag("user.id", info.UserID)
-			span.SetTag("installation.id", info.InstallationID)
-			span.SetTag("installation.url", info.URL)
-		}
-		if requestInfo, ok := request.InfoFromContext(r.Context()); ok {
-			requestInfo.SetAuth(info.InstallationID, info.URL, info.UserID)
-		}
-
-		ctx := r.Context()
-		// detect cross-region requests
-		ctx = twctx.WithCrossRegion(ctx, !strings.EqualFold(resources.Info.AWSRegion, info.Region))
-		// inject customer URL
-		ctx = twctx.WithCustomerURL(ctx, info.URL)
-		// inject bearer token
-		ctx = twctx.WithBearerToken(ctx, bearerToken)
-		// inject scopes
-		ctx = twctx.WithScopes(ctx, info.Meta.Scopes)
-		// inject session
-		ctx = session.WithBearerTokenContext(ctx, session.NewBearerToken(bearerToken, info.URL))
-
-		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/cmd/mcp-http/main_scopes_test.go
+++ b/cmd/mcp-http/main_scopes_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 // TestProtectedResourceScopesComeFromTheGroups pins that the scopes advertised
-// in the RFC 9728 metadata are the ones the registered ToolsetGroups declare.
-// The two used to be written out separately, so a group could ship with a scope
-// no client was ever told it could ask for — the tools would then be filtered
-// out of tools/list for every token.
+// in the RFC 9728 metadata are the ones this server's ToolsetGroups declare. The
+// two used to be written out separately, so a group could ship with a scope no
+// client was ever told it could ask for — its tools would then be filtered out
+// of tools/list for every token.
 func TestProtectedResourceScopesComeFromTheGroups(t *testing.T) {
-	resources := newTestResources(t)
+	var resources config.Resources
+	resources.Info.MCPURL = "https://mcp.example.com"
+	resources.Info.APIURL = "https://example.com"
 
 	groups, err := newToolsetGroups(resources)
 	if err != nil {
@@ -29,7 +31,7 @@ func TestProtectedResourceScopesComeFromTheGroups(t *testing.T) {
 		t.Fatal("no group declares a scope, so tools/list filtering is inert")
 	}
 
-	server := httptest.NewServer(newRouter(resources, want))
+	server := httptest.NewServer(newRouter(resources, groups))
 	defer server.Close()
 
 	response, err := server.Client().Get(server.URL + "/.well-known/oauth-protected-resource")
@@ -43,7 +45,6 @@ func TestProtectedResourceScopesComeFromTheGroups(t *testing.T) {
 	}
 
 	var metadata struct {
-		Resource        string   `json:"resource"`
 		ScopesSupported []string `json:"scopes_supported"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&metadata); err != nil {
@@ -53,39 +54,4 @@ func TestProtectedResourceScopesComeFromTheGroups(t *testing.T) {
 	if !slices.Equal(metadata.ScopesSupported, want) {
 		t.Errorf("scopes_supported = %v, want %v", metadata.ScopesSupported, want)
 	}
-}
-
-// TestProtectedResourceScopesAreValidJSON guards the hand-built JSON body: the
-// scopes are interpolated into a string literal, so an encoding slip produces
-// metadata no OAuth client can parse.
-func TestProtectedResourceScopesAreValidJSON(t *testing.T) {
-	resources := newTestResources(t)
-
-	for _, scopes := range [][]string{nil, {}, {"projects"}, {"projects", "desk", "spaces", "chat"}} {
-		server := httptest.NewServer(newRouter(resources, scopes))
-
-		response, err := server.Client().Get(server.URL + "/.well-known/oauth-protected-resource")
-		if err != nil {
-			server.Close()
-			t.Fatalf("scopes %v: failed to request metadata: %v", scopes, err)
-		}
-
-		var metadata map[string]any
-		err = json.NewDecoder(response.Body).Decode(&metadata)
-		response.Body.Close() //nolint:errcheck
-		server.Close()
-
-		if err != nil {
-			t.Errorf("scopes %v: metadata is not valid JSON: %v", scopes, err)
-		}
-	}
-}
-
-func newTestResources(t *testing.T) config.Resources {
-	t.Helper()
-
-	var resources config.Resources
-	resources.Info.MCPURL = "https://mcp.example.com"
-	resources.Info.APIURL = "https://example.com"
-	return resources
 }

--- a/pkg/config/resources.go
+++ b/pkg/config/resources.go
@@ -17,6 +17,7 @@ const (
 
 	defaultServerName  = "Teamwork.com"
 	defaultServerTitle = "Teamwork.com Model Context Protocol"
+	defaultMCPURL      = "https://mcp.ai.teamwork.com"
 )
 
 // Version is the current version of the MCP server. It is set at build time
@@ -103,6 +104,7 @@ type options struct {
 	envPrefix string
 	name      string
 	title     string
+	mcpURL    string
 	profiles  []string
 }
 
@@ -123,6 +125,17 @@ func WithServerIdentity(name, title string) Option {
 	}
 }
 
+// WithDefaultMCPURL sets the base URL this server reports as its own resource
+// identifier when the environment does not say. It must identify *this* server:
+// it is the "resource" in the RFC 9728 protected-resource metadata and the
+// resource_metadata pointer in every 401 challenge, so a server left on another
+// server's URL sends clients to authorise against the wrong resource.
+//
+// The environment variable still wins, so a deployment can override it.
+func WithDefaultMCPURL(url string) Option {
+	return func(o *options) { o.mcpURL = url }
+}
+
 // WithProfiles sets the named toolset profiles this server exposes as URL path
 // prefixes.
 func WithProfiles(profiles ...string) Option {
@@ -134,6 +147,7 @@ func newOptions(opts ...Option) options {
 		envPrefix: defaultEnvPrefix,
 		name:      defaultServerName,
 		title:     defaultServerTitle,
+		mcpURL:    defaultMCPURL,
 	}
 	for _, opt := range opts {
 		opt(&resolved)
@@ -157,7 +171,7 @@ func newResources(opts options) Resources {
 	resources.Info.ServerAddress = env("SERVER_ADDRESS", ":8080")
 	resources.Info.Environment = env("ENV", "dev")
 	resources.Info.AWSRegion = env("AWS_REGION", "us-east-1")
-	resources.Info.MCPURL = strings.TrimSuffix(env("URL", "https://mcp.ai.teamwork.com"), "/")
+	resources.Info.MCPURL = strings.TrimSuffix(env("URL", opts.mcpURL), "/")
 	resources.Info.MCPProfiles = profiles
 	resources.Info.APIURL = strings.TrimSuffix(env("API_URL", "https://teamwork.com"), "/")
 	resources.Info.HAProxyURL = env("HAPROXY_URL", "")

--- a/pkg/config/resources_test.go
+++ b/pkg/config/resources_test.go
@@ -110,3 +110,31 @@ func TestNewResourcesProfilesAppendToTheURL(t *testing.T) {
 		})
 	}
 }
+
+// TestNewResourcesDefaultMCPURL pins that a server can set its own resource
+// identifier. It is the "resource" in the RFC 9728 metadata and the
+// resource_metadata pointer in every 401 challenge, so a second server left on
+// the default would tell clients to authorise against the first one.
+func TestNewResourcesDefaultMCPURL(t *testing.T) {
+	t.Run("defaults to this server", func(t *testing.T) {
+		resources := newResources(newOptions())
+		if got := resources.Info.MCPURL; got != defaultMCPURL {
+			t.Errorf("MCPURL = %q, want %q", got, defaultMCPURL)
+		}
+	})
+
+	t.Run("overridden by option", func(t *testing.T) {
+		resources := newResources(newOptions(WithDefaultMCPURL("https://pro.example.com")))
+		if got := resources.Info.MCPURL; got != "https://pro.example.com" {
+			t.Errorf("MCPURL = %q, want %q", got, "https://pro.example.com")
+		}
+	})
+
+	t.Run("environment wins over the option", func(t *testing.T) {
+		t.Setenv("TW_MCP_URL", "https://from-the-environment.example.com/")
+		resources := newResources(newOptions(WithDefaultMCPURL("https://pro.example.com")))
+		if got := resources.Info.MCPURL; got != "https://from-the-environment.example.com" {
+			t.Errorf("MCPURL = %q, want the environment value with its slash trimmed", got)
+		}
+	})
+}

--- a/pkg/mcphttp/auth.go
+++ b/pkg/mcphttp/auth.go
@@ -1,0 +1,172 @@
+// Package mcphttp carries the HTTP plumbing an MCP server needs around the
+// protocol handler: the middleware chain, the health and RFC 9728 metadata
+// endpoints, and the bearer-token authentication that turns a token into the
+// per-request values tool handlers read.
+//
+// It lives here rather than in a server's main package because a main package
+// cannot be imported. Authentication especially must not be forked: two copies
+// drift, and the one that drifts is the one that stops rejecting what it should.
+package mcphttp
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/teamwork/mcp/pkg/auth"
+	"github.com/teamwork/mcp/pkg/config"
+	"github.com/teamwork/mcp/pkg/request"
+	"github.com/teamwork/mcp/pkg/twctx"
+	"github.com/teamwork/twapi-go-sdk/session"
+)
+
+var reBearerToken = regexp.MustCompile(`^Bearer (.+)$`)
+
+// Auth authenticates every request with a bearer token, rejecting the ones that
+// carry no usable credential and populating the context of the ones that do.
+//
+// Unauthenticated paths are the ones that cannot require a token: health checks,
+// browser favicon probes, and the /.well-known OAuth metadata an unauthorised
+// client fetches to discover where to authorise. A request with no
+// Authorization header on any other path is allowed through only when its JSON
+// body names a protocol method auth.Bypass whitelists, which is how a client
+// negotiates capabilities before it holds a token.
+func Auth(resources config.Resources, validator *auth.Validator, next http.Handler) http.Handler {
+	whitelistEndpoints := map[string][]string{
+		// health checks don't require authentication
+		"/api/health": {http.MethodGet, http.MethodOptions},
+		// browser may request favicons without authentication
+		"/favicon.ico": {http.MethodGet, http.MethodOptions},
+	}
+
+	whitelistPrefixEndpoints := map[string][]string{
+		// OAuth2 endpoints cannot require authentication
+		"/.well-known": {http.MethodGet, http.MethodOptions},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestLogger := resources.Logger().With(
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.String("query", r.URL.RawQuery),
+		)
+
+		if r.Header.Get("Authorization") == "" {
+			// some endpoints don't require auth
+
+			if methods, ok := whitelistEndpoints[r.URL.Path]; ok && slices.Contains(methods, r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			for prefix, methods := range whitelistPrefixEndpoints {
+				if strings.HasPrefix(r.URL.Path, prefix) && slices.Contains(methods, r.Method) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			content, err := io.ReadAll(r.Body)
+			if err != nil {
+				requestLogger.ErrorContext(r.Context(), "failed to read request body",
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+				return
+			}
+
+			bypass, err := auth.Bypass(content)
+			switch {
+			case err != nil, !bypass:
+				challenge(w, resources)
+			default:
+				r.Body = io.NopCloser(bytes.NewBuffer(content))
+				next.ServeHTTP(w, r)
+			}
+			return
+		}
+
+		matches := reBearerToken.FindStringSubmatch(r.Header.Get("Authorization"))
+		if len(matches) < 2 {
+			challenge(w, resources)
+			return
+		}
+		bearerToken := matches[1]
+
+		info, err := validator.GetBearerInfo(r.Context(), bearerToken)
+		switch {
+		case errors.Is(err, auth.ErrBearerInfoUnauthorized):
+			// The token was positively rejected, so challenge the client to
+			// re-authorise.
+			challenge(w, resources)
+			return
+
+		case errors.Is(err, auth.ErrBearerInfoCanceled):
+			// The client hung up while we were validating. Nobody is left to
+			// read a response and nothing failed on our side, so this is debug
+			// noise rather than an error.
+			requestLogger.DebugContext(r.Context(), "bearer info validation canceled by client",
+				slog.String("error", err.Error()),
+			)
+			return
+
+		case errors.Is(err, auth.ErrBearerInfoUnavailable):
+			// We could not determine whether the token is valid. Never send a
+			// re-authorisation challenge here: the token is probably fine, and
+			// telling the client to discard it puts the user through the whole
+			// OAuth flow (and MFA) over what may be a momentary blip.
+			requestLogger.ErrorContext(r.Context(), "failed to validate bearer info",
+				slog.String("error", err.Error()),
+			)
+			http.Error(w, "Failed to validate bearer token", http.StatusServiceUnavailable)
+			return
+
+		case err != nil:
+			requestLogger.ErrorContext(r.Context(), "failed to get bearer info",
+				slog.String("error", err.Error()),
+			)
+			http.Error(w, "Failed to get bearer info", http.StatusInternalServerError)
+			return
+		}
+
+		if span, ok := tracer.SpanFromContext(r.Context()); ok {
+			span.SetTag("user.id", info.UserID)
+			span.SetTag("installation.id", info.InstallationID)
+			span.SetTag("installation.url", info.URL)
+		}
+		if requestInfo, ok := request.InfoFromContext(r.Context()); ok {
+			requestInfo.SetAuth(info.InstallationID, info.URL, info.UserID)
+		}
+
+		ctx := r.Context()
+		// detect cross-region requests
+		ctx = twctx.WithCrossRegion(ctx, !strings.EqualFold(resources.Info.AWSRegion, info.Region))
+		// inject customer URL
+		ctx = twctx.WithCustomerURL(ctx, info.URL)
+		// inject bearer token
+		ctx = twctx.WithBearerToken(ctx, bearerToken)
+		// inject scopes
+		ctx = twctx.WithScopes(ctx, info.Meta.Scopes)
+		// inject session
+		ctx = session.WithBearerTokenContext(ctx, session.NewBearerToken(bearerToken, info.URL))
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// challenge answers 401 with the RFC 9728 pointer to this server's
+// protected-resource metadata, which is how a client learns where to authorise.
+// Only send it when the token was actually refused — it makes the client throw
+// its token away.
+//
+// https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response
+func challenge(w http.ResponseWriter, resources config.Resources) {
+	w.Header().Set("WWW-Authenticate",
+		`Bearer resource_metadata="`+resources.Info.MCPURL+`/.well-known/oauth-protected-resource"`)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}

--- a/pkg/mcphttp/endpoints.go
+++ b/pkg/mcphttp/endpoints.go
@@ -1,0 +1,87 @@
+package mcphttp
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/teamwork/mcp/pkg/config"
+	"github.com/teamwork/mcp/pkg/toolsets"
+)
+
+// resourceDocumentation is the guide an OAuth client is pointed at to understand
+// this authorization flow.
+const resourceDocumentation = "https://apidocs.teamwork.com/guides/teamwork/app-login-flow"
+
+// Health registers a GET/OPTIONS health check that requires no authentication.
+func Health(mux *http.ServeMux, path string) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if !allowGetOptions(w, r) {
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+}
+
+// ProtectedResource registers the RFC 9728 protected-resource metadata an
+// unauthorised client fetches to discover where and for what to authorise.
+//
+// The advertised scopes come from what the registered groups declare, so a scope
+// a client may ask for always has a group behind it. A group declaring a scope
+// the authorization server does not know will still fail at registration — the
+// authorization server keeps its own catalogue, and this endpoint cannot check
+// against it.
+//
+// https://datatracker.ietf.org/doc/html/rfc9728/#section-2
+func ProtectedResource(mux *http.ServeMux, resources config.Resources, groups []*toolsets.ToolsetGroup) {
+	scopesSupported, err := json.Marshal(toolsets.Scopes(groups))
+	if err != nil {
+		// Marshalling a []string cannot fail, but advertising no scope beats
+		// serving malformed metadata if it ever does.
+		resources.Logger().Error("failed to encode supported scopes",
+			slog.String("error", err.Error()),
+		)
+		scopesSupported = []byte("[]")
+	}
+
+	body := []byte(`{
+  "resource": "` + resources.Info.MCPURL + `",
+  "authorization_servers": ["` + resources.Info.APIURL + `"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "` + resourceDocumentation + `",
+  "scopes_supported": ` + string(scopesSupported) + `
+}`)
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		if !allowGetOptions(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		allowCORS(w)
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == http.MethodOptions {
+			return
+		}
+		_, _ = w.Write(body)
+	})
+}
+
+// allowGetOptions rejects anything but GET and OPTIONS, reporting whether the
+// caller should continue.
+func allowGetOptions(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodOptions {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+	return true
+}
+
+// allowCORS opens an unauthenticated discovery endpoint to browser clients,
+// which fetch it cross-origin before they hold any credential.
+func allowCORS(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+}

--- a/pkg/mcphttp/endpoints_test.go
+++ b/pkg/mcphttp/endpoints_test.go
@@ -1,0 +1,105 @@
+package mcphttp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/teamwork/mcp/pkg/config"
+	"github.com/teamwork/mcp/pkg/mcphttp"
+	"github.com/teamwork/mcp/pkg/toolsets"
+)
+
+// TestProtectedResourceIsValidJSON guards the hand-built metadata body: the
+// scopes are interpolated into a string literal, so an encoding slip produces
+// metadata no OAuth client can parse. The no-group case matters most — it must
+// advertise an empty array, not null.
+func TestProtectedResourceIsValidJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+	}{
+		{name: "no groups", scopes: nil},
+		{name: "one scope", scopes: []string{"projects"}},
+		{name: "several scopes", scopes: []string{"projects", "desk", "spaces", "chat"}},
+		{name: "groups sharing a scope", scopes: []string{"projects", "projects"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := make([]*toolsets.ToolsetGroup, 0, len(tt.scopes))
+			for i, scope := range tt.scopes {
+				groups = append(groups, toolsets.NewToolsetGroup(false).
+					SetNamespace("tw"+scope+string(rune('a'+i)), scope))
+			}
+
+			var resources config.Resources
+			resources.Info.MCPURL = "https://mcp.example.com"
+			resources.Info.APIURL = "https://example.com"
+
+			mux := http.NewServeMux()
+			mcphttp.ProtectedResource(mux, resources, groups)
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			response, err := server.Client().Get(server.URL + "/.well-known/oauth-protected-resource")
+			if err != nil {
+				t.Fatalf("failed to request metadata: %v", err)
+			}
+			defer response.Body.Close() //nolint:errcheck
+
+			var metadata struct {
+				Resource        string   `json:"resource"`
+				ScopesSupported []string `json:"scopes_supported"`
+			}
+			if err := json.NewDecoder(response.Body).Decode(&metadata); err != nil {
+				t.Fatalf("metadata is not valid JSON: %v", err)
+			}
+			if metadata.Resource != resources.Info.MCPURL {
+				t.Errorf("resource = %q, want %q", metadata.Resource, resources.Info.MCPURL)
+			}
+			if metadata.ScopesSupported == nil {
+				t.Error("scopes_supported decoded as null; it must always be an array")
+			}
+			if want := toolsets.Scopes(groups); !slices.Equal(metadata.ScopesSupported, want) {
+				t.Errorf("scopes_supported = %v, want %v", metadata.ScopesSupported, want)
+			}
+		})
+	}
+}
+
+// TestHealthRejectsWrites pins that the unauthenticated health endpoint answers
+// only GET and OPTIONS. It sits in front of authentication, so anything else it
+// accepted would be an unauthenticated write path.
+func TestHealthRejectsWrites(t *testing.T) {
+	mux := http.NewServeMux()
+	mcphttp.Health(mux, "/api/health")
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	for method, wantStatus := range map[string]int{
+		http.MethodGet:     http.StatusOK,
+		http.MethodOptions: http.StatusOK,
+		http.MethodPost:    http.StatusMethodNotAllowed,
+		http.MethodPut:     http.StatusMethodNotAllowed,
+		http.MethodDelete:  http.StatusMethodNotAllowed,
+	} {
+		request, err := http.NewRequestWithContext(t.Context(), method, server.URL+"/api/health", nil)
+		if err != nil {
+			t.Fatalf("%s: failed to build request: %v", method, err)
+		}
+		response, err := server.Client().Do(request)
+		if err != nil {
+			t.Fatalf("%s: failed to request health: %v", method, err)
+		}
+		_ = response.Body.Close()
+
+		if response.StatusCode != wantStatus {
+			t.Errorf("%s /api/health = %d, want %d", method, response.StatusCode, wantStatus)
+		}
+	}
+}

--- a/pkg/mcphttp/middleware.go
+++ b/pkg/mcphttp/middleware.go
@@ -1,0 +1,230 @@
+package mcphttp
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	ddhttp "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
+	"github.com/getsentry/sentry-go"
+	"github.com/teamwork/mcp/pkg/config"
+	"github.com/teamwork/mcp/pkg/logsafe"
+	"github.com/teamwork/mcp/pkg/request"
+)
+
+// DefaultMaxBodySize is the request body limit LimitBody applies unless a server
+// passes its own. Pin the same value into
+// mcp.StreamableHTTPOptions.MaxRequestBodyBytes: left at zero the SDK applies
+// its own smaller default, silently tightening the limit this one advertises.
+const DefaultMaxBodySize = 10 * 1024 * 1024 // 10 MB
+
+// Chain applies middlewares so the first argument is the outermost wrapper (runs
+// first on the request, last on the response).
+func Chain(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}
+
+// StripProfile checks whether the request path starts with a known profile name,
+// and if so strips it and sets a "TW-MCP-Profile" header. This lets clients use
+// URLs like "/project-manager/endpoint" to reach "/endpoint" with a profile
+// context.
+func StripProfile(profiles []string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the path starts with a known profile, strip it and set a header
+		r.Header.Set("TW-MCP-Profile", "")
+		for _, profile := range profiles {
+			if strings.HasPrefix(r.URL.Path, "/"+profile+"/") {
+				r.URL.Path = strings.TrimPrefix(r.URL.Path, "/"+profile)
+				r.Header.Add("TW-MCP-Profile", profile)
+				break
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// LimitBody caps the request body a client may send.
+func LimitBody(maxBodySize int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RequestInfo attaches the per-request trace and installation info every later
+// middleware and the MCP logging middleware read.
+func RequestInfo(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(request.WithInfo(r.Context(), request.NewInfo(r))))
+	})
+}
+
+// Log records one line per request: the trace id, the request and response, and
+// the installation and user the token resolved to. Request bodies go through
+// logsafe, which strips anything token-shaped.
+//
+// skipPaths keeps the noisy endpoints out: health checks fire constantly, and an
+// SSE stream lives as long as the request, so its body is logged by SSELog
+// instead.
+func Log(logger *slog.Logger, skipPaths map[string]struct{}, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, skip := skipPaths[r.URL.Path]; skip {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		var reqBody []byte
+		if r.Body != nil {
+			var err error
+			reqBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				logger.Error("failed to read request body", slog.String("error", err.Error()))
+			}
+			r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		}
+
+		start := time.Now()
+		rw := request.NewResponseWriter(w)
+		next.ServeHTTP(rw, r)
+
+		headers := r.Header.Clone()
+		if auth := headers.Get("Authorization"); auth != "" {
+			if authParts := strings.SplitN(auth, " ", 2); len(authParts) == 2 {
+				headers.Set("Authorization", authParts[0]+" REDACTED")
+			} else {
+				headers.Set("Authorization", "REDACTED")
+			}
+		}
+
+		info, _ := request.InfoFromContext(r.Context())
+		logger.Info("request",
+			slog.String("trace_id", info.TraceID()),
+			slog.String("request_url", r.URL.String()),
+			slog.String("request_method", r.Method),
+			slog.Any("request_headers", headers),
+			slog.String("request_body", logsafe.String(string(reqBody))),
+			slog.Int("response_status", rw.StatusCode()),
+			slog.Any("response_headers", rw.Header()),
+			slog.String("response_body", string(rw.Body())),
+			slog.Duration("duration", time.Since(start)),
+			slog.Int64("installation.id", info.InstallationID()),
+			slog.String("installation.url", info.InstallationURL()),
+			slog.Int64("user.id", info.UserID()),
+		)
+	})
+}
+
+// SSELog logs a Server-Sent Events endpoint, where the long-lived GET stream and
+// the short-lived POST message deliveries need different treatment: the stream
+// is logged once when it opens and once when it closes, so a connection held for
+// hours does not sit unlogged, or buffer its body until it ends.
+func SSELog(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers := r.Header.Clone()
+		if auth := headers.Get("Authorization"); auth != "" {
+			if authParts := strings.SplitN(auth, " ", 2); len(authParts) == 2 {
+				headers.Set("Authorization", authParts[0]+" REDACTED")
+			} else {
+				headers.Set("Authorization", "REDACTED")
+			}
+		}
+
+		info, _ := request.InfoFromContext(r.Context())
+
+		if r.Method == http.MethodGet {
+			// long-lived SSE stream connection
+			logger.Info("SSE stream opened",
+				slog.String("trace_id", info.TraceID()),
+				slog.String("request_url", r.URL.String()),
+				slog.String("request_method", r.Method),
+				slog.Any("request_headers", headers),
+				slog.String("path", r.URL.String()),
+			)
+			start := time.Now()
+			next.ServeHTTP(w, r)
+			logger.Info("SSE stream closed",
+				slog.String("trace_id", info.TraceID()),
+				slog.Duration("duration", time.Since(start)),
+			)
+			return
+		}
+
+		// short-lived message deliveries to a session
+
+		sessionID := r.URL.Query().Get("sessionid")
+
+		var reqBody []byte
+		if r.Body != nil {
+			var err error
+			reqBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				logger.Error("failed to read SSE message body", slog.String("error", err.Error()))
+			}
+			r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		}
+
+		start := time.Now()
+		rw := request.NewResponseWriter(w)
+		next.ServeHTTP(rw, r)
+
+		logger.Info("SSE message",
+			slog.String("trace_id", info.TraceID()),
+			slog.String("session_id", sessionID),
+			slog.String("request_url", r.URL.String()),
+			slog.String("request_method", r.Method),
+			slog.Any("request_headers", headers),
+			slog.String("request_body", logsafe.String(string(reqBody))),
+			slog.Int("response_status", rw.StatusCode()),
+			slog.Any("response_headers", rw.Header()),
+			slog.String("response_body", string(rw.Body())),
+			slog.Duration("duration", time.Since(start)),
+			slog.Int64("installation.id", info.InstallationID()),
+			slog.String("installation.url", info.InstallationURL()),
+			slog.Int64("user.id", info.UserID()),
+		)
+	})
+}
+
+// Sentry scopes a Sentry hub to the request so a panic or reported error carries
+// the request that caused it. A no-op when no DSN is configured.
+func Sentry(resources config.Resources, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if resources.Info.Log.SentryDSN != "" {
+			hub := sentry.CurrentHub().Clone()
+			hub.Scope().SetRequest(r)
+			ctx := sentry.SetHubOnContext(r.Context(), hub)
+			r = r.WithContext(ctx)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Tracer wraps the handler in Datadog APM tracing, naming each span by method
+// and path. Returns next unchanged when APM is disabled.
+//
+// skipPaths drops the endpoints not worth a trace: health checks are constant
+// noise, and a long-lived SSE stream does not fit a request span. Every
+// /.well-known path is skipped too.
+func Tracer(resources config.Resources, skipPaths map[string]struct{}, next http.Handler) http.Handler {
+	if !resources.Info.DatadogAPM.Enabled {
+		return next
+	}
+	return ddhttp.WrapHandler(next, resources.Info.DatadogAPM.Service, "http.request",
+		ddhttp.WithResourceNamer(func(req *http.Request) string {
+			return fmt.Sprintf("%s_%s", req.Method, req.URL.Path)
+		}),
+		ddhttp.WithIgnoreRequest(func(req *http.Request) bool {
+			if _, skip := skipPaths[req.URL.Path]; skip {
+				return true
+			}
+			return strings.HasPrefix(req.URL.Path, "/.well-known")
+		}),
+	)
+}


### PR DESCRIPTION
## Description

The middleware chain, bearer auth and the health and RFC 9728 endpoints lived in `cmd/mcp-http`, a `main` package, so another server could only copy them. Auth especially must not be forked: two copies drift, and the one that drifts stops rejecting what it should.

Moved to `pkg/mcphttp` and wired this server onto it too, which is what actually keeps the two from diverging.

Also adds `config.WithDefaultMCPURL`. `MCPURL` was hardcoded to this server's host, so a second server left it advertising the wrong "resource" and pointing its 401 challenges here.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors