### PR TITLE
Feature: Reach the files area, and attach a file more than once

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Teamwork.com MCP Server — Tool Reference</title>
-<meta name="description" content="Every tool the Teamwork.com MCP server exposes to an AI client: 208 tools across 14 toolsets and 4 products, generated from the server's own registry.">
+<meta name="description" content="Every tool the Teamwork.com MCP server exposes to an AI client: 209 tools across 14 toolsets and 4 products, generated from the server's own registry.">
 <meta property="og:title" content="Teamwork.com MCP Server — Tool Reference">
-<meta property="og:description" content="208 tools across 4 Teamwork.com products, generated from the server's own toolset registry.">
+<meta property="og:description" content="209 tools across 4 Teamwork.com products, generated from the server's own toolset registry.">
 <meta property="og:type" content="website">
 <link rel="icon" href="data:image/svg+xml,image/svg&#43;xml,%3Csvg%20width=%2252%22%20height=%2250%22%20viewBox=%220%200%2052%2050%22%20fill=%22none%22%20xmlns=%22http:%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cellipse%20cx=%2226.2857%22%20cy=%2225%22%20rx=%2225.7143%22%20ry=%2225%22%20fill=%22%231D1C39%22%2F%3E%0A%3Cpath%20d=%22M27.7099%2020.8746C29.0831%2020.8746%2029.8737%2020.1463%2029.8737%2018.8922C29.8737%2017.7189%2029.0415%2016.9098%2027.7515%2016.9098H24.6305V14.6847C24.6305%2013.0664%2023.4237%2012.2168%2022.2586%2012.2168C21.0934%2012.2168%2019.8867%2013.0664%2019.8867%2014.6847V30.1392C19.8867%2033.8612%2021.4263%2035.52%2024.8386%2035.52C26.6695%2035.52%2027.7515%2035.0749%2028.5421%2034.5895C29.1247%2034.2658%2029.3744%2033.578%2029.3744%2033.0521C29.3744%2032.0407%2028.7086%2030.9483%2027.7099%2030.9483C27.585%2030.9483%2027.4186%2030.9888%2027.2937%2031.0292C27.2521%2031.0697%2027.1689%2031.0697%2027.1273%2031.1102C26.8776%2031.2315%2026.5031%2031.3934%2026.0037%2031.3934C25.3795%2031.3934%2024.6721%2031.1911%2024.6721%2029.5323V20.8746H27.7099Z%22%20fill=%22white%22%2F%3E%0A%3Cpath%20d=%22M37.863%2027.3887C35.5743%2027.3887%2033.7017%2029.2092%2033.7017%2031.4344C33.7017%2033.6595%2035.5743%2035.48%2037.863%2035.48C40.1517%2035.48%2042.0243%2033.6595%2042.0243%2031.4344C42.0243%2029.1688%2040.1517%2027.3887%2037.863%2027.3887Z%22%20fill=%22%23FF22B1%22%2F%3E%0A%3C%2Fsvg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -473,8 +473,8 @@ footer p { margin: 0 0 6px; }
     <div class="stats">
       <div class="stat"><span class="stat__n">4</span><span class="stat__l">Products</span></div>
       <div class="stat"><span class="stat__n">14</span><span class="stat__l">Toolsets</span></div>
-      <div class="stat"><span class="stat__n">208</span><span class="stat__l">Tools</span></div>
-      <div class="stat"><span class="stat__n">107&#8239;/&#8239;101</span><span class="stat__l">Read / write</span></div>
+      <div class="stat"><span class="stat__n">209</span><span class="stat__l">Tools</span></div>
+      <div class="stat"><span class="stat__n">107&#8239;/&#8239;102</span><span class="stat__l">Read / write</span></div>
     </div>
   </div>
 </div>
@@ -544,7 +544,7 @@ footer p { margin: 0 0 6px; }
             <button class="chip" type="button" data-access-filter="read" aria-pressed="false">Read</button>
             <button class="chip" type="button" data-access-filter="write" aria-pressed="false">Write</button>
           </div>
-          <span class="controls__count" id="tool-count" aria-live="polite">208 tools</span>
+          <span class="controls__count" id="tool-count" aria-live="polite">209 tools</span>
         </div>
       </div>
     </div>
@@ -555,7 +555,7 @@ footer p { margin: 0 0 6px; }
         <div class="product__head">
           <h3 class="product__name">Projects</h3>
           <span class="product__scope">twprojects-&#8203;* &middot; scope projects</span>
-          <span class="product__counts">134 tools &middot; 6 toolsets</span>
+          <span class="product__counts">135 tools &middot; 6 toolsets</span>
         </div>
         <div class="toolset" data-toolset id="twprojects-content">
           <div class="toolset__head">
@@ -1034,6 +1034,11 @@ footer p { margin: 0 0 6px; }
           </div>
           <p class="subhead">Tools</p>
           <div class="tools">
+            <div class="tool" data-search="twprojects-add_project_file store an uploaded file in a project&#39;s files area, where people find it outside any one task or comment." data-access="write">
+              <span class="badge badge--write">write</span>
+              <span class="tool__name">twprojects-add_project_file</span>
+              <span class="tool__desc">Store an uploaded file in a project&#39;s files area, where people find it outside any one task or comment.</span>
+            </div>
             <div class="tool" data-search="twprojects-add_project_member add a user to a project." data-access="write">
               <span class="badge badge--write">write</span>
               <span class="tool__name">twprojects-add_project_member</span>

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -64,7 +64,7 @@ Project, category, template, member, custom field, and custom item (user-defined
 | File | ✓ | — | — | — |
 | Upload Url | ✓ | — | — | — |
 
-**Other actions:** `add_project_member`, `clone_project`, `count_projects`
+**Other actions:** `add_project_file`, `add_project_member`, `clone_project`, `count_projects`
 
 ### Tasks — `twprojects-tasks`
 

--- a/internal/twprojects/files.go
+++ b/internal/twprojects/files.go
@@ -26,6 +26,7 @@ import (
 const (
 	MethodFileCreate      toolsets.Method = "twprojects-create_file"
 	MethodUploadURLCreate toolsets.Method = "twprojects-create_upload_url"
+	MethodProjectFileAdd  toolsets.Method = "twprojects-add_project_file"
 )
 
 // maxAttachmentBytes caps the decoded size of an inline attachment.
@@ -306,6 +307,130 @@ func UploadURLCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 	}
 }
 
+// projectFileAddResult is what the tool hands back. ID is the durable handle: a
+// reference is spent once, this can be attached as often as it is needed.
+type projectFileAddResult struct {
+	ID    int64  `json:"id"`
+	Usage string `json:"usage"`
+}
+
+// ProjectFileAdd stores an uploaded file in a project's files area, which is
+// what turns a single-use reference into a file that can be attached more than
+// once.
+func ProjectFileAdd(engine *twapi.Engine) toolsets.ToolWrapper {
+	return toolsets.ToolWrapper{
+		Tool: &mcp.Tool{
+			Name: string(MethodProjectFileAdd),
+			Description: fmt.Sprintf("Store an uploaded file in a project's files area, where people "+
+				"find it outside any one task or comment. Upload it first with %s, then pass the "+
+				"reference here. Returns a numeric file ID which, unlike a reference, survives being "+
+				"used: pass it in attachment_file_ids on %s or %s to attach the same file to as many "+
+				"tasks as needed. Attaching a reference to a task, comment or message already files it "+
+				"here, so use this tool to store a file on its own, to describe or categorise it, or "+
+				"when it has to reach more than one place.",
+				MethodUploadURLCreate, MethodTaskCreate, MethodTaskUpdate),
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Add Project File",
+				DestructiveHint: new(false),
+				OpenWorldHint:   new(false),
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"project_id": {
+						Type:        "integer",
+						Description: "The ID of the project whose files area will hold the file.",
+					},
+					"reference": {
+						Type:      "string",
+						MinLength: new(1),
+						Description: fmt.Sprintf("The reference of an uploaded file, as returned by %s or "+
+							"%s. It looks like \"tf_1a2b\" and can only be used once.",
+							MethodUploadURLCreate, MethodFileCreate),
+					},
+					"name": {
+						Description: "Override the name the file was uploaded with, including its extension.",
+						AnyOf:       []*jsonschema.Schema{{Type: "string"}, {Type: "null"}},
+					},
+					"description": {
+						Description: "A description of the file.",
+						AnyOf:       []*jsonschema.Schema{{Type: "string"}, {Type: "null"}},
+					},
+					"category_id": {
+						Description: "File it under an existing file category. Wins over category_name.",
+						AnyOf:       []*jsonschema.Schema{{Type: "integer"}, {Type: "null"}},
+					},
+					"category_name": {
+						Description: "File it under a category with this name, creating one when the " +
+							"project has none. Ignored when category_id is given.",
+						AnyOf: []*jsonschema.Schema{{Type: "string"}, {Type: "null"}},
+					},
+					"tag_ids": helpers.TagIDsAssociateSchema("file"),
+					"private": {
+						Description: "Hide the file from client users.",
+						AnyOf:       []*jsonschema.Schema{{Type: "boolean"}, {Type: "null"}},
+					},
+					"auto_new_version": {
+						Description: "Store it as a new version of an existing file with the same name in " +
+							"the project, rather than as a separate file.",
+						AnyOf: []*jsonschema.Schema{{Type: "boolean"}, {Type: "null"}},
+					},
+					"notify_current_user": {
+						Description: "Notify the user adding the file. Defaults to false.",
+						AnyOf:       []*jsonschema.Schema{{Type: "boolean"}, {Type: "null"}},
+					},
+				},
+				Required: []string{"project_id", "reference"},
+			},
+		},
+		Handler: func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var arguments map[string]any
+			if err := json.Unmarshal(request.Params.Arguments, &arguments); err != nil {
+				return helpers.NewToolResultTextError("failed to decode request: %s", err.Error()), nil
+			}
+
+			var fileCreateRequest projects.FileCreateRequest
+			var reference string
+			// TagIDs is a LegacyNumericList, which the numeric list binder cannot
+			// infer through, so it is bound as its underlying type and converted.
+			var tagIDs []int64
+			if err := helpers.ParamGroup(arguments,
+				helpers.RequiredNumericParam(&fileCreateRequest.Path.ProjectID, "project_id"),
+				helpers.RequiredParam(&reference, "reference"),
+				helpers.OptionalPointerParam(&fileCreateRequest.Name, "name"),
+				helpers.OptionalPointerParam(&fileCreateRequest.Description, "description"),
+				helpers.OptionalNumericPointerParam(&fileCreateRequest.CategoryID, "category_id"),
+				helpers.OptionalPointerParam(&fileCreateRequest.CategoryName, "category_name"),
+				helpers.OptionalNumericListParam(&tagIDs, "tag_ids"),
+				helpers.OptionalPointerParam(&fileCreateRequest.Private, "private"),
+				helpers.OptionalPointerParam(&fileCreateRequest.AutoNewVersion, "auto_new_version"),
+				helpers.OptionalPointerParam(&fileCreateRequest.NotifyCurrentUser, "notify_current_user"),
+			); err != nil {
+				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
+			}
+			fileCreateRequest.TagIDs = projects.LegacyNumericList(tagIDs)
+
+			// A reference surrounded by whitespace is the model's, not the API's,
+			// and the endpoint would reject it as unknown rather than as untidy.
+			fileCreateRequest.PendingFileRef = projects.PendingFileRef(strings.TrimSpace(reference))
+			if fileCreateRequest.PendingFileRef == "" {
+				return helpers.NewToolResultTextError("reference must not be empty"), nil
+			}
+
+			file, err := projects.FileCreate(ctx, engine, fileCreateRequest)
+			if err != nil {
+				return helpers.HandleAPIError(err, "failed to add the file to the project")
+			}
+
+			return helpers.NewToolResultJSON(projectFileAddResult{
+				ID: int64(file.ID),
+				Usage: fmt.Sprintf("Pass %d in attachment_file_ids on %s or %s. Unlike a reference, "+
+					"it can be used more than once.", file.ID, MethodTaskCreate, MethodTaskUpdate),
+			})
+		},
+	}
+}
+
 // parseAttachmentRefs reads the attachment references shared by the tools that
 // can attach a file. It returns nil when the caller named none, so that the
 // request omits the field entirely rather than sending an empty set.
@@ -329,23 +454,62 @@ func parseAttachmentRefs(arguments map[string]any) ([]projects.PendingFileRef, *
 	return cleaned, nil
 }
 
-// parseTaskAttachments reads the attachment references for the task tools,
-// which take the structured form rather than a plain list.
+// attachmentFileIDsSchema returns the schema for the file identifier parameter,
+// which is what a caller uses to attach a file that already exists.
+//
+// It is a separate parameter rather than a value attachment_refs also accepts,
+// because the two are not interchangeable: a reference is spent by the first
+// attachment and an identifier is not. Telling them apart by the "tf_" prefix
+// would work today and encode a guess about the API's identifier format that
+// even the SDK declines to make.
+func attachmentFileIDsSchema(entity string) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: fmt.Sprintf(
+			"IDs of files already in a project's files area to attach to the %s, as returned by "+
+				"%s. Unlike a reference these can be used repeatedly, so this is how one file "+
+				"reaches several tasks. Files are added to whatever is already attached; nothing "+
+				"is removed.",
+			entity, MethodProjectFileAdd),
+		AnyOf: []*jsonschema.Schema{
+			{Type: "array", Items: &jsonschema.Schema{Type: "integer"}},
+			{Type: "null"},
+		},
+	}
+}
+
+// parseTaskAttachments reads the attachments for the task tools, which take the
+// structured form rather than a plain list, and are the only ones that can
+// attach a file that already exists as well as a freshly uploaded one.
 func parseTaskAttachments(arguments map[string]any) (*projects.TaskAttachments, *mcp.CallToolResult) {
 	refs, toolResult := parseAttachmentRefs(arguments)
 	if toolResult != nil {
 		return nil, toolResult
 	}
-	if len(refs) == 0 {
+
+	var fileIDs []int64
+	if err := helpers.ParamGroup(arguments,
+		helpers.OptionalNumericListParam(&fileIDs, "attachment_file_ids"),
+	); err != nil {
+		return nil, helpers.NewToolResultTextError("invalid attachment_file_ids: %s", err.Error())
+	}
+
+	if len(refs) == 0 && len(fileIDs) == 0 {
 		return nil, nil
 	}
 
-	attachments := projects.TaskAttachments{
-		PendingFiles: make([]projects.TaskAttachmentPendingFile, 0, len(refs)),
+	var attachments projects.TaskAttachments
+	if len(refs) > 0 {
+		attachments.PendingFiles = make([]projects.TaskAttachmentPendingFile, 0, len(refs))
+		for _, ref := range refs {
+			attachments.PendingFiles = append(attachments.PendingFiles,
+				projects.TaskAttachmentPendingFile{Reference: ref})
+		}
 	}
-	for _, ref := range refs {
-		attachments.PendingFiles = append(attachments.PendingFiles,
-			projects.TaskAttachmentPendingFile{Reference: ref})
+	if len(fileIDs) > 0 {
+		attachments.Files = make([]projects.TaskAttachmentFile, 0, len(fileIDs))
+		for _, fileID := range fileIDs {
+			attachments.Files = append(attachments.Files, projects.TaskAttachmentFile{ID: fileID})
+		}
 	}
 	return &attachments, nil
 }

--- a/internal/twprojects/files_test.go
+++ b/internal/twprojects/files_test.go
@@ -1,6 +1,7 @@
 package twprojects_test
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -577,5 +578,149 @@ func TestUploadURLCreateRejectsBadInput(t *testing.T) {
 				t.Errorf("expected no request to be sent, got %d", len(*recorded))
 			}
 		})
+	}
+}
+
+func TestProjectFileAdd(t *testing.T) {
+	mcpServer, recorded := mcpServerRecordingMock(t, []testutil.ProjectsMockRoute{{
+		Match:  "/projects/777/files",
+		Method: http.MethodPost,
+		Status: http.StatusCreated,
+		Body:   []byte(`{"id":"4242"}`),
+	}}, http.StatusCreated, []byte(`{"id":"4242"}`))
+
+	var result map[string]any
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodProjectFileAdd.String(), map[string]any{
+		"project_id":    777,
+		"reference":     "  tf_1a2b  ",
+		"name":          "contract.pdf",
+		"description":   "Signed original",
+		"category_name": "Contracts",
+		"private":       true,
+	},
+		testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, message mcp.Result) {
+			t.Helper()
+			result = decodeToolJSON(t, message)
+		}),
+	)
+
+	if len(*recorded) != 1 {
+		t.Fatalf("expected one request, got %d", len(*recorded))
+	}
+
+	var body struct {
+		File struct {
+			PendingFileRef string `json:"pendingFileRef"`
+			Name           string `json:"name"`
+			Description    string `json:"description"`
+			CategoryName   string `json:"category-name"`
+			Private        bool   `json:"private"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal((*recorded)[0].Body, &body); err != nil {
+		t.Fatalf("failed to decode the request body: %s", err)
+	}
+
+	// Whitespace is the model's, not the API's, and the endpoint would reject
+	// the padded form as an unknown reference rather than as untidy.
+	if body.File.PendingFileRef != "tf_1a2b" {
+		t.Errorf("expected the trimmed reference on the wire, got %q", body.File.PendingFileRef)
+	}
+	if body.File.Name != "contract.pdf" {
+		t.Errorf("expected the name on the wire, got %q", body.File.Name)
+	}
+	if body.File.Description != "Signed original" {
+		t.Errorf("expected the description on the wire, got %q", body.File.Description)
+	}
+	if body.File.CategoryName != "Contracts" {
+		t.Errorf("expected the category name on the wire, got %q", body.File.CategoryName)
+	}
+	if !body.File.Private {
+		t.Error("expected the file to be marked private on the wire")
+	}
+
+	// The durable handle, which is the whole reason to file it here.
+	if got := result["id"]; got != float64(4242) {
+		t.Errorf("expected the created file ID, got %v", got)
+	}
+}
+
+func TestProjectFileAddRejectsBlankReference(t *testing.T) {
+	mcpServer, recorded := mcpServerRecordingMock(t, nil, http.StatusCreated, []byte(`{"id":"1"}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodProjectFileAdd.String(), map[string]any{
+		"project_id": 777,
+		"reference":  "   ",
+	},
+		testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+			t.Helper()
+			assertErrorResultContains(t, result, "must not be empty")
+		}),
+	)
+
+	if len(*recorded) != 0 {
+		t.Errorf("expected no request to be sent, got %d", len(*recorded))
+	}
+}
+
+// TestTaskAttachmentFileIDsReachTheWire covers the half that makes a filed
+// document worth having: an identifier survives being used, so the same file
+// reaches more than one task. The mocks reply the same either way, so this has
+// to assert on the encoded body.
+func TestTaskAttachmentFileIDsReachTheWire(t *testing.T) {
+	mcpServer, recorded := mcpServerRecordingMock(t, nil, http.StatusCreated, []byte(`{"task":{"id":1}}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskCreate.String(), map[string]any{
+		"tasklist_id":         123,
+		"name":                "Countersign the contract",
+		"attachment_file_ids": []any{4242, 4243},
+		"attachment_refs":     []any{"tf_A"},
+	})
+
+	if len(*recorded) == 0 {
+		t.Fatal("expected the task to be created")
+	}
+
+	var body struct {
+		Attachments struct {
+			Files []struct {
+				ID int64 `json:"id"`
+			} `json:"files"`
+			PendingFiles []struct {
+				Reference string `json:"reference"`
+			} `json:"pendingFiles"`
+		} `json:"attachments"`
+	}
+	if err := json.Unmarshal((*recorded)[0].Body, &body); err != nil {
+		t.Fatalf("failed to decode the request body: %s", err)
+	}
+
+	if len(body.Attachments.Files) != 2 {
+		t.Fatalf("expected two file attachments, got %d", len(body.Attachments.Files))
+	}
+	if body.Attachments.Files[0].ID != 4242 || body.Attachments.Files[1].ID != 4243 {
+		t.Errorf("expected the file IDs on the wire, got %+v", body.Attachments.Files)
+	}
+	// The two forms are independent, so naming one must not drop the other.
+	if len(body.Attachments.PendingFiles) != 1 || body.Attachments.PendingFiles[0].Reference != "tf_A" {
+		t.Errorf("expected the pending reference alongside, got %+v", body.Attachments.PendingFiles)
+	}
+}
+
+// TestTaskAttachmentsOmittedWithoutEither pins that adding the second parameter
+// did not start sending an empty attachments object on every task.
+func TestTaskAttachmentsOmittedWithoutEither(t *testing.T) {
+	mcpServer, recorded := mcpServerRecordingMock(t, nil, http.StatusCreated, []byte(`{"task":{"id":1}}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTaskCreate.String(), map[string]any{
+		"tasklist_id": 123,
+		"name":        "No attachments here",
+	})
+
+	if len(*recorded) == 0 {
+		t.Fatal("expected the task to be created")
+	}
+	if bytes.Contains((*recorded)[0].Body, []byte(`"attachments"`)) {
+		t.Errorf("expected no attachments key, got %s", (*recorded)[0].Body)
 	}
 }

--- a/internal/twprojects/tasks.go
+++ b/internal/twprojects/tasks.go
@@ -152,9 +152,10 @@ func TaskCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"assignees":       helpers.UserGroupsSchema("Assignees for the task.", false),
-					"tag_ids":         helpers.TagIDsAssociateSchema("task"),
-					"attachment_refs": attachmentRefsSchema("task"),
+					"assignees":           helpers.UserGroupsSchema("Assignees for the task.", false),
+					"tag_ids":             helpers.TagIDsAssociateSchema("task"),
+					"attachment_refs":     attachmentRefsSchema("task"),
+					"attachment_file_ids": attachmentFileIDsSchema("task"),
 					"predecessors": {
 						Description: "Task dependencies that must be completed before this task can start.",
 						AnyOf: []*jsonschema.Schema{
@@ -393,8 +394,9 @@ func TaskUpdate(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
-					"tag_ids":         helpers.TagIDsAssociateSchema("task"),
-					"attachment_refs": attachmentRefsSchema("task"),
+					"tag_ids":             helpers.TagIDsAssociateSchema("task"),
+					"attachment_refs":     attachmentRefsSchema("task"),
+					"attachment_file_ids": attachmentFileIDsSchema("task"),
 					"predecessors": {
 						Description: "Task dependencies that must be completed before this task can start.",
 						AnyOf: []*jsonschema.Schema{

--- a/internal/twprojects/tools.go
+++ b/internal/twprojects/tools.go
@@ -53,6 +53,7 @@ func DefaultToolsetGroup(readOnly, allowDelete bool, engine *twapi.Engine) *tool
 	projectsWriteTools := []toolsets.ToolWrapper{
 		FileCreate(engine),
 		UploadURLCreate(engine),
+		ProjectFileAdd(engine),
 		ProjectCategoryCreate(engine),
 		ProjectCategoryUpdate(engine),
 		ProjectClone(engine),


### PR DESCRIPTION
Stacked on #489 — review that first. Base is `feature/create-upload-url`, so this diff shows
only the files-area work.

## Why

Chasing the customer's upload complaint turned up two gaps behind it.

**Nothing calls `projects.FileCreate`.** A file could only ever arrive in a project's files
area as a side effect of being attached to a task, comment or message. There was no way to
store one on its own, or to give it a description, category or tags. `twprojects-create_file`
is named for this and does something else — it produces a pending reference.

**A pending reference is spent by the first attachment**, and the files area is the only
route to an identifier that is not. But `parseTaskAttachments` filled
`TaskAttachments.PendingFiles` and never `.Files`, so nothing could consume one. A single
document belonging to three tasks had to be uploaded three times.

That second one is the customer's actual use case — one insurance certificate referenced
from several tasks — even though it is not what they filed.

## What

`twprojects-add_project_file {project_id, reference, …}` stores an uploaded file in a
project's files area and answers with its ID.

`attachment_file_ids` on `create_task` and `update_task` accepts those IDs alongside
`attachment_refs`.

**Why two parameters rather than one that takes either:** they are not interchangeable —
one is spent by the first attachment and the other is not — and telling them apart by the
`tf_` prefix would encode a guess about the identifier format that the SDK itself declines
to make (it never parses or constructs that prefix).

## Verification

`go build ./... && go vet ./... && go test ./...` all pass; docs regenerated.

Per `AGENTS.md`, the mocks reply the same either way, so the tests assert on the encoded
body rather than on the call succeeding: `pendingFileRef` and the optional fields reach the
`POST /projects/{id}/files.json` body, and both attachment forms survive together on a task.

`TestTaskAttachmentsOmittedWithoutEither` is the regression guard — adding a second
parameter must not start sending an empty `attachments` object on every task. The
pre-existing `TestTaskAttachmentsOmittedWhenNotRequested` in the SDK still passes too.

Token cost, per `go run ./cmd/mcp-tokens -base=main`: **+665** for this PR (+982 for the
stack). `add_project_file` +499, and +83 each on `create_task`/`update_task`.

## Open questions for you, @rafaeljusto

1. **Was `.Files` left out deliberately?** You restricted comments to pending refs only for
   a stated reason (the endpoint takes nothing else). If the task `.Files` omission was also
   deliberate rather than incidental, say so and I will drop that half — I could not tell
   from the code which it was.
2. **Naming.** `create_file` produces a reference, `add_project_file` consumes one. I avoided
   renaming `create_file` because it is shipped and clients depend on it, and instead
   rewrote its description to say what it actually returns. Still not lovely.
3. **Messages are deliberately untouched.** `MessageCreateRequest.Attachments` is a
   `LegacyNumericList` that would take file IDs the same way, but that is outside the three
   flows this work was scoped to, so it is a follow-up rather than a quiet widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
