### PR TITLE
Feature: Add deadline and completed filters to list_milestones

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sonh/qs v0.7.0
 	github.com/teamwork/desksdkgo v1.1.0
 	github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb
-	github.com/teamwork/twapi-go-sdk v1.25.0
+	github.com/teamwork/twapi-go-sdk v1.26.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/teamwork/desksdkgo v1.1.0 h1:PpIquf92fAtT0qtSMGK3LGRxAvIPDjl7/jkSh0/F
 github.com/teamwork/desksdkgo v1.1.0/go.mod h1:Mgvw83q8iqHr7Sm9xV1iI/T89o3ObaPU3ChMJheRzwA=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb h1:bQluDjySZeC5etnWgjk4WFRy0PvzGDw8XEBd4JJYWCQ=
 github.com/teamwork/spacessdkgo v0.0.0-20260518181558-a6af69d00abb/go.mod h1:jfE0RLsZuk/3Glzs5bJ95pNb92emV7uXZYgoGSLQ76I=
-github.com/teamwork/twapi-go-sdk v1.25.0 h1:sikgIcdo2Mc3lJT6vKo0I5IkZfR9O05namsute2AXrQ=
-github.com/teamwork/twapi-go-sdk v1.25.0/go.mod h1:akTysmeHa9IACt/jMtpRZRy+aLHFlJWge27vqNLpgsc=
+github.com/teamwork/twapi-go-sdk v1.26.0 h1:aBVVoRswe/Qf03UCn8oUgyqB3muVrNehmXwJsH5Qp8U=
+github.com/teamwork/twapi-go-sdk v1.26.0/go.mod h1:akTysmeHa9IACt/jMtpRZRy+aLHFlJWge27vqNLpgsc=
 github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
 github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/twprojects/milestones.go
+++ b/internal/twprojects/milestones.go
@@ -365,8 +365,10 @@ func MilestoneGet(engine *twapi.Engine) toolsets.ToolWrapper {
 func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 	return toolsets.ToolWrapper{
 		Tool: &mcp.Tool{
-			Name:        string(MethodMilestoneList),
-			Description: "List milestones. Scope by project_id or omit for site-wide.",
+			Name: string(MethodMilestoneList),
+			Description: "List milestones. Scope by project_id or omit for site-wide. Completed milestones are " +
+				"included by default; pass show_completed false to see only the outstanding ones. Use due_after " +
+				"and due_before to bound the deadline instead of listing everything and filtering afterwards.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "List Milestones",
 				ReadOnlyHint:    true,
@@ -396,13 +398,28 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 					},
 					"tag_ids":        helpers.TagIDsFilterSchema("milestones"),
 					"match_all_tags": helpers.MatchAllTagsSchema(),
-					"order_by":       milestoneOrdering.orderBySchema(),
-					"order_mode":     orderModeSchema(),
-					"page":           helpers.PageSchema(),
-					"page_size":      helpers.PageSizeSchema(),
-					"verbose":        helpers.VerboseSchema(),
-					"count_only":     helpers.CountOnlySchema("milestones"),
-					"fields":         helpers.FieldsSchema[projects.Milestone]("milestone"),
+					"due_after": helpers.DateFilterSchema(
+						"Only include milestones with a deadline on or after this date.",
+					),
+					"due_before": helpers.DateFilterSchema(
+						"Only include milestones with a deadline on or before this date.",
+					),
+					"show_completed": {
+						Description: "If false, only return milestones that are not completed yet. Included by default, " +
+							"unlike the task and tasklist lists.",
+						AnyOf: []*jsonschema.Schema{
+							{Type: "boolean"},
+							{Type: "null"},
+						},
+						Default: []byte(`true`),
+					},
+					"order_by":   milestoneOrdering.orderBySchema(),
+					"order_mode": orderModeSchema(),
+					"page":       helpers.PageSchema(),
+					"page_size":  helpers.PageSizeSchema(),
+					"verbose":    helpers.VerboseSchema(),
+					"count_only": helpers.CountOnlySchema("milestones"),
+					"fields":     helpers.FieldsSchema[projects.Milestone]("milestone"),
 				},
 				Required: []string{},
 			},
@@ -417,11 +434,15 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 			}
 			verbose := true
 			var countOnly bool
