### PR TITLE
Fix: Store update_comment bodies as HTML instead of escaped text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sonh/qs v0.7.0
 	github.com/teamwork/desksdkgo v1.1.0
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.22.3
+	github.com/teamwork/twapi-go-sdk v1.22.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.1.0 h1:PpIquf92fAtT0qtSMGK3LGRxAvIPDjl7/jkSh0/F
 github.com/teamwork/desksdkgo v1.1.0/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.22.3 h1:3yprS/uNq73isAgJZHRKmVtiEJAjRbgcxj8F8lrkFgE=
-github.com/teamwork/twapi-go-sdk v1.22.3/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
+github.com/teamwork/twapi-go-sdk v1.22.4 h1:4DtrfoPiOEz9zGW0DKUZSdJczohOmKMEjLylsXmTsfo=
+github.com/teamwork/twapi-go-sdk v1.22.4/go.mod h1:uj6BNtyyKtggfeY3whzn8bLWuhP1twhghjWD6z3h3F4=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=


### PR DESCRIPTION
## Description

`v1` spells the content type key in camelCase on comment creation and hyphenated on update. The SDK sent `contentType` in both cases, so an update fell back to the `TEXT` default and stored the markup escaped - `update_comment` with `content_type` `HTML` rendered visible tags instead of formatting.

`twapi-go-sdk v1.22.4` sends `content-type` on update.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors