### PR TITLE
Feature: Filter the timelog list by billable and invoiced state

### DIFF
--- a/internal/twprojects/timelogs.go
+++ b/internal/twprojects/timelogs.go
@@ -490,6 +490,33 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 							{Type: "null"},
 						},
 					},
+					"billable_type": {
+						Description: "Restrict the results to billable or non-billable timelogs. Omit, or pass all, " +
+							"to include both. For billable hours rather than the entries themselves, " +
+							"twprojects-summarize_timelogs reports them without paging.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{
+								string(projects.TimelogBillableTypeAll),
+								string(projects.TimelogBillableTypeBillable),
+								string(projects.TimelogBillableTypeNonBillable),
+							}},
+							{Type: "null"},
+						},
+					},
+					"invoiced_type": {
+						Description: "Restrict the results to timelogs that have or have not been added to an " +
+							"invoice. Omit, or pass all, to include both. Invoiced is not the same as billed: " +
+							"noninvoiced answers \"what is still to be invoiced\" only for billable time, so pass " +
+							"billable_type alongside it.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "string", Enum: []any{
+								string(projects.TimelogInvoicedTypeAll),
+								string(projects.TimelogInvoicedTypeInvoiced),
+								string(projects.TimelogInvoicedTypeNonInvoiced),
+							}},
+							{Type: "null"},
+						},
+					},
 					"order_by":   timelogOrdering.orderBySchema(),
 					"order_mode": orderModeSchema(),
 					"page":       helpers.PageSchema(),
@@ -522,6 +549,18 @@ func TimelogList(engine *twapi.Engine) toolsets.ToolWrapper {
 				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToCompanyIDs, "assigned_company_ids"),
 				helpers.OptionalNumericListParam(&timelogListRequest.Filters.AssignedToTeamIDs, "assigned_team_ids"),
 				helpers.OptionalNumericListParam(&timelogListRequest.Filters.DeskTicketIDs, "ticketIds"),
+				helpers.OptionalParam(&timelogListRequest.Filters.BillableType, "billable_type",
+					helpers.RestrictValues(
+						projects.TimelogBillableTypeAll,
+						projects.TimelogBillableTypeBillable,
+						projects.TimelogBillableTypeNonBillable,
+					)),
+				helpers.OptionalParam(&timelogListRequest.Filters.InvoicedType, "invoiced_type",
+					helpers.RestrictValues(
+						projects.TimelogInvoicedTypeAll,
+						projects.TimelogInvoicedTypeInvoiced,
+						projects.TimelogInvoicedTypeNonInvoiced,
+					)),
 				timelogOrdering.param(&timelogListRequest.Filters.OrderBy, &timelogListRequest.Filters.OrderMode),
 				helpers.OptionalNumericParam(&timelogListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&timelogListRequest.Filters.PageSize, "page_size"),

--- a/internal/twprojects/timelogs_test.go
+++ b/internal/twprojects/timelogs_test.go
@@ -214,3 +214,95 @@ func TestTimelogListByTask(t *testing.T) {
 		"page_size":            float64(10),
 	})
 }
+
+// TestTimelogListBillableAndInvoicedFilters asserts both filters reach the query
+// string. The mock answers with the same body either way, so a filter that never
+// leaves the process looks exactly like a working one from the caller's side —
+// and a dropped billable filter is worse than no filter at all, since the caller
+// then reports non-billable time as billable.
+func TestTimelogListBillableAndInvoicedFilters(t *testing.T) {
+	tests := []struct {
+		name         string
+		arguments    map[string]any
+		billableType string
+		invoicedType string
+	}{{
+		name:         "billable only",
+		arguments:    map[string]any{"billable_type": "billable"},
+		billableType: "billable",
+	}, {
+		name:         "non-billable only",
+		arguments:    map[string]any{"billable_type": "nonbillable"},
+		billableType: "nonbillable",
+	}, {
+		name:         "invoiced only",
+		arguments:    map[string]any{"invoiced_type": "invoiced"},
+		invoicedType: "invoiced",
+	}, {
+		name: "billable and not yet invoiced",
+		arguments: map[string]any{
+			"billable_type": "billable",
+			"invoiced_type": "noninvoiced",
+		},
+		billableType: "billable",
+		invoicedType: "noninvoiced",
+	}, {
+		name:         "an explicit all is sent as-is",
+		arguments:    map[string]any{"billable_type": "all"},
+		billableType: "all",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, lastURL := testutil.ProjectsMCPServerMockWithRequestURL(t, http.StatusOK, []byte(`{}`))
+
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogList.String(), tt.arguments)
+
+			query := lastURL.Query()
+			if got := query.Get("billableType"); got != tt.billableType {
+				t.Errorf("expected billableType=%q but got %q (raw query: %s)", tt.billableType, got, lastURL.RawQuery)
+			}
+			if got := query.Get("invoicedType"); got != tt.invoicedType {
+				t.Errorf("expected invoicedType=%q but got %q (raw query: %s)", tt.invoicedType, got, lastURL.RawQuery)
+			}
+		})
+	}
+}
+
+// TestTimelogListRejectsUnknownBillableAndInvoicedValues covers the enum being
+// closed. The endpoint ignores a query parameter it cannot parse, so accepting
+// "unbilled" here would silently widen the results to every entry rather than
+// failing the call.
+func TestTimelogListRejectsUnknownBillableAndInvoicedValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{{
+		name:      "billable_type outside the enum",
+		arguments: map[string]any{"billable_type": "unbilled"},
+	}, {
+		name:      "invoiced_type outside the enum",
+		arguments: map[string]any{"invoiced_type": "billed"},
+	}, {
+		name:      "a boolean instead of the enum",
+		arguments: map[string]any{"billable_type": true},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{}`))
+
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodTimelogList.String(), tt.arguments,
+				testutil.ExecuteToolRequestWithCheckMessage(func(t *testing.T, result mcp.Result) {
+					t.Helper()
+					toolResult, ok := result.(*mcp.CallToolResult)
+					if !ok {
+						t.Fatalf("unexpected result type: %T", result)
+					}
+					if !toolResult.IsError {
+						t.Errorf("expected an error tool result but the call succeeded")
+					}
+				}))
+		})
+	}
+}


### PR DESCRIPTION
## Description

`GET /time` accepts `billableType` and `invoicedType`, but `list_timelogs` exposes neither, so a caller wanting billable entries had to page the whole list and filter them itself. `count_timelogs` inherits both through `countTool`.

Closed enums rather than booleans, matching the tri-state the endpoint takes. An unknown value fails the call rather than being dropped: the endpoint ignores a query parameter it cannot parse, so a typo would quietly widen the results to every entry.

Needs SDK v1.26.0 for the filter fields.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors