### PR TITLE
Fix: twchat - checks for not supporting DMs to current user

### DIFF
--- a/internal/testutil/mcp.go
+++ b/internal/testutil/mcp.go
@@ -34,6 +34,14 @@ type (
 	// ProjectsMCPServerRecordingMock.
 	ProjectsRecordedRequest = pkgtestutil.RecordedRequest
 
+	// ChatMockRoute pairs a substring match against the request URL path with
+	// the status and body to return when it matches.
+	ChatMockRoute = pkgtestutil.MockRoute
+
+	// ChatRecordedRequest is one HTTP request captured by
+	// ChatMCPServerRecordingMock.
+	ChatRecordedRequest = pkgtestutil.RecordedRequest
+
 	// ToolRequest represents a tool request for testing.
 	ToolRequest = pkgtestutil.ToolRequest
 
@@ -182,6 +190,25 @@ func ChatMCPServerMock(t *testing.T, status int, response []byte) *mcp.Server {
 	t.Helper()
 	engine := pkgtestutil.EngineMock(status, response)
 	return pkgtestutil.MCPServer(t, twchat.DefaultToolsetGroup(false, engine))
+}
+
+// ChatMCPServerRecordingMock is like ChatMCPServerMock but answers per-path
+// routes and records every request in order, with a fallback for anything the
+// routes miss.
+//
+// The direct-message tools make more than one call — they identify the
+// authenticated user before resolving a conversation — so a single canned body
+// cannot drive them, and only the recorded requests show that a rejected call
+// sent nothing to the pair or message routes.
+func ChatMCPServerRecordingMock(
+	t *testing.T,
+	routes []ChatMockRoute,
+	fallbackStatus int,
+	fallbackBody []byte,
+) (*mcp.Server, *[]ChatRecordedRequest) {
+	t.Helper()
+	engine, recorded := pkgtestutil.RecordingEngineMock(routes, fallbackStatus, fallbackBody)
+	return pkgtestutil.MCPServer(t, twchat.DefaultToolsetGroup(false, engine)), recorded
 }
 
 // DeskMCPServerMock creates a mock MCP server for twdesk testing. It injects the

--- a/internal/twchat/chat.go
+++ b/internal/twchat/chat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -105,6 +106,96 @@ func redactSensitive(v any) {
 			redactSensitive(item)
 		}
 	}
+}
+
+// chatID decodes a Teamwork Chat identifier, which the API renders as a JSON
+// number on some payloads and as a string on others (a sent message answers
+// {"id":"789","message":{"id":789}}). A missing or null value decodes as 0.
+type chatID int64
+
+// UnmarshalJSON accepts both the number and the string form.
+func (c *chatID) UnmarshalJSON(b []byte) error {
+	raw := strings.Trim(strings.TrimSpace(string(b)), `"`)
+	if raw == "" || raw == "null" {
+		*c = 0
+		return nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to decode chat identifier %s: %w", b, err)
+	}
+	*c = chatID(parsed)
+	return nil
+}
+
+// currentUserID resolves the authenticated chat user's own ID from
+// GET /chat/v7/me. It follows pairConversationID's convention: a non-nil
+// *mcp.CallToolResult is the caller's return value, and a non-nil error is an
+// internal failure.
+func currentUserID(ctx context.Context, engine *twapi.Engine) (int64, *mcp.CallToolResult, error) {
+	const label = "failed to identify the current chat user"
+
+	resp, err := twapi.ExecuteRaw(ctx, engine, currentUserGetRequest{})
+	if err != nil {
+		result, handleErr := helpers.HandleAPIError(err, label)
+		return 0, result, handleErr
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		result, handleErr := helpers.HandleAPIError(twapi.NewHTTPError(resp, label), label)
+		return 0, result, handleErr
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	// The payload nests the identity under "account"; both the account itself
+	// and an embedded "user" object can carry the ID, so prefer the inner one
+	// and fall back to the outer.
+	var parsed struct {
+		Account struct {
+			ID   chatID `json:"id"`
+			User struct {
+				ID chatID `json:"id"`
+			} `json:"user"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return 0, nil, fmt.Errorf("failed to decode current chat user response: %w", err)
+	}
+	if id := parsed.Account.User.ID; id != 0 {
+		return int64(id), nil, nil
+	}
+	if id := parsed.Account.ID; id != 0 {
+		return int64(id), nil, nil
+	}
+	// Returning 0 here would silently disable the self-target guard on a
+	// payload change, so report it instead of letting the send through.
+	return 0, helpers.NewToolResultTextError(
+		"%s: the response carried no user id", label), nil
+}
+
+// rejectSelfTarget reports a tool-level error when userID is the authenticated
+// user, so a DM tool cannot open a conversation with, or message, the caller
+// themself. It returns (nil, nil) when the target is somebody else.
+//
+// It costs one extra request, and it has to run before the pair conversation is
+// resolved: that route creates the conversation as a side effect, so checking
+// afterwards would leave a self-conversation behind on every rejected call.
+func rejectSelfTarget(ctx context.Context, engine *twapi.Engine, userID int64) (*mcp.CallToolResult, error) {
+	currentID, errResult, err := currentUserID(ctx, engine)
+	if err != nil || errResult != nil {
+		return errResult, err
+	}
+	if currentID == userID {
+		return helpers.NewToolResultTextError(
+			"user %d is the authenticated user, and these tools do not message the caller themself. "+
+				"Use list_people to find the person you want to reach.", userID), nil
+	}
+	return nil, nil
 }
 
 // CurrentUserGet returns the current authenticated Teamwork Chat user.
@@ -401,13 +492,15 @@ func DMGetOrCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 				OpenWorldHint:   new(false),
 			},
 			Description: "Get the 1:1 direct-message conversation with a person, creating it if it does not " +
-				"exist yet. Returns the conversation (use its id with send_message). Use list_people to find user_id.",
+				"exist yet. Returns the conversation (use its id with send_message). Use list_people to find " +
+				"user_id. The authenticated user cannot be the target: naming your own user id is rejected.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"user_id": {
-						Type:        "integer",
-						Description: "The ID of the person to get the direct-message conversation with.",
+						Type: "integer",
+						Description: "The ID of the person to get the direct-message conversation with. Must be " +
+							"somebody other than the authenticated user; see get_current_user.",
 					},
 				},
 				Required: []string{"user_id"},
@@ -418,7 +511,12 @@ func DMGetOrCreate(engine *twapi.Engine) toolsets.ToolWrapper {
 			if err != nil {
 				return helpers.NewToolResultTextError("%v", err), nil
 			}
-			req := pairConversationGetRequest{UserID: int64(arguments.GetInt("user_id", 0))}
+			userID := int64(arguments.GetInt("user_id", 0))
+			if errResult, err := rejectSelfTarget(ctx, engine, userID); err != nil || errResult != nil {
+				return errResult, err
+			}
+
+			req := pairConversationGetRequest{UserID: userID}
 			return execute(ctx, engine, req, "failed to resolve direct message conversation")
 		},
 	}
@@ -436,13 +534,16 @@ func SendDM(engine *twapi.Engine) toolsets.ToolWrapper {
 				OpenWorldHint:   new(false),
 			},
 			Description: "Send a direct message to a person, resolving (or creating) the 1:1 conversation " +
-				"automatically. Requires user_id and body. Use list_people to find user_id.",
+				"automatically. Requires user_id and body. Use list_people to find user_id. The authenticated " +
+				"user cannot be the recipient: naming your own user id is rejected and nothing is sent, so " +
+				"report a summary in the conversation instead of messaging yourself in chat.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"user_id": {
-						Type:        "integer",
-						Description: "The ID of the person to send the direct message to.",
+						Type: "integer",
+						Description: "The ID of the person to send the direct message to. Must be somebody other " +
+							"than the authenticated user; see get_current_user.",
 					},
 					"body": {
 						Type:        "string",
@@ -461,6 +562,13 @@ func SendDM(engine *twapi.Engine) toolsets.ToolWrapper {
 			body := arguments.GetString("body", "")
 			if body == "" {
 				return helpers.NewToolResultTextError("body is required"), nil
+			}
+
+			// Refuse a self-DM before resolving the conversation: the pair route
+			// creates one as a side effect, so a later check would leave a
+			// self-conversation behind on every rejected call.
+			if errResult, err := rejectSelfTarget(ctx, engine, userID); err != nil || errResult != nil {
+				return errResult, err
 			}
 
 			// Resolve (or create) the 1:1 conversation, then post the message to it.

--- a/internal/twchat/chat_test.go
+++ b/internal/twchat/chat_test.go
@@ -1,6 +1,7 @@
 package twchat_test
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -107,19 +108,158 @@ func TestConversationListByType(t *testing.T) {
 }
 
 func TestDMGetOrCreate(t *testing.T) {
-	mcpServer := mcpServerMock(t, http.StatusOK, []byte(`{"conversation":{"id":456,"type":"pair"},"STATUS":"ok"}`))
+	mcpServer, _ := dmMcpServerMock(t, 7,
+		[]byte(`{"conversation":{"id":456,"type":"pair"},"STATUS":"ok"}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twchat.MethodDMGetOrCreate.String(), map[string]any{
 		"user_id": float64(42),
 	})
 }
 
 func TestSendDM(t *testing.T) {
-	// The single-response mock returns this body for both the get-or-create
-	// pair-conversation call and the subsequent send-message call.
-	mcpServer := mcpServerMock(t, http.StatusOK,
+	// The fallback body serves both the get-or-create pair-conversation call
+	// and the subsequent send-message call.
+	mcpServer, _ := dmMcpServerMock(t, 7,
 		[]byte(`{"conversation":{"id":456,"type":"pair"},"message":{"id":789},"STATUS":"ok"}`))
 	testutil.ExecuteToolRequest(t, mcpServer, twchat.MethodSendDM.String(), map[string]any{
 		"user_id": float64(42),
 		"body":    "Hello directly from MCP!",
 	})
+}
+
+// TestDMToolsRejectTheCurrentUser pins the self-target guard on both direct
+// message tools. Asserting the recorded requests is what makes it meaningful:
+// the pair route creates the conversation as a side effect, so a rejection that
+// still reached it would leave a self-conversation behind, and the mock would
+// answer the send with the same body either way.
+func TestDMToolsRejectTheCurrentUser(t *testing.T) {
+	const currentUserID = 42
+
+	for _, tt := range []struct {
+		name string
+		tool string
+		args map[string]any
+	}{{
+		name: "send_dm",
+		tool: twchat.MethodSendDM.String(),
+		args: map[string]any{"user_id": float64(currentUserID), "body": "note to self"},
+	}, {
+		name: "get_or_create_dm",
+		tool: twchat.MethodDMGetOrCreate.String(),
+		args: map[string]any{"user_id": float64(currentUserID)},
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, recorded := dmMcpServerMock(t, currentUserID,
+				[]byte(`{"conversation":{"id":456,"type":"pair"},"message":{"id":789}}`))
+
+			testutil.ExecuteToolRequest(t, mcpServer, tt.tool, tt.args,
+				testutil.ExecuteToolRequestWithCheckMessage(checkToolError(t, "authenticated user")))
+
+			for _, request := range *recorded {
+				if path := request.URL.Path; path != "/chat/v7/me" {
+					t.Errorf("rejected call still reached %s %s", request.Method, path)
+				}
+			}
+		})
+	}
+}
+
+// TestSendDMWithoutACurrentUserIDIsAnError pins the shape dependency: a /me
+// payload carrying no identifiable user id must fail the call rather than
+// silently disable the guard.
+func TestSendDMWithoutACurrentUserIDIsAnError(t *testing.T) {
+	mcpServer, recorded := testutil.ChatMCPServerRecordingMock(t, []testutil.ChatMockRoute{{
+		Match:  "/chat/v7/me",
+		Status: http.StatusOK,
+		Body:   []byte(`{"account":{"firstName":"Jane"}}`),
+	}}, http.StatusOK, []byte(`{"conversation":{"id":456},"message":{"id":789}}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twchat.MethodSendDM.String(), map[string]any{
+		"user_id": float64(42),
+		"body":    "Hello directly from MCP!",
+	}, testutil.ExecuteToolRequestWithCheckMessage(checkToolError(t, "no user id")))
+
+	if len(*recorded) != 1 {
+		t.Errorf("expected the call to stop after /me, got %d requests", len(*recorded))
+	}
+}
+
+// TestCurrentUserIDMatchesTheLivePayload pins the parse against the shape the
+// endpoint actually returns: the identity is nested under account.user, and the
+// account repeats the same id at its top level. Values here are sanitized.
+func TestCurrentUserIDMatchesTheLivePayload(t *testing.T) {
+	body := []byte(`{"account":{"region":"US","user":{"id":12345,"firstName":"John","lastName":"Doe",` +
+		`"email":"john@example.com","handle":"johndoe","role":"admin","deleted":false,` +
+		`"apiKey":"twp_example","authKey":"tw-example-12345","installationName":"Example"},` +
+		`"settings":{"timeFormat":"12hr"},"firstName":"John","lastName":"Doe","id":12345,` +
+		`"authkey":"tw-example-12345","baseHref":"https://test.teamwork.com/","isAdmin":true,` +
+		`"apiKey":"twp_example","installationId":777,"counts":{}},"status":"ok"}`)
+
+	// Self-target: the id under account.user must be recognised as the caller.
+	mcpServer, recorded := testutil.ChatMCPServerRecordingMock(t, []testutil.ChatMockRoute{{
+		Match:  "/chat/v7/me",
+		Status: http.StatusOK,
+		Body:   body,
+	}}, http.StatusOK, []byte(`{"conversation":{"id":456},"message":{"id":789}}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twchat.MethodSendDM.String(), map[string]any{
+		"user_id": float64(12345),
+		"body":    "note to self",
+	}, testutil.ExecuteToolRequestWithCheckMessage(checkToolError(t, "authenticated user")))
+
+	if len(*recorded) != 1 {
+		t.Errorf("expected the call to stop after /me, got %d requests", len(*recorded))
+	}
+
+	// Somebody else: the same payload must let the send through.
+	mcpServer, recorded = testutil.ChatMCPServerRecordingMock(t, []testutil.ChatMockRoute{{
+		Match:  "/chat/v7/me",
+		Status: http.StatusOK,
+		Body:   body,
+	}}, http.StatusOK, []byte(`{"conversation":{"id":456},"message":{"id":789}}`))
+
+	testutil.ExecuteToolRequest(t, mcpServer, twchat.MethodSendDM.String(), map[string]any{
+		"user_id": float64(54321),
+		"body":    "Hello directly from MCP!",
+	})
+
+	if len(*recorded) != 3 {
+		t.Errorf("expected /me, the pair lookup and the send, got %d requests", len(*recorded))
+	}
+}
+
+// dmMcpServerMock answers /chat/v7/me with the given user id and everything
+// else with fallbackBody, which is what the two-call direct message tools need.
+func dmMcpServerMock(t *testing.T, currentUserID int64, fallbackBody []byte) (*mcp.Server, *[]testutil.ChatRecordedRequest) {
+	t.Helper()
+
+	return testutil.ChatMCPServerRecordingMock(t, []testutil.ChatMockRoute{{
+		Match:  "/chat/v7/me",
+		Status: http.StatusOK,
+		Body:   []byte(fmt.Sprintf(`{"account":{"id":%d}}`, currentUserID)),
+	}}, http.StatusOK, fallbackBody)
+}
+
+// checkToolError asserts the tool answered with an IsError result whose text
+// contains want.
+func checkToolError(t *testing.T, want string) func(*testing.T, mcp.Result) {
+	t.Helper()
+
+	return func(t *testing.T, result mcp.Result) {
+		t.Helper()
+
+		toolResult, ok := result.(*mcp.CallToolResult)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", result)
+		}
+		if !toolResult.IsError {
+			t.Fatalf("expected an error result, got: %v", toolResult.Content)
+		}
+		text, ok := toolResult.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("unexpected content type: %T", toolResult.Content[0])
+		}
+		if !strings.Contains(text.Text, want) {
+			t.Errorf("expected error to mention %q, got: %s", want, text.Text)
+		}
+	}
 }


### PR DESCRIPTION
## Description
Teamwork Chat doesn't support sending direct messages to the current user. This PR adds checks to it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors