### PR TITLE
Docs: Point attachment_refs at the pre-signed upload path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1099,10 +1099,10 @@ footer p { margin: 0 0 6px; }
               <span class="tool__name">twprojects-create_project_template</span>
               <span class="tool__desc">Create project template.</span>
             </div>
-            <div class="tool" data-search="twprojects-create_upload_url reserve an upload for a file and get back a short-lived url to send its bytes to, plus a single-use reference like &#34;tf_1a2b&#34;." data-access="write">
+            <div class="tool" data-search="twprojects-create_upload_url reserve an upload for a file and get back a short-lived url to send its bytes to, plus a single-use reference." data-access="write">
               <span class="badge badge--write">write</span>
               <span class="tool__name">twprojects-create_upload_url</span>
-              <span class="tool__desc">Reserve an upload for a file and get back a short-lived URL to send its bytes to, plus a single-use reference like &#34;tf_1a2b&#34;.</span>
+              <span class="tool__desc">Reserve an upload for a file and get back a short-lived URL to send its bytes to, plus a single-use reference.</span>
             </div>
             <div class="tool" data-search="twprojects-get_custom_field get custom field." data-access="read">
               <span class="badge badge--read">read</span>

--- a/internal/twprojects/files.go
+++ b/internal/twprojects/files.go
@@ -57,10 +57,11 @@ const maxFileNameBytes = 200
 func attachmentRefsSchema(entity string) *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Description: fmt.Sprintf(
-			"References of files to attach to the %s, as returned by %s. Each looks like "+
-				"\"tf_1a2b\" and can only be used once, so upload a file for each place it "+
-				"should go. Files are added to whatever is already attached; nothing is removed.",
-			entity, MethodFileCreate),
+			"References of files to attach to the %s, as returned by %s or %s. Each is \"tf_\" "+
+				"followed by a UUID and the file extension, and can only be used once, so reserve "+
+				"an upload for each place a file should go. Files are added to whatever is already "+
+				"attached; nothing is removed.",
+			entity, MethodUploadURLCreate, MethodFileCreate),
 		AnyOf: []*jsonschema.Schema{
 			{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
 			{Type: "null"},
@@ -85,7 +86,7 @@ func FileCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 			Name: string(MethodFileCreate),
 			Description: fmt.Sprintf("Upload short text you are generating yourself, such as a plan, a "+
 				"spec or a CSV, so it can be attached to a task, comment or message. Returns a "+
-				"single-use reference like \"tf_1a2b\"; pass it in attachment_refs on %s, %s, %s or %s. "+
+				"single-use reference; pass it in attachment_refs on %s, %s, %s or %s. "+
 				"Content is sent inline as base64, which means you have to emit the whole file as text, "+
 				"so use %s instead for anything that already exists as a file — it hands back a URL to "+
 				"send the bytes to directly, and is the only safe option for a document that must stay "+
@@ -205,10 +206,10 @@ func UploadURLCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 		Tool: &mcp.Tool{
 			Name: string(MethodUploadURLCreate),
 			Description: fmt.Sprintf("Reserve an upload for a file and get back a short-lived URL to "+
-				"send its bytes to, plus a single-use reference like \"tf_1a2b\". Use this for any file "+
+				"send its bytes to, plus a single-use reference. Use this for any file "+
 				"that already exists — a PDF, an image, a signed document — because the bytes go straight "+
 				"from you to storage and are never read into the conversation. Send the file with the "+
-				"returned method, URL and headers, adding Content-Length set to size, and no "+
+				"returned method and URL, setting exactly the headers returned and no "+
 				"authorization of your own. Then pass the reference in attachment_refs on %s, %s, %s or "+
 				"%s. Prefer %s only for short text you are generating yourself.",
 				MethodTaskCreate, MethodTaskUpdate, MethodCommentCreate, MethodMessageCreate,
@@ -345,7 +346,8 @@ func ProjectFileAdd(engine *twapi.Engine) toolsets.ToolWrapper {
 						Type:      "string",
 						MinLength: new(1),
 						Description: fmt.Sprintf("The reference of an uploaded file, as returned by %s or "+
-							"%s. It looks like \"tf_1a2b\" and can only be used once.",
+							"%s. It is \"tf_\" followed by a UUID and the file extension, and can only be "+
+							"used once.",
 							MethodUploadURLCreate, MethodFileCreate),
 					},
 					"name": {


### PR DESCRIPTION
## What

`attachment_refs` on `create_task`, `update_task`, `create_comment` and `create_message` described its references as coming from `twprojects-create_file` alone. A client reading only the parameter schema — the common case — had no indication that a `twprojects-create_upload_url` reference belonged there, which steers it onto the inline base64 path for files that already exist. The description now names `create_upload_url` first.

Two smaller corrections in the same file:

- `"tf_1a2b"` is not the shape of an issued reference. Where the reference is an input (`attachment_refs`, `add_project_file.reference`) the description now gives the real shape; where it is an output (`create_file`, `create_upload_url`) the example is dropped, since the value is in the result.
- `create_upload_url` told the caller to send the returned headers "adding Content-Length set to size", but the handler already sets `Content-Length` in the map it returns. It now says to send exactly the headers returned, which is what the `usage` string already said.

## Verification

Tool descriptions only — no behaviour change. `go build ./...`, `go vet` and `go test ./internal/twprojects/` pass; no test asserted on the description text. All four descriptions were rendered to confirm the substitutions read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
