### PR TITLE
Fix: Tell callers to omit notify and keep the default recipients

### DIFF
--- a/pkg/helpers/schema.go
+++ b/pkg/helpers/schema.go
@@ -231,17 +231,32 @@ func userGroupsSchema(description string, required, jobRoles bool) *jsonschema.S
 // before the handler runs, so parseNotify (twprojects) can only coerce what
 // the schema allows. false = notify nobody. true = followers and the default
 // when withFollowers (comments), otherwise an alias for "all", the default.
+//
+// The description opens by telling the caller to omit it, because the parameter
+// is a trap in the one shape a model reaches for most. On the wire notify is a
+// single value, so a supplied one *replaces* the default recipients instead of
+// widening them: asked to comment and let one person know, a model sets notify
+// to that person alone and every follower the default would have notified is
+// dropped, silently — the response says nothing about who was told. Omitting the
+// parameter is not the same as omitting the field, which is why the advice is
+// safe to give: the handlers substitute their own default (followers for
+// comments, "all" elsewhere), where the API left to itself notifies nobody.
 func NotifySchema(description string, withFollowers bool) *jsonschema.Schema {
 	defaultValue := json.RawMessage(`"all"`)
+	defaultRecipients := "all project members"
 	boolDescription := `true is the same as "all": notify all project members. false notifies nobody.`
 	boolPhrase := `, the boolean true as an alias for "all"`
 	if withFollowers {
 		defaultValue = json.RawMessage(`true`)
+		defaultRecipients = "every follower of the related entity"
 		boolDescription = "true notifies all followers of the entity this comment is related to. " +
 			"false notifies nobody."
 		boolPhrase = ", the boolean true to notify all followers of the related entity"
 	}
-	description += ` Accepts the string "all" to notify all project members` + boolPhrase +
+	description += " Omit it unless the user named who to notify: the default notifies " + defaultRecipients +
+		", and a value here replaces that set rather than adding to it, so a narrower one silently drops " +
+		"everyone else who would have been told." +
+		` Accepts the string "all" to notify all project members` + boolPhrase +
 		`, the boolean false to notify nobody, a plain array of user IDs (e.g. [123, 456]), ` +
 		`or an object selecting user_ids, company_ids, team_ids and/or job_role_ids ` +
 		`(e.g. {"user_ids": [123, 456]}).`

--- a/pkg/helpers/schema_test.go
+++ b/pkg/helpers/schema_test.go
@@ -1,6 +1,7 @@
 package helpers_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -225,6 +226,68 @@ func TestUserGroupsSchemaWithoutJobRoles(t *testing.T) {
 			t.Errorf("UserGroupsSchema MaxProperties = %v, want 4", got.MaxProperties)
 		}
 	})
+}
+
+func TestNotifySchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		withFollowers bool
+		wantDefault   string
+		wantRecipient string
+	}{
+		{
+			name:          "project members",
+			wantDefault:   `"all"`,
+			wantRecipient: "all project members",
+		},
+		{
+			name:          "followers",
+			withFollowers: true,
+			wantDefault:   "true",
+			wantRecipient: "every follower of the related entity",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := helpers.NotifySchema("Who to notify.", tt.withFollowers)
+			if !strings.HasPrefix(got.Description, "Who to notify. ") {
+				t.Errorf("NotifySchema description = %q, want the caller's text first", got.Description)
+			}
+			if string(got.Default) != tt.wantDefault {
+				t.Errorf("NotifySchema Default = %q, want %s", string(got.Default), tt.wantDefault)
+			}
+			// Advertising the shapes is not enough. A supplied value replaces the
+			// default recipients, so a model that fills the parameter in to notify
+			// one person drops every follower it was never asked to drop - and the
+			// response says nothing about it. The description has to say so, and
+			// has to name the default it would be replacing.
+			wantPhrases := []string{
+				"Omit it unless",
+				tt.wantRecipient,
+				"replaces that set rather than adding to it",
+			}
+			for _, want := range wantPhrases {
+				if !strings.Contains(got.Description, want) {
+					t.Errorf("NotifySchema description missing %q: %q", want, got.Description)
+				}
+			}
+			// Every shape parseNotify coerces has to be advertised here, or SDK
+			// validation rejects it before the handler can coerce anything.
+			var types []string
+			for _, branch := range got.AnyOf {
+				types = append(types, branch.Type)
+			}
+			for _, want := range []string{"string", "boolean", "array", "object", "null"} {
+				if !slices.Contains(types, want) {
+					t.Errorf("NotifySchema AnyOf missing a %s branch, got %v", want, types)
+				}
+			}
+		})
+	}
 }
 
 func TestDateTimeFilterSchema(t *testing.T) {


### PR DESCRIPTION
## The trap

`notify` is a single value on the wire — `true`, `"ALL"`, or a comma-separated ID list. There is no additive shape, so a supplied value **replaces** the default recipients rather than widening them. Asked to comment and let one person know, a client sets `notify` to that person alone and every follower the default would have notified is dropped.

Nothing reveals it. The response carries no recipient list, `projects.Comment` has no follower field, and no read path returns one — so the call succeeds identically either way and the mistake is never learnt.

The description advertised the accepted shapes and said nothing about the cost of using one, which reads as an invitation to fill the parameter in.

## The change

`helpers.NotifySchema` now opens by telling the caller to omit it, and names the default it would be replacing:

> Who to notify of the new comment. **Omit it unless the user named who to notify: the default notifies every follower of the related entity, and a value here replaces that set rather than adding to it, so a narrower one silently drops everyone else who would have been told.** Accepts the string "all" …

The wording follows the parameter's existing split: *every follower of the related entity* for comments, *all project members* for messages, replies and links — all 8 call sites, since the same trap applies to each.

Omitting the parameter is not the same as omitting the field, which is what makes the advice safe to give: the handlers substitute their own default (`1f7c708`), where the endpoints left to themselves notify nobody.

## Notes

- `TestNotifySchema` pins both branches — the advice, the default it names, and that every shape `parseNotify` coerces is still advertised.
- Cost: +374 tokens, +0.57% of the tool-definitions block (`go run ./cmd/mcp-tokens -base=main`), spread over 8 tools.
- Generated docs are unchanged — they carry tool descriptions, not parameter descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)