+			var showCompleted *bool
 			err := helpers.ParamGroup(arguments,
 				helpers.OptionalNumericParam(&milestoneListRequest.Path.ProjectID, "project_id"),
 				helpers.OptionalParam(&milestoneListRequest.Filters.SearchTerm, "search_term"),
 				helpers.OptionalNumericListParam(&milestoneListRequest.Filters.TagIDs, "tag_ids"),
 				helpers.OptionalPointerParam(&milestoneListRequest.Filters.MatchAllTags, "match_all_tags"),
+				helpers.OptionalDatePointerParam(&milestoneListRequest.Filters.DueAfter, "due_after"),
+				helpers.OptionalDatePointerParam(&milestoneListRequest.Filters.DueBefore, "due_before"),
+				helpers.OptionalPointerParam(&showCompleted, "show_completed"),
 				milestoneOrdering.param(&milestoneListRequest.Filters.OrderBy, &milestoneListRequest.Filters.OrderMode),
 				helpers.OptionalNumericParam(&milestoneListRequest.Filters.Page, "page"),
 				helpers.OptionalNumericParam(&milestoneListRequest.Filters.PageSize, "page_size"),
@@ -431,6 +452,15 @@ func MilestoneList(engine *twapi.Engine) toolsets.ToolWrapper {
 			)
 			if err != nil {
 				return helpers.NewToolResultTextError("invalid parameters: %s", err.Error()), nil
+			}
+
+			// The endpoint returns milestones in every state, so hiding the completed
+			// ones means asking for the incomplete ones by name. Only an explicit false
+			// narrows the list: unset leaves the endpoint's own default in place.
+			if showCompleted != nil && !*showCompleted {
+				milestoneListRequest.Filters.Statuses = []projects.MilestoneStatus{
+					projects.MilestoneStatusIncomplete,
+				}
 			}
 
 			if !verbose && len(milestoneListRequest.Filters.Fields.Milestones) == 0 {

--- a/internal/twprojects/milestones_test.go
+++ b/internal/twprojects/milestones_test.go
@@ -62,6 +62,9 @@ func TestMilestoneList(t *testing.T) {
 		"search_term":    "test",
 		"tag_ids":        []float64{1, 2, 3},
 		"match_all_tags": true,
+		"due_after":      "2026-03-04",
+		"due_before":     "2026-05-06",
+		"show_completed": false,
 		"page":           float64(1),
 		"page_size":      float64(10),
 	})
@@ -77,4 +80,66 @@ func TestMilestoneListByProject(t *testing.T) {
 		"page":           float64(1),
 		"page_size":      float64(10),
 	})
+}
+
+// TestMilestoneListDeadlineFilters covers the reason these filters exist: a
+// schedule check bounds the deadline server-side instead of paging every
+// milestone and discarding most of them, so the dates have to reach the wire.
+func TestMilestoneListDeadlineFilters(t *testing.T) {
+	mcpServer, recorded := mcpServerRecordingMock(t, nil, http.StatusOK, []byte(`{}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMilestoneList.String(), map[string]any{
+		"due_after":  "2026-03-04",
+		"due_before": "2026-05-06",
+	})
+
+	if len(*recorded) == 0 {
+		t.Fatal("expected the milestones to be listed")
+	}
+	query := (*recorded)[0].URL.Query()
+	if got := query.Get("dueAfter"); got != "2026-03-04" {
+		t.Errorf("expected dueAfter=2026-03-04 but got %q", got)
+	}
+	if got := query.Get("dueBefore"); got != "2026-05-06" {
+		t.Errorf("expected dueBefore=2026-05-06 but got %q", got)
+	}
+}
+
+// TestMilestoneListShowCompleted pins the one parameter that is not passed
+// straight through. Milestones are returned in every state, so hiding the
+// completed ones means naming the incomplete ones, and only an explicit false
+// may do that: leaving it out has to keep the endpoint's own behaviour.
+func TestMilestoneListShowCompleted(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		want      string
+	}{{
+		name:      "false narrows the list to incomplete milestones",
+		arguments: map[string]any{"show_completed": false},
+		want:      "incomplete",
+	}, {
+		name:      "true leaves every state in",
+		arguments: map[string]any{"show_completed": true},
+		want:      "",
+	}, {
+		name:      "unset leaves every state in",
+		arguments: map[string]any{},
+		want:      "",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, recorded := mcpServerRecordingMock(t, nil, http.StatusOK, []byte(`{}`))
+
+			testutil.ExecuteToolRequest(t, mcpServer, twprojects.MethodMilestoneList.String(), tt.arguments)
+
+			if len(*recorded) == 0 {
+				t.Fatal("expected the milestones to be listed")
+			}
+			if got := (*recorded)[0].URL.Query().Get("status"); got != tt.want {
+				t.Errorf("expected status=%q but got %q", tt.want, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

Adds `due_after`, `due_before` and `show_completed`, so a schedule check can filter in the request instead of paging through every milestone and filtering the reply.

`show_completed` defaults to true, unlike `list_tasks`: milestones come back in every state, so only an explicit false narrows the list. Needs SDK v1.26.0.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors